### PR TITLE
Fix keypoint fixture playback stalls

### DIFF
--- a/demo/fixtures/basketball_geometry/fixture.meta.json
+++ b/demo/fixtures/basketball_geometry/fixture.meta.json
@@ -1,6 +1,6 @@
 {
   "datasetId": "basketball_geometry_v1",
-  "displayName": "Geometry showcase (9s basketball)",
+  "displayName": "Basketball with Keypoints",
   "inferenceLabel": "SAM3 + YOLOv8m-pose",
   "media": {
     "file": "../basketball_sample/basketball_sample.mp4",

--- a/packages/web/src/renderers/pixi-vector-layer.test.ts
+++ b/packages/web/src/renderers/pixi-vector-layer.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPixiVectorLayer } from "#renderers/pixi-vector-layer";
+import { KeypointMarkerShape } from "supervision-js-core";
+import type {
+  BufferedDetectionTimeline,
+  DetectionFrame,
+  KeypointStyle,
+} from "supervision-js-core";
+
+describe("pixi vector layer", () => {
+  it("recycles graphics when frame-scoped detection ids change", () => {
+    const frames = [
+      createFrame(0, ["pose-0", "pose-1"]),
+      createFrame(1, ["pose-2"]),
+    ];
+    const layer = createLayer(frames);
+    const container = layer.createContainer() as unknown as FakeContainer;
+
+    layer.drawFrame(0);
+    expect(container.children).toHaveLength(2);
+
+    layer.drawFrame(1);
+    expect(container.children).toHaveLength(2);
+    expect(container.children.filter((child) => child.visible)).toHaveLength(1);
+    expect(layer.translateDetection("pose-0", 1, 2)).toBe(false);
+    expect(layer.translateDetection("pose-2", 3, 4)).toBe(true);
+  });
+
+  it("does not allocate graphics when the matching style is disabled", () => {
+    const frame = createFrame(0, ["pose-0"]);
+    const layer = createLayer([frame], null);
+    const container = layer.createContainer() as unknown as FakeContainer;
+
+    layer.drawFrame(0);
+
+    expect(container.children).toHaveLength(0);
+  });
+
+  it("releases active graphics when the matching style is disabled", () => {
+    const frame = createFrame(0, ["pose-0"]);
+    const layer = createLayer([frame]);
+    const container = layer.createContainer() as unknown as FakeContainer;
+
+    layer.drawFrame(0);
+    layer.setStyles({ keypointStyle: null });
+    layer.drawFrame(0);
+
+    expect(container.children).toHaveLength(1);
+    expect(container.children[0]?.visible).toBe(false);
+    expect(layer.translateDetection("pose-0", 1, 2)).toBe(false);
+  });
+
+  it("does not allocate graphics when styles resolve no instructions", () => {
+    const frame = createFrame(0, ["pose-0"]);
+    const layer = createLayer([frame], { resolve: () => undefined });
+    const container = layer.createContainer() as unknown as FakeContainer;
+
+    layer.drawFrame(0);
+
+    expect(container.children).toHaveLength(0);
+  });
+
+  it("redraws an invalidated active detection without allocating", () => {
+    const frame = createFrame(0, ["pose-0"]);
+    const layer = createLayer([frame]);
+    const container = layer.createContainer() as unknown as FakeContainer;
+
+    layer.drawFrame(0);
+    const display = container.children[0]!;
+    expect(display.clear).toHaveBeenCalledOnce();
+
+    layer.drawFrame(0);
+    expect(display.clear).toHaveBeenCalledOnce();
+
+    layer.invalidateDetection("pose-0");
+    layer.drawFrame(0);
+    expect(container.children).toHaveLength(1);
+    expect(display.clear).toHaveBeenCalledTimes(2);
+    expect(display.position.set).toHaveBeenLastCalledWith(0, 0);
+  });
+});
+
+class FakeContainer {
+  readonly children: FakeGraphics[] = [];
+  sortableChildren = false;
+
+  addChild(...children: FakeGraphics[]) {
+    this.children.push(...children);
+  }
+}
+
+class FakeGraphics {
+  readonly circle = vi.fn(() => this);
+  readonly clear = vi.fn(() => this);
+  readonly fill = vi.fn(() => this);
+  readonly lineTo = vi.fn(() => this);
+  readonly moveTo = vi.fn(() => this);
+  readonly poly = vi.fn(() => this);
+  readonly position = { set: vi.fn() };
+  readonly stroke = vi.fn(() => this);
+  visible = true;
+  zIndex = 0;
+}
+
+const keypointStyle: KeypointStyle = {
+  resolve(detection) {
+    if (!detection.keypoints) return undefined;
+
+    return {
+      edges: [],
+      markers: detection.keypoints.points.map((point, index) => ({
+        fill: { alpha: 1, color: 0xff0000 },
+        index,
+        point,
+        radius: 3,
+        shape: KeypointMarkerShape.Circle,
+      })),
+    };
+  },
+};
+
+function createLayer(
+  frames: readonly DetectionFrame[],
+  style: KeypointStyle | null = keypointStyle,
+) {
+  return createPixiVectorLayer({
+    Container: FakeContainer as never,
+    detectionTimeline: createTimeline(frames),
+    Graphics: FakeGraphics as never,
+    keypointStyle: style,
+    polygonStyle: null,
+    polylineStyle: null,
+  });
+}
+
+function createFrame(
+  frameIndex: number,
+  ids: readonly string[],
+): DetectionFrame {
+  return {
+    detections: ids.map((id, index) => ({
+      id,
+      keypoints: {
+        edges: [],
+        points: [{ x: index + 1, y: index + 2 }],
+      },
+    })),
+    frameIndex,
+    mediaTime: frameIndex,
+  };
+}
+
+function createTimeline(
+  frames: readonly DetectionFrame[],
+): BufferedDetectionTimeline {
+  return {
+    destroy() {},
+    getBufferedFrames: () => frames,
+    getState: () => ({
+      bufferEndTime: frames.at(-1)?.mediaTime ?? 0,
+      bufferStartTime: frames[0]?.mediaTime ?? 0,
+      detectionCount: frames.reduce(
+        (count, frame) => count + frame.detections.length,
+        0,
+      ),
+      errorMessage: null,
+      frameCount: frames.length,
+      requestedEndTime: frames.at(-1)?.mediaTime ?? 0,
+      requestedStartTime: frames[0]?.mediaTime ?? 0,
+      status: "ready",
+    }),
+    prepare: async () => undefined,
+    prefetch() {},
+    selectFrame: (mediaTime: number) =>
+      frames.find((frame) => frame.mediaTime === mediaTime),
+  } as unknown as BufferedDetectionTimeline;
+}

--- a/packages/web/src/renderers/pixi-vector-layer.ts
+++ b/packages/web/src/renderers/pixi-vector-layer.ts
@@ -7,8 +7,11 @@ import {
   type Detection,
   type DetectionFrame,
   type AnnotationStyleContext,
+  type KeypointDrawInstruction,
   type KeypointStyle,
+  type PolygonDrawInstruction,
   type PolygonStyle,
+  type PolylineDrawInstruction,
   type PolylineStyle,
 } from "supervision-js-core";
 import type {
@@ -19,7 +22,15 @@ import { drawPixiPath, resolveScreenLength } from "./pixi-path";
 
 interface RetainedVectorEntry {
   readonly display: PixiGraphics;
-  key: string;
+  cleared: boolean;
+}
+
+interface ResolvedVectorDetection {
+  readonly key: string;
+  readonly zIndex: number;
+  readonly polygon?: PolygonDrawInstruction;
+  readonly polyline?: PolylineDrawInstruction;
+  readonly keypoints?: KeypointDrawInstruction;
 }
 
 export interface PixiVectorLayer {
@@ -63,6 +74,7 @@ export function createPixiVectorLayer(options: {
   let lastFrameKey = "";
   let lastViewportScale = 0;
   const entries = new Map<string, RetainedVectorEntry>();
+  const entryPool: RetainedVectorEntry[] = [];
   const invalidated = new Set<string>();
 
   return {
@@ -93,38 +105,46 @@ export function createPixiVectorLayer(options: {
       lastViewportScale = viewportScale;
 
       if (!frame) {
-        hideAll();
+        releaseInactiveEntries(new Set<string>());
+        invalidated.clear();
         return;
       }
 
-      const activeKeys = new Set<string>();
+      const resolvedDetections = frame.detections.flatMap(
+        (detection, detectionIndex) => {
+          if (
+            !detection.polygon &&
+            !detection.polyline &&
+            !detection.keypoints
+          ) {
+            return [];
+          }
 
-      frame.detections.forEach((detection, detectionIndex) => {
-        if (!detection.polygon && !detection.polyline && !detection.keypoints) {
-          return;
-        }
-        const key = detectionKey(detection, detectionIndex);
-        activeKeys.add(key);
-        const entry = ensureEntry(key);
+          const resolved = resolveDetection(
+            detection,
+            detectionIndex,
+            frame,
+            mediaTime,
+            viewportScale,
+          );
+
+          return resolved ? [resolved] : [];
+        },
+      );
+      const activeKeys = new Set<string>(
+        resolvedDetections.map((detection) => detection.key),
+      );
+      releaseInactiveEntries(activeKeys);
+
+      for (const detection of resolvedDetections) {
+        const entry = ensureEntry(detection.key);
         entry.display.visible = true;
-        entry.display.zIndex = detection.zIndex ?? detectionIndex;
+        entry.display.zIndex = detection.zIndex;
         entry.display.position?.set?.(0, 0);
-        drawDetection(
-          entry.display,
-          detection,
-          detectionIndex,
-          frame,
-          mediaTime,
-          viewportScale,
-        );
-        invalidated.delete(key);
-      });
-
-      for (const [key, entry] of entries) {
-        if (!activeKeys.has(key)) {
-          entry.display.visible = false;
-        }
+        drawDetection(entry, detection, viewportScale);
       }
+
+      invalidated.clear();
     },
 
     invalidateDetection(id) {
@@ -153,6 +173,7 @@ export function createPixiVectorLayer(options: {
 
     destroy() {
       entries.clear();
+      entryPool.length = 0;
       invalidated.clear();
       container = undefined;
     },
@@ -162,27 +183,39 @@ export function createPixiVectorLayer(options: {
     let entry = entries.get(key);
 
     if (!entry) {
-      entry = { display: new options.Graphics(), key };
+      entry = entryPool.pop();
+
+      if (!entry) {
+        entry = { cleared: false, display: new options.Graphics() };
+        container?.addChild(entry.display);
+      }
+
       entries.set(key, entry);
-      container?.addChild(entry.display);
     }
 
     return entry;
   }
 
-  function hideAll() {
-    for (const entry of entries.values()) entry.display.visible = false;
+  function releaseInactiveEntries(activeKeys: ReadonlySet<string>) {
+    for (const [key, entry] of entries) {
+      if (activeKeys.has(key)) continue;
+
+      entries.delete(key);
+      entry.display.clear();
+      entry.cleared = true;
+      entry.display.visible = false;
+      entry.display.position?.set?.(0, 0);
+      entryPool.push(entry);
+    }
   }
 
-  function drawDetection(
-    graphics: PixiGraphics,
+  function resolveDetection(
     detection: Detection,
     detectionIndex: number,
     frame: DetectionFrame,
     mediaTime: number,
     viewportScale: number,
-  ) {
-    graphics.clear();
+  ): ResolvedVectorDetection | undefined {
     const context = {
       detectionIndex,
       frame,
@@ -191,6 +224,29 @@ export function createPixiVectorLayer(options: {
       ...options.resolveContextState?.(detection),
     };
     const polygon = polygonStyle?.resolve(detection, context);
+    const polyline = polylineStyle?.resolve(detection, context);
+    const keypoints = keypointStyle?.resolve(detection, context);
+
+    if (!polygon && !polyline && !keypoints) return undefined;
+
+    return {
+      key: detectionKey(detection, detectionIndex),
+      keypoints,
+      polygon,
+      polyline,
+      zIndex: detection.zIndex ?? detectionIndex,
+    };
+  }
+
+  function drawDetection(
+    entry: RetainedVectorEntry,
+    detection: ResolvedVectorDetection,
+    viewportScale: number,
+  ) {
+    const graphics = entry.display;
+    if (!entry.cleared) graphics.clear();
+    entry.cleared = false;
+    const { keypoints, polygon, polyline } = detection;
 
     if (polygon) {
       graphics.poly(
@@ -208,7 +264,6 @@ export function createPixiVectorLayer(options: {
         );
     }
 
-    const polyline = polylineStyle?.resolve(detection, context);
     if (polyline)
       drawPixiPath(
         graphics,
@@ -218,7 +273,6 @@ export function createPixiVectorLayer(options: {
         viewportScale,
       );
 
-    const keypoints = keypointStyle?.resolve(detection, context);
     if (!keypoints) return;
 
     for (const edge of keypoints.edges) {


### PR DESCRIPTION
# Description

Fixes the basketball keypoint demo playback stalls by recycling retained Pixi vector graphics across frame-scoped detection IDs. Vector entries are now allocated only for geometry that resolves to a draw instruction, keeping the scene bounded by concurrent detections instead of every ID seen in the timeline.

Also renames the fixture from "Geometry showcase (9s basketball)" to "Basketball with Keypoints".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added focused regression tests for pooling, disabled and filtered geometry, current-frame translation, and invalidation
- Ran `npm run verify` successfully (369 Vitest tests plus typechecks, lint, formatting, package smoke tests, demo/docs builds, and benchmark builds)
- Verified the local keypoint demo advanced 3.19 media seconds during a 3-second playback interval with no console errors
- Fresh base-to-commit review passed with no findings

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- hosting

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
