### PR TITLE
Fix stale mask artifacts after same-frame edits

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,11 +100,13 @@ export {
   decodeDetectionMaskPayload,
   detectMaskBorders,
   encodeBinaryMask,
+  encodeBinaryMaskWithBounds,
   encodeDetectionMaskPayload,
   extractMaskContour,
   extractMaskRectRuns,
   isDeflatedBase64DetectionMaskPayload,
   type DetectionMaskCompressionCodec,
+  type EncodedBinaryMask,
   type MaskRectRun,
 } from "#utils/detection-masks";
 export {

--- a/packages/core/src/utils/detection-masks.test.ts
+++ b/packages/core/src/utils/detection-masks.test.ts
@@ -7,6 +7,7 @@ import {
   decodeDetectionMaskPayload,
   detectMaskBorders,
   encodeBinaryMask,
+  encodeBinaryMaskWithBounds,
   encodeDetectionMaskPayload,
   extractMaskContour,
   extractMaskRectRuns,
@@ -19,6 +20,16 @@ describe("detection mask utilities", () => {
   it("round-trips row-major binary masks through COCO compressed RLE", () => {
     const mask = encodeBinaryMask(data, 4, 3);
     expect(decodeCompressedRleMask(mask).data).toEqual(data);
+  });
+
+  it("derives mask bounds while encoding the binary raster", () => {
+    const result = encodeBinaryMaskWithBounds(data, 4, 3);
+
+    expect(result.mask).toEqual(encodeBinaryMask(data, 4, 3));
+    expect(result.bounds).toEqual({ height: 2, width: 2, x: 2, y: 1 });
+    expect(
+      encodeBinaryMaskWithBounds(new Uint8Array(12), 4, 3).bounds,
+    ).toBeNull();
   });
 
   it("supports an injected transport compression codec", () => {

--- a/packages/core/src/utils/detection-masks.ts
+++ b/packages/core/src/utils/detection-masks.ts
@@ -23,6 +23,11 @@ export interface DetectionMaskCompressionCodec {
 
 export type MaskRectRun = TopLeftRect;
 
+export interface EncodedBinaryMask {
+  readonly bounds: Rect | null;
+  readonly mask: DetectionMask;
+}
+
 export function encodeBinaryMask(
   data: Uint8Array,
   width: number,
@@ -55,6 +60,64 @@ export function encodeBinaryMask(
     encoding: DetectionMaskEncoding.CompressedRle,
     height,
     width,
+  };
+}
+
+/** Encodes a binary mask and derives its bounds in the same raster traversal. */
+export function encodeBinaryMaskWithBounds(
+  data: Uint8Array,
+  width: number,
+  height: number,
+): EncodedBinaryMask {
+  assertMaskDimensions(data, width, height);
+
+  const runs: number[] = [];
+  let currentValue = 0;
+  let runLength = 0;
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+
+  for (let x = 0; x < width; x += 1) {
+    for (let y = 0; y < height; y += 1) {
+      const value = data[y * width + x] ? 1 : 0;
+
+      if (value) {
+        minX = Math.min(minX, x);
+        minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x);
+        maxY = Math.max(maxY, y);
+      }
+
+      if (value === currentValue) {
+        runLength += 1;
+      } else {
+        runs.push(runLength);
+        currentValue = value;
+        runLength = 1;
+      }
+    }
+  }
+
+  runs.push(runLength);
+
+  return {
+    bounds:
+      maxX < 0
+        ? null
+        : {
+            height: maxY - minY + 1,
+            width: maxX - minX + 1,
+            x: minX + (maxX - minX + 1) / 2,
+            y: minY + (maxY - minY + 1) / 2,
+          },
+    mask: {
+      counts: encodeCompressedRleCounts(runs),
+      encoding: DetectionMaskEncoding.CompressedRle,
+      height,
+      width,
+    },
   };
 }
 

--- a/packages/web/src/editing/mask-brush-editor.test.ts
+++ b/packages/web/src/editing/mask-brush-editor.test.ts
@@ -1,0 +1,178 @@
+import { decodeCompressedRleMask } from "supervision-js-core";
+import { describe, expect, it, vi } from "vitest";
+
+import { MaskBrushMode, createMaskBrushEditor } from "./mask-brush-editor";
+
+describe("mask brush editor", () => {
+  it("separates cursor updates from bounded raster updates", () => {
+    const { canvas, reads } = createCanvasHarness(64, 48);
+    const onCursorUpdate = vi.fn();
+    const onTextureUpdate = vi.fn();
+    const editor = createMaskBrushEditor({
+      canvas,
+      height: 48,
+      onCursorUpdate,
+      onTextureUpdate,
+      width: 64,
+    });
+    const cursorListener = vi.fn();
+    const textureListener = vi.fn();
+    editor.subscribeCursorUpdates(cursorListener);
+    editor.subscribeTextureUpdates(textureListener);
+
+    editor.setCursor({ x: 12, y: 10 }, { radius: 3 });
+
+    expect(onCursorUpdate).toHaveBeenCalledTimes(1);
+    expect(cursorListener).toHaveBeenCalledTimes(1);
+    expect(onTextureUpdate).not.toHaveBeenCalled();
+    expect(textureListener).not.toHaveBeenCalled();
+    expect(reads).toHaveLength(0);
+
+    editor.beginStroke({ x: 12, y: 10 }, { radius: 3 });
+    editor.extendStroke({ x: 18, y: 14 });
+
+    expect(onTextureUpdate).toHaveBeenCalledTimes(2);
+    expect(textureListener).toHaveBeenCalledTimes(2);
+    expect(onCursorUpdate).toHaveBeenCalledTimes(3);
+    expect(reads).toHaveLength(2);
+    expect(reads.every((read) => read.width < 64 && read.height < 48)).toBe(
+      true,
+    );
+
+    const readsBeforeCommit = reads.length;
+    const mask = editor.endStroke();
+    expect(editor.getMaskBounds()).toEqual({
+      height: expect.any(Number),
+      width: expect.any(Number),
+      x: expect.any(Number),
+      y: expect.any(Number),
+    });
+    expect(reads).toHaveLength(readsBeforeCommit);
+    expect(
+      decodeCompressedRleMask(mask).data.some((value) => value === 1),
+    ).toBe(true);
+  });
+
+  it("restores only the touched raster when a stroke is cancelled", () => {
+    const { canvas, reads } = createCanvasHarness(32, 32);
+    const editor = createMaskBrushEditor({ canvas, height: 32, width: 32 });
+
+    editor.beginStroke({ x: 8, y: 8 }, { radius: 2 });
+    editor.endStroke();
+    const before = editor.getMask();
+    const readsBeforeCancelledStroke = reads.length;
+
+    editor.beginStroke(
+      { x: 20, y: 20 },
+      { mode: MaskBrushMode.Add, radius: 2 },
+    );
+    editor.extendStroke({ x: 24, y: 24 });
+    editor.cancelStroke();
+
+    expect(editor.getMask()).toEqual(before);
+    expect(
+      reads
+        .slice(readsBeforeCancelledStroke)
+        .every((read) => read.width < 32 && read.height < 32),
+    ).toBe(true);
+  });
+});
+
+function createCanvasHarness(width: number, height: number) {
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  const reads: Array<{ height: number; width: number; x: number; y: number }> =
+    [];
+  let currentArc = { radius: 0, x: 0, y: 0 };
+  let operation: GlobalCompositeOperation = "source-over";
+
+  const context = {
+    arc(x: number, y: number, radius: number) {
+      currentArc = { radius, x, y };
+    },
+    beginPath() {},
+    clearRect(x: number, y: number, rectWidth: number, rectHeight: number) {
+      for (let py = y; py < y + rectHeight; py += 1) {
+        for (let px = x; px < x + rectWidth; px += 1) {
+          pixels.fill(0, (py * width + px) * 4, (py * width + px + 1) * 4);
+        }
+      }
+    },
+    createImageData(rectWidth: number, rectHeight: number) {
+      return {
+        colorSpace: "srgb",
+        data: new Uint8ClampedArray(rectWidth * rectHeight * 4),
+        height: rectHeight,
+        width: rectWidth,
+      } as ImageData;
+    },
+    fill() {
+      const left = Math.max(
+        0,
+        Math.floor(currentArc.x - currentArc.radius - 1),
+      );
+      const top = Math.max(0, Math.floor(currentArc.y - currentArc.radius - 1));
+      const right = Math.min(
+        width,
+        Math.ceil(currentArc.x + currentArc.radius + 1),
+      );
+      const bottom = Math.min(
+        height,
+        Math.ceil(currentArc.y + currentArc.radius + 1),
+      );
+      for (let y = top; y < bottom; y += 1) {
+        for (let x = left; x < right; x += 1) {
+          if (
+            Math.hypot(x + 0.5 - currentArc.x, y + 0.5 - currentArc.y) >
+            currentArc.radius
+          ) {
+            continue;
+          }
+          const offset = (y * width + x) * 4;
+          const value = operation === "destination-out" ? 0 : 255;
+          pixels[offset] = value;
+          pixels[offset + 1] = value;
+          pixels[offset + 2] = value;
+          pixels[offset + 3] = value;
+        }
+      }
+    },
+    getImageData(x: number, y: number, rectWidth: number, rectHeight: number) {
+      reads.push({ height: rectHeight, width: rectWidth, x, y });
+      const data = new Uint8ClampedArray(rectWidth * rectHeight * 4);
+      for (let py = 0; py < rectHeight; py += 1) {
+        const source = ((y + py) * width + x) * 4;
+        data.set(
+          pixels.subarray(source, source + rectWidth * 4),
+          py * rectWidth * 4,
+        );
+      }
+      return { data, height: rectHeight, width: rectWidth } as ImageData;
+    },
+    putImageData(image: ImageData, x: number, y: number) {
+      for (let py = 0; py < image.height; py += 1) {
+        const target = ((y + py) * width + x) * 4;
+        pixels.set(
+          image.data.subarray(py * image.width * 4, (py + 1) * image.width * 4),
+          target,
+        );
+      }
+    },
+    restore() {},
+    save() {},
+    set fillStyle(_value: string) {},
+    get globalCompositeOperation() {
+      return operation;
+    },
+    set globalCompositeOperation(value: GlobalCompositeOperation) {
+      operation = value;
+    },
+  } as unknown as CanvasRenderingContext2D;
+
+  const canvas = {
+    getContext: () => context,
+    height,
+    width,
+  } as unknown as HTMLCanvasElement;
+
+  return { canvas, reads };
+}

--- a/packages/web/src/editing/mask-brush-editor.ts
+++ b/packages/web/src/editing/mask-brush-editor.ts
@@ -1,8 +1,9 @@
 import {
   decodeCompressedRleMask,
-  encodeBinaryMask,
+  encodeBinaryMaskWithBounds,
   type DetectionMask,
   type Point,
+  type Rect,
 } from "supervision-js-core";
 
 export enum MaskBrushMode {
@@ -22,12 +23,14 @@ export interface MaskBrushEditor {
   seed(mask: DetectionMask): void;
   clear(): void;
   getMask(): DetectionMask;
+  getMaskBounds(): Rect | null;
   getCursor(): { point: Point | null; radius: number; mode: MaskBrushMode };
   setCursor(
     point: Point | null,
     options?: { mode?: MaskBrushMode; radius?: number },
   ): void;
   subscribeTextureUpdates(listener: () => void): () => void;
+  subscribeCursorUpdates(listener: () => void): () => void;
 }
 
 /** Renderer-neutral connection between a brush editor and its live preview. */
@@ -43,6 +46,7 @@ export function createMaskBrushEditor(options: {
   readonly width: number;
   readonly height: number;
   readonly canvas?: HTMLCanvasElement;
+  readonly onCursorUpdate?: () => void;
   readonly onTextureUpdate?: () => void;
   readonly onCommit?: (mask: DetectionMask) => void;
 }): MaskBrushEditor {
@@ -56,54 +60,74 @@ export function createMaskBrushEditor(options: {
   const brushContext = context;
 
   let lastPoint: Point | null = null;
-  let snapshot: ImageData | null = null;
+  let binary = new Uint8Array(canvas.width * canvas.height);
+  let cachedOutput: ReturnType<typeof encodeBinaryMaskWithBounds> | null = null;
+  let strokeDirtyRect: RasterRect | null = null;
+  let strokePatches: BinaryPatch[] = [];
+  let stroking = false;
   let radius = 12;
   let mode = MaskBrushMode.Add;
   let cursor: Point | null = null;
+  const cursorListeners = new Set<() => void>();
   const textureListeners = new Set<() => void>();
 
   return {
     canvas,
     beginStroke(point, strokeOptions = {}) {
-      if (snapshot) return;
-      snapshot = brushContext.getImageData(0, 0, canvas.width, canvas.height);
+      if (stroking) return;
+      stroking = true;
+      strokeDirtyRect = null;
+      strokePatches = [];
       radius = Math.max(0.5, strokeOptions.radius ?? radius);
       mode = strokeOptions.mode ?? mode;
       lastPoint = point;
       cursor = point;
-      paintPoint(point);
-      update();
+      if (paintPoints([point])) updateTexture();
+      updateCursor();
     },
     extendStroke(point) {
       cursor = point;
-      if (!lastPoint || !snapshot) return;
-      for (const interpolated of bresenham(lastPoint, point))
-        paintPoint(interpolated);
+      if (!lastPoint || !stroking) {
+        updateCursor();
+        return;
+      }
+      if (paintPoints(bresenham(lastPoint, point))) updateTexture();
       lastPoint = point;
-      update();
+      updateCursor();
     },
     endStroke() {
-      if (!snapshot) return getMask();
-      snapshot = null;
+      if (!stroking) return getMask();
+      stroking = false;
+      strokeDirtyRect = null;
+      strokePatches = [];
       lastPoint = null;
       const mask = getMask();
       options.onCommit?.(mask);
       return mask;
     },
     cancelStroke() {
-      if (snapshot) brushContext.putImageData(snapshot, 0, 0);
-      snapshot = null;
+      if (!stroking) return;
+      for (let index = strokePatches.length - 1; index >= 0; index -= 1) {
+        restoreBinaryPatch(binary, canvas.width, strokePatches[index]!);
+      }
+      if (strokeDirtyRect) writeBinaryRect(strokeDirtyRect);
+      stroking = false;
+      strokeDirtyRect = null;
+      strokePatches = [];
       lastPoint = null;
-      update();
+      cachedOutput = null;
+      updateTexture();
+      updateCursor();
     },
     seed(mask) {
       const decoded = decodeCompressedRleMask(mask);
       if (decoded.width !== canvas.width || decoded.height !== canvas.height) {
         throw new Error("Seed mask dimensions must match the brush canvas.");
       }
+      binary = decoded.data.slice();
       const image = brushContext.createImageData(canvas.width, canvas.height);
-      for (let index = 0; index < decoded.data.length; index += 1) {
-        if (!decoded.data[index]) continue;
+      for (let index = 0; index < binary.length; index += 1) {
+        if (!binary[index]) continue;
         const offset = index * 4;
         image.data[offset] = 255;
         image.data[offset + 1] = 255;
@@ -111,55 +135,191 @@ export function createMaskBrushEditor(options: {
         image.data[offset + 3] = 255;
       }
       brushContext.putImageData(image, 0, 0);
-      update();
+      cachedOutput = null;
+      updateTexture();
     },
     clear() {
       brushContext.clearRect(0, 0, canvas.width, canvas.height);
-      update();
+      binary.fill(0);
+      cachedOutput = null;
+      updateTexture();
     },
     getMask,
+    getMaskBounds: () => getOutput().bounds,
     getCursor: () => ({ mode, point: cursor, radius }),
     setCursor(point, cursorOptions = {}) {
       cursor = point;
       radius = Math.max(0.5, cursorOptions.radius ?? radius);
       mode = cursorOptions.mode ?? mode;
-      update();
+      updateCursor();
     },
     subscribeTextureUpdates(listener) {
       textureListeners.add(listener);
       return () => textureListeners.delete(listener);
     },
+    subscribeCursorUpdates(listener) {
+      cursorListeners.add(listener);
+      return () => cursorListeners.delete(listener);
+    },
   };
 
-  function paintPoint(point: Point) {
+  function paintPoints(points: readonly Point[]) {
+    const dirtyRect = getPaintRect(points, radius, canvas.width, canvas.height);
+    if (!dirtyRect) return false;
+    strokePatches.push(copyBinaryPatch(binary, canvas.width, dirtyRect));
+    strokeDirtyRect = unionRasterRects(strokeDirtyRect, dirtyRect);
+
     brushContext.save();
     brushContext.globalCompositeOperation =
       mode === MaskBrushMode.Erase ? "destination-out" : "source-over";
     brushContext.fillStyle = "white";
-    brushContext.beginPath();
-    brushContext.arc(point.x, point.y, radius, 0, Math.PI * 2);
-    brushContext.fill();
+    for (const point of points) {
+      brushContext.beginPath();
+      brushContext.arc(point.x, point.y, radius, 0, Math.PI * 2);
+      brushContext.fill();
+    }
     brushContext.restore();
+    syncBinaryRect(dirtyRect);
+    cachedOutput = null;
+    return true;
   }
 
   function getMask() {
-    const rgba = brushContext.getImageData(
-      0,
-      0,
-      canvas.width,
-      canvas.height,
-    ).data;
-    const binary = new Uint8Array(canvas.width * canvas.height);
-    for (let index = 0; index < binary.length; index += 1) {
-      binary[index] = rgba[index * 4 + 3]! > 0 ? 1 : 0;
-    }
-    return encodeBinaryMask(binary, canvas.width, canvas.height);
+    return getOutput().mask;
   }
 
-  function update() {
+  function getOutput() {
+    cachedOutput ??= encodeBinaryMaskWithBounds(
+      binary,
+      canvas.width,
+      canvas.height,
+    );
+    return cachedOutput;
+  }
+
+  function syncBinaryRect(rect: RasterRect) {
+    const rgba = brushContext.getImageData(
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+    ).data;
+    for (let y = 0; y < rect.height; y += 1) {
+      for (let x = 0; x < rect.width; x += 1) {
+        const target = (rect.y + y) * canvas.width + rect.x + x;
+        const source = (y * rect.width + x) * 4 + 3;
+        binary[target] = rgba[source]! > 0 ? 1 : 0;
+      }
+    }
+  }
+
+  function writeBinaryRect(rect: RasterRect) {
+    const image = brushContext.createImageData(rect.width, rect.height);
+    for (let y = 0; y < rect.height; y += 1) {
+      for (let x = 0; x < rect.width; x += 1) {
+        if (!binary[(rect.y + y) * canvas.width + rect.x + x]) continue;
+        const offset = (y * rect.width + x) * 4;
+        image.data[offset] = 255;
+        image.data[offset + 1] = 255;
+        image.data[offset + 2] = 255;
+        image.data[offset + 3] = 255;
+      }
+    }
+    brushContext.putImageData(image, rect.x, rect.y);
+  }
+
+  function updateTexture() {
     options.onTextureUpdate?.();
     for (const listener of textureListeners) listener();
   }
+
+  function updateCursor() {
+    options.onCursorUpdate?.();
+    for (const listener of cursorListeners) listener();
+  }
+}
+
+interface RasterRect {
+  readonly height: number;
+  readonly width: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+interface BinaryPatch {
+  readonly data: Uint8Array;
+  readonly rect: RasterRect;
+}
+
+function getPaintRect(
+  points: readonly Point[],
+  radius: number,
+  width: number,
+  height: number,
+): RasterRect | null {
+  if (points.length === 0) return null;
+  let minX = points[0]!.x;
+  let minY = points[0]!.y;
+  let maxX = minX;
+  let maxY = minY;
+  for (let index = 1; index < points.length; index += 1) {
+    const point = points[index]!;
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  }
+  const padding = radius + 1;
+  const left = Math.max(0, Math.floor(minX - padding));
+  const top = Math.max(0, Math.floor(minY - padding));
+  const right = Math.min(width, Math.ceil(maxX + padding));
+  const bottom = Math.min(height, Math.ceil(maxY + padding));
+  return right <= left || bottom <= top
+    ? null
+    : { height: bottom - top, width: right - left, x: left, y: top };
+}
+
+function copyBinaryPatch(
+  binary: Uint8Array,
+  stride: number,
+  rect: RasterRect,
+): BinaryPatch {
+  const data = new Uint8Array(rect.width * rect.height);
+  for (let y = 0; y < rect.height; y += 1) {
+    data.set(
+      binary.subarray(
+        (rect.y + y) * stride + rect.x,
+        (rect.y + y) * stride + rect.x + rect.width,
+      ),
+      y * rect.width,
+    );
+  }
+  return { data, rect };
+}
+
+function restoreBinaryPatch(
+  binary: Uint8Array,
+  stride: number,
+  patch: BinaryPatch,
+) {
+  for (let y = 0; y < patch.rect.height; y += 1) {
+    binary.set(
+      patch.data.subarray(y * patch.rect.width, (y + 1) * patch.rect.width),
+      (patch.rect.y + y) * stride + patch.rect.x,
+    );
+  }
+}
+
+function unionRasterRects(
+  current: RasterRect | null,
+  next: RasterRect,
+): RasterRect {
+  if (!current) return next;
+  const x = Math.min(current.x, next.x);
+  const y = Math.min(current.y, next.y);
+  const right = Math.max(current.x + current.width, next.x + next.width);
+  const bottom = Math.max(current.y + current.height, next.y + next.height);
+  return { height: bottom - y, width: right - x, x, y };
 }
 
 function bresenham(from: Point, to: Point) {

--- a/packages/web/src/media-session.integration.test.ts
+++ b/packages/web/src/media-session.integration.test.ts
@@ -135,6 +135,7 @@ describe("media session integration", () => {
       canvas: { height: 2, width: 2 },
       getCursor: () => ({ mode: "add", point: null, radius: 1 }),
       subscribeTextureUpdates: () => () => undefined,
+      subscribeCursorUpdates: () => () => undefined,
     };
 
     const session = await createMediaSession({

--- a/packages/web/src/render-preparation/prepared-render-window.test.ts
+++ b/packages/web/src/render-preparation/prepared-render-window.test.ts
@@ -82,6 +82,128 @@ const manyFrames = Array.from({ length: 10 }, (_, frameIndex) => ({
 })) satisfies DetectionFrame[];
 
 describe("prepared render window", () => {
+  it("rebuilds the active mask artifact when semantic content changes at the same frame key", async () => {
+    vi.useFakeTimers();
+    resetMocks();
+
+    try {
+      const mutableFrames = [frames[0]!] as DetectionFrame[];
+      const renderWindow = createPreparedRenderWindow({
+        detectionTimeline: createTimeline(mutableFrames),
+        maskStyle: new BaseMaskStyle(),
+      });
+
+      renderWindow.getFrame(0);
+      await vi.runOnlyPendingTimersAsync();
+      const originalArtifact = renderWindow.getFrame(0)?.maskFrame;
+      const closeOriginalArtifact = vi.spyOn(originalArtifact!, "close");
+
+      expect(renderWindow.getFrame(0)?.maskFrame).toBe(originalArtifact);
+
+      const replacementFrame: DetectionFrame = {
+        ...frames[0]!,
+        detections: [
+          {
+            mask: {
+              counts: "13",
+              encoding: DetectionMaskEncoding.CompressedRle,
+              height: 2,
+              width: 2,
+            },
+          },
+        ],
+      };
+      mutableFrames[0] = replacementFrame;
+
+      const beforePreparation = renderWindow.getFrame(0);
+      await vi.runOnlyPendingTimersAsync();
+      const afterPreparation = renderWindow.getFrame(0);
+
+      expect(beforePreparation?.detectionFrame).toBe(replacementFrame);
+      expect(beforePreparation?.maskFrame).toBeUndefined();
+      expect(afterPreparation?.maskFrame).not.toBe(originalArtifact);
+      expect(closeOriginalArtifact).toHaveBeenCalledOnce();
+
+      renderWindow.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards a late mask artifact after the same frame key is replaced", async () => {
+    vi.useFakeTimers();
+    resetMocks();
+
+    try {
+      const staleImageBitmap = {
+        close: vi.fn(),
+        height: 2,
+        width: 2,
+      } as unknown as ImageBitmap;
+      const replacementImageBitmap = {
+        close: vi.fn(),
+        height: 2,
+        width: 2,
+      } as unknown as ImageBitmap;
+      const completedArtifacts = [staleImageBitmap, replacementImageBitmap];
+      const mutableFrames = [frames[0]!] as DetectionFrame[];
+      const fakeWorker = createFakeMaskPreparationWorker({
+        autoComplete: false,
+        createCompleteData: () => ({
+          imageBitmap: completedArtifacts.shift(),
+        }),
+      });
+      const renderWindow = createPreparedRenderWindow({
+        detectionTimeline: createTimeline(mutableFrames),
+        maskStyle: new BaseMaskStyle(),
+        prefetchFrameCount: 1,
+        renderPreparation: {
+          maskFrame: { workerCount: 1 },
+          mode: RenderPreparationMode.Worker,
+          workerFactory: { createWorker: () => fakeWorker.worker },
+        },
+      });
+
+      renderWindow.getFrame(0);
+      await vi.runOnlyPendingTimersAsync();
+
+      mutableFrames[0] = {
+        ...frames[0]!,
+        detections: [
+          {
+            mask: {
+              counts: "13",
+              encoding: DetectionMaskEncoding.CompressedRle,
+              height: 2,
+              width: 2,
+            },
+          },
+        ],
+      };
+      renderWindow.getFrame(0);
+
+      fakeWorker.completeNext();
+      await flushMaskPreparationTimers(4);
+
+      expect(staleImageBitmap.close).toHaveBeenCalledOnce();
+      expect(fakeWorker.messages).toHaveLength(2);
+      expect(renderWindow.getFrame(0)?.maskFrame).toBeUndefined();
+
+      fakeWorker.completeNext();
+      await flushMaskPreparationTimers(4);
+
+      expect(renderWindow.getFrame(0)?.maskFrame?.source).toBe(
+        replacementImageBitmap,
+      );
+      expect(replacementImageBitmap.close).not.toHaveBeenCalled();
+
+      renderWindow.destroy();
+      expect(replacementImageBitmap.close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("prepares and returns a cached mask artifact for the active frame", async () => {
     vi.useFakeTimers();
     resetMocks();

--- a/packages/web/src/render-preparation/prepared-render-window.ts
+++ b/packages/web/src/render-preparation/prepared-render-window.ts
@@ -142,6 +142,9 @@ export function createPreparedRenderWindow(options: {
   const queuedMaskFrameKeys: string[] = [];
   const inFlightMaskFrames = new Set<PendingMaskFrame>();
   const emptyMaskFrameKeys = new Set<string>();
+  // Detection frames are immutable snapshots. A new object at an existing
+  // timeline key therefore represents a source revision for that artifact.
+  const observedMaskFrames = new Map<string, DetectionFrame>();
   const readinessWaiters = new Set<() => void>();
   let scheduledQueuePump: ScheduledPreparationTask | undefined;
 
@@ -157,12 +160,13 @@ export function createPreparedRenderWindow(options: {
     const isActiveFrame =
       scheduleOptions.priority === PreparedRenderSchedulePriority.Active;
 
-    if (
-      !maskStyle ||
-      preparedMaskFrames.has(key) ||
-      emptyMaskFrameKeys.has(key) ||
-      isDestroyed
-    ) {
+    if (!maskStyle || isDestroyed) {
+      return false;
+    }
+
+    observeMaskFrame(frame, key);
+
+    if (preparedMaskFrames.has(key) || emptyMaskFrameKeys.has(key)) {
       return false;
     }
 
@@ -413,6 +417,40 @@ export function createPreparedRenderWindow(options: {
     }
   }
 
+  function observeMaskFrame(frame: DetectionFrame, key: string) {
+    const previousFrame = observedMaskFrames.get(key);
+
+    if (previousFrame === frame) {
+      return;
+    }
+
+    observedMaskFrames.set(key, frame);
+
+    if (!previousFrame) {
+      return;
+    }
+
+    invalidateMaskFrame(key);
+  }
+
+  function invalidateMaskFrame(key: string) {
+    lastPreparedBufferSignature = null;
+    lastPreparedWindowMediaTime = null;
+    removeQueuedMaskFrameKey(key);
+    pendingMaskFrames.delete(key);
+    emptyMaskFrameKeys.delete(key);
+
+    const maskFrame = preparedMaskFrames.get(key);
+
+    if (!maskFrame) {
+      return;
+    }
+
+    preparedMaskFrames.delete(key);
+    options.onMaskFrameEvicted?.(key);
+    maskFrame.close();
+  }
+
   const schedulePreparedWindow = (
     detectionFrame: DetectionFrame | undefined,
     mediaTime: number,
@@ -447,10 +485,10 @@ export function createPreparedRenderWindow(options: {
     const bufferedFrames = getBufferedDetectionTimelineFrameSnapshot(
       options.detectionTimeline,
     );
-    timeline.rememberFrames(
-      bufferedFrames,
-      getKnownFrameRetentionKeys(bufferedFrames),
-    );
+    const retainedKeys = getKnownFrameRetentionKeys(bufferedFrames);
+
+    timeline.rememberFrames(bufferedFrames, retainedKeys);
+    pruneObservedMaskFrames(retainedKeys);
     lastPreparedWindowFrames = timeline.getWindowFrames(
       bufferedFrames,
       anchorTime,
@@ -689,6 +727,14 @@ export function createPreparedRenderWindow(options: {
     }
   }
 
+  function pruneObservedMaskFrames(retainedKeys: ReadonlySet<string>) {
+    for (const key of observedMaskFrames.keys()) {
+      if (!retainedKeys.has(key)) {
+        observedMaskFrames.delete(key);
+      }
+    }
+  }
+
   function findPreparedMaskFrameEvictionCandidate() {
     const targetKeys = new Set(lastPreparedTargetFrames.map(getFrameKey));
     const activeKey = activeMaskFrame?.key ?? null;
@@ -723,6 +769,7 @@ export function createPreparedRenderWindow(options: {
     pendingMaskFrames.clear();
     queuedMaskFrameKeys.length = 0;
     emptyMaskFrameKeys.clear();
+    observedMaskFrames.clear();
     timeline.clear();
 
     if (preparedMaskFrames.size > 0) {

--- a/packages/web/src/renderers/pixi-mask-brush-preview.test.ts
+++ b/packages/web/src/renderers/pixi-mask-brush-preview.test.ts
@@ -1,0 +1,76 @@
+import type { MaskBrushEditor } from "#editing/mask-brush-editor";
+import { describe, expect, it, vi } from "vitest";
+
+import { createPixiMaskBrushPreview } from "./pixi-mask-brush-preview";
+
+describe("Pixi mask brush preview", () => {
+  it("uploads raster changes and redraws cursor changes independently", () => {
+    let textureListener: (() => void) | null = null;
+    let cursorListener: (() => void) | null = null;
+    const sourceUpdate = vi.fn();
+    const textureUpdate = vi.fn();
+    const cursorClear = vi.fn();
+    const editor = {
+      canvas: { height: 40, width: 60 },
+      getCursor: () => ({ mode: "add", point: { x: 4, y: 5 }, radius: 3 }),
+      subscribeCursorUpdates(listener: () => void) {
+        cursorListener = listener;
+        return () => {
+          cursorListener = null;
+        };
+      },
+      subscribeTextureUpdates(listener: () => void) {
+        textureListener = listener;
+        return () => {
+          textureListener = null;
+        };
+      },
+    } as unknown as MaskBrushEditor;
+
+    class Source {
+      destroy = vi.fn();
+      update = sourceUpdate;
+    }
+    class Texture {
+      destroy = vi.fn();
+      update = textureUpdate;
+    }
+    class Sprite {
+      alpha = 1;
+      height = 0;
+      tint = 0;
+      width = 0;
+    }
+    class Graphics {
+      circle = vi.fn();
+      clear = cursorClear;
+      stroke = vi.fn();
+    }
+    class Container {
+      addChild = vi.fn();
+    }
+
+    const preview = createPixiMaskBrushPreview({
+      CanvasSource: Source as never,
+      Container: Container as never,
+      Graphics: Graphics as never,
+      Sprite: Sprite as never,
+      Texture: Texture as never,
+      preview: { editor },
+    });
+
+    expect(cursorClear).toHaveBeenCalledTimes(1);
+    cursorListener!();
+    expect(cursorClear).toHaveBeenCalledTimes(2);
+    expect(sourceUpdate).not.toHaveBeenCalled();
+
+    textureListener!();
+    expect(sourceUpdate).toHaveBeenCalledTimes(1);
+    expect(textureUpdate).not.toHaveBeenCalled();
+    expect(cursorClear).toHaveBeenCalledTimes(2);
+
+    preview.destroy();
+    expect(textureListener).toBeNull();
+    expect(cursorListener).toBeNull();
+  });
+});

--- a/packages/web/src/renderers/pixi-mask-brush-preview.ts
+++ b/packages/web/src/renderers/pixi-mask-brush-preview.ts
@@ -50,12 +50,11 @@ export function createPixiMaskBrushPreview(options: {
   sprite.tint = options.preview.color ?? 0x22c55e;
   display.addChild(sprite, cursor);
 
-  const update = () => {
+  const updateTexture = () => {
     source.update();
-    texture.update();
-    drawCursor();
   };
-  const unsubscribe = editor.subscribeTextureUpdates(update);
+  const unsubscribeTexture = editor.subscribeTextureUpdates(updateTexture);
+  const unsubscribeCursor = editor.subscribeCursorUpdates(drawCursor);
   drawCursor();
 
   return {
@@ -65,7 +64,8 @@ export function createPixiMaskBrushPreview(options: {
       drawCursor();
     },
     destroy() {
-      unsubscribe();
+      unsubscribeCursor();
+      unsubscribeTexture();
       texture.destroy();
       source.destroy();
     },


### PR DESCRIPTION
# Description

Invalidate prepared mask artifacts when an immutable detection-frame snapshot is replaced at the same timeline key. This prevents selected-mask brush edits from continuing to display the old raster while preserving artifact reuse for unchanged frames and presentation-only style changes.

Late results from an invalidated worker job are closed and cannot replace the newer pending job.

The selected-mask brush hot path now keeps a binary mask backing store, snapshots only dirty stroke regions for cancel, computes RLE and bounds together, and separates cursor notifications from raster texture invalidation. Cursor hover no longer uploads the canvas texture, one active move produces one raster notification, and stroke boundaries no longer read back the full RGBA canvas or decode the mask again for bounds.

Source: `/Users/joaomarcoscrs/.local/state/brains/live/work/_reports/bug-investigation-2026-08-03-mask-brush-main-thread-lag.md`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added regression coverage for same-key mask replacement and artifact eviction.
- Added worker-race coverage proving late stale artifacts are closed and never published.
- Added operation-count coverage proving cursor updates do not invalidate textures, active moves emit one raster notification, stroke boundaries avoid full-frame canvas reads, and cancel restores the touched raster.
- Added Pixi preview coverage proving source uploads and cursor redraws are independent.
- Ran `npm run verify` at commit `d3c75726ddf162fca4765a575e76a53cb9a62882` (62 test files / 422 tests plus all package, docs, demo, example, and benchmark builds).

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Regenerate the private supervision-js tarball for core-app consumers.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
