### PR TITLE
Fix buffered playback coverage and renderer resizing

### DIFF
--- a/docs/public/api/rendering.ts
+++ b/docs/public/api/rendering.ts
@@ -7,6 +7,7 @@
 export {
   createMediaRenderer,
   createMediaStreamRendererSource,
+  DetectionTimelineOrigin,
   MediaRendererFit,
   MediaRendererPlaybackState,
   MediaSourceStatus,

--- a/packages/core/src/detections/writable-detection-frame-source.test.ts
+++ b/packages/core/src/detections/writable-detection-frame-source.test.ts
@@ -193,6 +193,65 @@ describe("writable detection frame source", () => {
     expect(source.getAvailableRanges()).toEqual([{ endTime: 2, startTime: 0 }]);
   });
 
+  it("keeps sparse out-of-order batch ranges unavailable and separately journaled", async () => {
+    const store = createStore();
+    const source = createWritableDetectionFrameSource({
+      datasetId: "dataset",
+      store,
+    });
+    let resolved = false;
+    const waitForRange = source
+      .waitForRange({ endTime: 2, startTime: 0 })
+      .then(() => {
+        resolved = true;
+      });
+
+    await source.appendFrames([
+      {
+        detections: [],
+        endTime: 3,
+        frameIndex: 2,
+        mediaTime: 2,
+      },
+      {
+        detections: [],
+        endTime: 1,
+        frameIndex: 0,
+        mediaTime: 0,
+      },
+    ]);
+    await Promise.resolve();
+
+    expect.soft(resolved).toBe(false);
+    expect(source.getVersion()).toBe(1);
+    expect(source.getVersion({ endTime: 1.75, startTime: 1.25 })).toBe(0);
+    expect(source.getAvailableRanges()).toEqual([
+      { endTime: 1, startTime: 0 },
+      { endTime: 3, startTime: 2 },
+    ]);
+    expect(source.getChangesSince!(0, [{ endTime: 3, startTime: 0 }])).toEqual({
+      ranges: [
+        { endTime: 1, startTime: 0 },
+        { endTime: 3, startTime: 2 },
+      ],
+      requiresReload: false,
+      version: 1,
+    });
+
+    await source.appendFrames([
+      {
+        detections: [],
+        endTime: 2,
+        frameIndex: 1,
+        mediaTime: 1,
+      },
+    ]);
+    await waitForRange;
+
+    expect(resolved).toBe(true);
+    expect(source.getAvailableRanges()).toEqual([{ endTime: 3, startTime: 0 }]);
+  });
+
   it("applies rolling retention after appending frames", async () => {
     const frameStore: DetectionFrame[] = [];
     const store = createMutableStore(frameStore);

--- a/packages/core/src/detections/writable-detection-frame-source.ts
+++ b/packages/core/src/detections/writable-detection-frame-source.ts
@@ -49,13 +49,17 @@ export function createWritableDetectionFrameSource(options: {
 
   const recordRangeWrite = (
     nextSummary: ColdDetectionFrameStoreWriteSummary,
-    changedRange: DetectionFrameSourceVersionRange,
+    changedSourceRanges: readonly DetectionFrameSourceVersionRange[],
   ) => {
     summary = nextSummary;
     version += 1;
-    changedRanges.push({ ...changedRange, version });
+
+    for (const changedRange of changedSourceRanges) {
+      changedRanges.push({ ...changedRange, version });
+      recordAvailableRange(changedRange, availableRanges);
+    }
+
     compactChangedRangeJournal();
-    recordAvailableRange(changedRange, availableRanges);
     resolveCoveredWaiters();
 
     return nextSummary;
@@ -97,7 +101,7 @@ export function createWritableDetectionFrameSource(options: {
       );
       assertActive();
 
-      const changedRange = getDetectionFramesRange(frames);
+      const changedSourceRanges = getDetectionFrameRanges(frames);
       const retainedSummary = await applyRetention(nextSummary);
       assertActive();
 
@@ -105,12 +109,12 @@ export function createWritableDetectionFrameSource(options: {
         return recordAllRangesWrite(retainedSummary);
       }
 
-      if (!changedRange) {
+      if (changedSourceRanges.length === 0) {
         summary = nextSummary;
         return nextSummary;
       }
 
-      return recordRangeWrite(nextSummary, changedRange);
+      return recordRangeWrite(nextSummary, changedSourceRanges);
     },
 
     async replaceFrames(frames) {
@@ -343,22 +347,14 @@ function shouldApplyWindowRetention(
   );
 }
 
-function getDetectionFramesRange(
+function getDetectionFrameRanges(
   frames: readonly DetectionFrame[],
-): DetectionFrameSourceVersionRange | null {
-  if (frames.length === 0) {
-    return null;
-  }
-
-  return frames.reduce(
-    (range, frame) => ({
-      endTime: Math.max(range.endTime, frame.endTime ?? frame.mediaTime),
-      startTime: Math.min(range.startTime, frame.mediaTime),
-    }),
-    {
-      endTime: Number.NEGATIVE_INFINITY,
-      startTime: Number.POSITIVE_INFINITY,
-    },
+): readonly DetectionFrameSourceVersionRange[] {
+  return mergeRanges(
+    frames.map((frame) => ({
+      endTime: frame.endTime ?? frame.mediaTime,
+      startTime: frame.mediaTime,
+    })),
   );
 }
 

--- a/packages/web/src/detections/offset-detection-frame-source.test.ts
+++ b/packages/web/src/detections/offset-detection-frame-source.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DetectionFrameSource } from "supervision-js-core";
+import { createOffsetDetectionFrameSource } from "./offset-detection-frame-source";
+
+describe("offset detection frame source", () => {
+  it("translates reads, frames, coverage, versions, and incremental changes", async () => {
+    const source: DetectionFrameSource = {
+      destroy: vi.fn(),
+      getAvailableRanges: vi.fn(() => [{ startTime: 0, endTime: 1 }]),
+      getChangesSince: vi.fn(() => ({
+        ranges: [{ startTime: 0.25, endTime: 0.5 }],
+        requiresReload: false,
+        version: 3,
+      })),
+      getVersion: vi.fn(() => 3),
+      loadFrames: vi.fn(async () => [
+        {
+          detections: [],
+          endTime: 1 / 30,
+          frameIndex: 0,
+          mediaTime: 0,
+        },
+      ]),
+      waitForRange: vi.fn(async () => undefined),
+    };
+    const shifted = createOffsetDetectionFrameSource(source, 0.6);
+
+    await expect(shifted.loadFrames(0.6, 1.6)).resolves.toEqual([
+      {
+        detections: [],
+        endTime: 0.6 + 1 / 30,
+        frameIndex: 0,
+        mediaTime: 0.6,
+      },
+    ]);
+    expect(source.loadFrames).toHaveBeenCalledWith(0, 1);
+
+    await shifted.waitForRange?.({ startTime: 0.6, endTime: 1.6 });
+    expect(source.waitForRange).toHaveBeenCalledWith({
+      startTime: 0,
+      endTime: 1,
+    });
+    expect(shifted.getAvailableRanges?.()).toEqual([
+      { startTime: 0.6, endTime: 1.6 },
+    ]);
+    expect(shifted.getVersion?.({ startTime: 0.6, endTime: 1.6 })).toBe(3);
+    expect(source.getVersion).toHaveBeenCalledWith({
+      startTime: 0,
+      endTime: 1,
+    });
+    expect(
+      shifted.getChangesSince?.(2, [{ startTime: 0.6, endTime: 1.6 }]),
+    ).toEqual({
+      ranges: [{ startTime: 0.85, endTime: 1.1 }],
+      requiresReload: false,
+      version: 3,
+    });
+
+    shifted.destroy?.();
+    expect(source.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a non-finite offset", () => {
+    expect(() =>
+      createOffsetDetectionFrameSource(
+        { loadFrames: vi.fn(async () => []) },
+        Number.NaN,
+      ),
+    ).toThrow("offsetSeconds must be finite.");
+  });
+});

--- a/packages/web/src/detections/offset-detection-frame-source.ts
+++ b/packages/web/src/detections/offset-detection-frame-source.ts
@@ -1,0 +1,89 @@
+import type {
+  DetectionFrame,
+  DetectionFrameSource,
+  DetectionFrameSourceVersionRange,
+} from "supervision-js-core";
+
+/**
+ * Presents a detection source on a shifted media timeline.
+ *
+ * The wrapped source remains expressed in its own zero-based clock. Renderer
+ * reads, coverage waits, and incremental changes are translated in both
+ * directions so buffering and frame selection share the same timeline.
+ */
+export function createOffsetDetectionFrameSource(
+  source: DetectionFrameSource,
+  offsetSeconds: number,
+): DetectionFrameSource {
+  if (!Number.isFinite(offsetSeconds)) {
+    throw new RangeError("offsetSeconds must be finite.");
+  }
+
+  const fromRendererRange = (range: DetectionFrameSourceVersionRange) => ({
+    endTime: range.endTime - offsetSeconds,
+    startTime: range.startTime - offsetSeconds,
+  });
+  const toRendererRange = (range: DetectionFrameSourceVersionRange) => ({
+    endTime: range.endTime + offsetSeconds,
+    startTime: range.startTime + offsetSeconds,
+  });
+  const toRendererFrame = (frame: DetectionFrame): DetectionFrame => ({
+    ...frame,
+    mediaTime: frame.mediaTime + offsetSeconds,
+    ...(frame.endTime === undefined
+      ? {}
+      : { endTime: frame.endTime + offsetSeconds }),
+  });
+
+  return {
+    async loadFrames(startTime, endTime) {
+      const frames = await source.loadFrames(
+        startTime - offsetSeconds,
+        endTime - offsetSeconds,
+      );
+      return frames.map(toRendererFrame);
+    },
+    ...(source.waitForRange
+      ? {
+          waitForRange: (range: DetectionFrameSourceVersionRange) =>
+            source.waitForRange?.(fromRendererRange(range)) ??
+            Promise.resolve(),
+        }
+      : {}),
+    ...(source.getAvailableRanges
+      ? {
+          getAvailableRanges: () =>
+            (source.getAvailableRanges?.() ?? []).map(toRendererRange),
+        }
+      : {}),
+    ...(source.getVersion
+      ? {
+          getVersion: (range?: DetectionFrameSourceVersionRange) =>
+            source.getVersion?.(
+              range === undefined ? undefined : fromRendererRange(range),
+            ) ?? 0,
+        }
+      : {}),
+    ...(source.getChangesSince
+      ? {
+          getChangesSince: (
+            version: number,
+            ranges: readonly DetectionFrameSourceVersionRange[],
+          ) => {
+            const changes = source.getChangesSince?.(
+              version,
+              ranges.map(fromRendererRange),
+            );
+            if (!changes) {
+              return { ranges: [], requiresReload: false, version };
+            }
+            return {
+              ...changes,
+              ranges: changes.ranges.map(toRendererRange),
+            };
+          },
+        }
+      : {}),
+    destroy: () => source.destroy?.(),
+  };
+}

--- a/packages/web/src/index.test.ts
+++ b/packages/web/src/index.test.ts
@@ -62,6 +62,7 @@ describe("package entrypoint", () => {
       "DetectionInteractionState",
       "DetectionMaskEncoding",
       "DetectionPickTarget",
+      "DetectionTimelineOrigin",
       "FocusTargetMode",
       "KeypointMarkerShape",
       "KeypointVisibility",

--- a/packages/web/src/index.test.ts
+++ b/packages/web/src/index.test.ts
@@ -528,6 +528,75 @@ describe("package entrypoint", () => {
     renderer.destroy();
   });
 
+  it("keeps prediction-gated playback inside exact appended coverage", async () => {
+    resetMocks();
+    mediaMock.samples = [
+      createMockSample(0, 0),
+      createMockSample(0.04, 0),
+      createMockSample(0.08, 0),
+    ];
+    const {
+      createMemoryColdDetectionFrameStore,
+      createWritableDetectionFrameSource,
+    } = await import("./index");
+    const detectionSource = createWritableDetectionFrameSource({
+      datasetId: "sparse-predictions",
+      store: createMemoryColdDetectionFrameStore(),
+    });
+
+    await detectionSource.appendFrames([
+      { detections: [], endTime: 0.04, frameIndex: 0, mediaTime: 0 },
+      { detections: [], endTime: 0.12, frameIndex: 2, mediaTime: 0.08 },
+    ]);
+
+    const renderer = await createRenderer(false, false, {
+      detectionBuffer: {
+        playbackGate: {
+          enabled: true,
+          requiredAheadSeconds: 0.08,
+        },
+      },
+      detectionSource,
+    });
+
+    mediaMock.getSample.mockClear();
+    mediaMock.samplesCallStarts.length = 0;
+    await renderer.play();
+    await vi.waitFor(() => {
+      expect(mediaMock.samplesCallStarts).toEqual([0]);
+      expect(mediaMock.sampleNextCalls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    flushAnimationFrame(40);
+    await vi.waitFor(() => {
+      expect(renderer.getState().playbackState).toBe(
+        MediaRendererPlaybackState.Buffering,
+      );
+    });
+
+    expect(mediaMock.samples[1].draw).not.toHaveBeenCalled();
+
+    await detectionSource.appendFrames([
+      {
+        detections: [],
+        endTime: 0.08,
+        frameIndex: 1,
+        mediaTime: 0.04,
+      },
+    ]);
+    await vi.waitFor(() => {
+      expect(mediaMock.samples[1].draw).toHaveBeenCalledOnce();
+    });
+
+    expect(renderer.getState()).toMatchObject({
+      currentTime: 0.04,
+      playbackState: MediaRendererPlaybackState.Playing,
+    });
+
+    renderer.destroy();
+    detectionSource.destroy?.();
+  });
+
   it("seek uses random sample lookup and updates detections and buffer state", async () => {
     resetMocks();
     mediaMock.samples = [

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -248,6 +248,7 @@ export {
   type MediaSessionWritableDetectionOptions,
 } from "#types/media-session";
 export {
+  DetectionTimelineOrigin,
   MediaRendererFit,
   MediaRendererPlaybackState,
   MediaSourceStatus,

--- a/packages/web/src/renderers/media-renderer-core.test.ts
+++ b/packages/web/src/renderers/media-renderer-core.test.ts
@@ -7,6 +7,7 @@ import type {
   DecodedVideoSample,
 } from "#media/media-source";
 import {
+  DetectionTimelineOrigin,
   MediaRendererPlaybackState,
   type MediaRendererOptions,
 } from "#types/media-renderer";
@@ -165,6 +166,75 @@ describe("media renderer core", () => {
     expect(detectionSource.loadFrames).toHaveBeenCalledTimes(2);
     expect(detectionSource.loadFrames).toHaveBeenNthCalledWith(1, 4.25, 5);
     expect(detectionSource.loadFrames).toHaveBeenNthCalledWith(2, 0, 1.75);
+
+    renderer.destroy();
+  });
+
+  it("aligns zero-based detections to a non-zero media start timestamp", async () => {
+    resetMocks();
+
+    const samples = [
+      createMockSample(0.6, 1 / 30),
+    ] as unknown as DecodedVideoSample[];
+    const detectionSource = {
+      loadFrames: vi.fn(async () => [
+        {
+          detections: [{ id: "mask-0" }],
+          endTime: 1 / 30,
+          frameIndex: 0,
+          mediaTime: 0,
+        },
+      ]),
+    };
+    const renderer = await createMediaRendererCore(
+      {
+        autoPlay: false,
+        container: {} as HTMLElement,
+        detectionBuffer: {
+          bufferAheadSeconds: 0,
+          bufferBehindSeconds: 0,
+          frameIndexOriginTime: 0,
+          frameRate: 30,
+          selectionMode: DetectionFrameSelectionMode.NearestFrameIndex,
+        },
+        detectionSource,
+        detectionTimelineOrigin: DetectionTimelineOrigin.MediaStart,
+        loop: false,
+        source: createSource(samples, {
+          duration: 1,
+          firstTimestamp: 0.6,
+        }),
+      } satisfies MediaRendererOptions,
+      {
+        createScene: vi.fn(async (options) =>
+          createScene({
+            presentSample: vi.fn((sample) => {
+              const activeFrame = options.detectionTimeline.selectFrame(
+                sample.timestamp,
+              );
+              sample.close();
+              return {
+                activeDetectionCount: activeFrame?.detections.length ?? 0,
+                activeDetectionFrameIndex: activeFrame?.frameIndex ?? null,
+                activeDetectionFrameTime: activeFrame?.mediaTime ?? null,
+                detectionBuffer: createIdleDetectionBufferState(),
+                duration: sample.duration,
+                mediaTime: sample.timestamp,
+              };
+            }),
+          }),
+        ),
+        openMediaSource: vi.fn(),
+      },
+    );
+
+    expect(detectionSource.loadFrames).toHaveBeenCalledWith(0, 0);
+    expect(renderer.getState()).toMatchObject({
+      activeDetectionCount: 1,
+      activeDetectionFrameIndex: 0,
+      activeDetectionFrameTime: 0.6,
+      currentTime: 0.6,
+    });
 
     renderer.destroy();
   });

--- a/packages/web/src/renderers/media-renderer-core.ts
+++ b/packages/web/src/renderers/media-renderer-core.ts
@@ -19,6 +19,7 @@ import {
   type MediaPlaybackController,
 } from "#playback/media-playback-controller";
 import {
+  DetectionTimelineOrigin,
   MediaRendererFit,
   type MediaRenderer,
   type MediaRendererOptions,
@@ -26,6 +27,7 @@ import {
 } from "#types/media-renderer";
 import { MediaInteractionMode } from "supervision-js-core";
 import type { RenderPreparationPlaybackGateOptions } from "#types/render-preparation";
+import { createOffsetDetectionFrameSource } from "#detections/offset-detection-frame-source";
 import { createMediaRendererRuntimeState } from "./media-renderer-state";
 import type {
   MediaRendererScene,
@@ -371,12 +373,6 @@ export async function createMediaRendererCore(
       );
     }
 
-    detectionTimeline = createBufferedDetectionTimeline({
-      source:
-        options.detectionSource ??
-        createArrayDetectionFrameSource(options.detectionFrames),
-      ...options.detectionBuffer,
-    });
     const mediaSource = await openRendererMediaSource(options, providers);
     mediaInput = mediaSource.input;
     sampleSink = mediaSource.sampleSink;
@@ -389,6 +385,29 @@ export async function createMediaRendererCore(
     const { metadata } = mediaSource;
 
     firstTimestamp = metadata.firstTimestamp;
+    const detectionSource =
+      options.detectionSource ??
+      createArrayDetectionFrameSource(options.detectionFrames);
+    detectionTimeline = createBufferedDetectionTimeline({
+      source:
+        options.detectionTimelineOrigin ===
+          DetectionTimelineOrigin.MediaStart && metadata.firstTimestamp !== 0
+          ? createOffsetDetectionFrameSource(
+              detectionSource,
+              metadata.firstTimestamp,
+            )
+          : detectionSource,
+      ...options.detectionBuffer,
+      ...(options.detectionTimelineOrigin ===
+        DetectionTimelineOrigin.MediaStart &&
+      options.detectionBuffer?.frameIndexOriginTime !== undefined
+        ? {
+            frameIndexOriginTime:
+              options.detectionBuffer.frameIndexOriginTime +
+              metadata.firstTimestamp,
+          }
+        : {}),
+    });
     const mediaDimensions = runtimeState.recordMediaMetadata(metadata);
     mediaScene = await providers.createScene({
       annotationOverlayStyle: options.annotationOverlayStyle,

--- a/packages/web/src/renderers/pixi-media-scene.test.ts
+++ b/packages/web/src/renderers/pixi-media-scene.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe("Pixi media scene container resizing", () => {
-  it("queues a Pixi resize when the host element changes size", () => {
+  it("synchronously resizes Pixi when the host element changes size", () => {
     const observe = vi.fn();
     const disconnect = vi.fn();
     let notify: ResizeObserverCallback = () => undefined;
@@ -27,13 +27,13 @@ describe("Pixi media scene container resizing", () => {
 
     vi.stubGlobal("ResizeObserver", TestResizeObserver);
     const container = {} as HTMLElement;
-    const queueResize = vi.fn();
+    const resize = vi.fn();
 
-    const stopObserving = observePixiContainerResize(container, queueResize);
+    const stopObserving = observePixiContainerResize(container, resize);
 
     expect(observe).toHaveBeenCalledWith(container);
     notify([], {} as ResizeObserver);
-    expect(queueResize).toHaveBeenCalledTimes(1);
+    expect(resize).toHaveBeenCalledTimes(1);
 
     stopObserving();
     expect(disconnect).toHaveBeenCalledTimes(1);
@@ -41,15 +41,12 @@ describe("Pixi media scene container resizing", () => {
 
   it("is a no-op where ResizeObserver is unavailable", () => {
     vi.stubGlobal("ResizeObserver", undefined);
-    const queueResize = vi.fn();
+    const resize = vi.fn();
 
-    const stopObserving = observePixiContainerResize(
-      {} as HTMLElement,
-      queueResize,
-    );
+    const stopObserving = observePixiContainerResize({} as HTMLElement, resize);
 
     expect(() => stopObserving()).not.toThrow();
-    expect(queueResize).not.toHaveBeenCalled();
+    expect(resize).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/renderers/pixi-media-scene.test.ts
+++ b/packages/web/src/renderers/pixi-media-scene.test.ts
@@ -1,6 +1,57 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { canReuseMaskVisibilityArtifacts } from "./pixi-media-scene";
+import {
+  canReuseMaskVisibilityArtifacts,
+  observePixiContainerResize,
+} from "./pixi-media-scene";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Pixi media scene container resizing", () => {
+  it("queues a Pixi resize when the host element changes size", () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    let notify: ResizeObserverCallback = () => undefined;
+
+    class TestResizeObserver {
+      public constructor(callback: ResizeObserverCallback) {
+        notify = callback;
+      }
+
+      public observe = observe;
+      public unobserve = vi.fn();
+      public disconnect = disconnect;
+    }
+
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    const container = {} as HTMLElement;
+    const queueResize = vi.fn();
+
+    const stopObserving = observePixiContainerResize(container, queueResize);
+
+    expect(observe).toHaveBeenCalledWith(container);
+    notify([], {} as ResizeObserver);
+    expect(queueResize).toHaveBeenCalledTimes(1);
+
+    stopObserving();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op where ResizeObserver is unavailable", () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const queueResize = vi.fn();
+
+    const stopObserving = observePixiContainerResize(
+      {} as HTMLElement,
+      queueResize,
+    );
+
+    expect(() => stopObserving()).not.toThrow();
+    expect(queueResize).not.toHaveBeenCalled();
+  });
+});
 
 describe("Pixi media scene mask visibility", () => {
   it("reuses mask artifacts across equivalent visibility objects", () => {

--- a/packages/web/src/renderers/pixi-media-scene.ts
+++ b/packages/web/src/renderers/pixi-media-scene.ts
@@ -48,14 +48,14 @@ import type {
 
 export function observePixiContainerResize(
   container: HTMLElement,
-  queueResize: () => void,
+  resize: () => void,
 ): () => void {
   const ResizeObserverConstructor = globalThis.ResizeObserver;
   if (!ResizeObserverConstructor) {
     return () => undefined;
   }
 
-  const observer = new ResizeObserverConstructor(() => queueResize());
+  const observer = new ResizeObserverConstructor(() => resize());
   observer.observe(container);
   return () => observer.disconnect();
 }
@@ -421,11 +421,14 @@ export async function createPixiMediaScene(
 
   // Pixi's ResizePlugin listens to the window resize event, which does not
   // fire when an application drawer or split pane changes only this element's
-  // dimensions. Observe the actual host and use Pixi's queued resize so the
-  // renderer screen and the contain/cover fit are recalculated together.
+  // dimensions. Resize Pixi and recompute the contain/cover transform in the
+  // same observer callback so CSS cannot stretch an old canvas between frames.
   const disconnectContainerResizeObserver = observePixiContainerResize(
     options.container,
-    () => app.queueResize(),
+    () => {
+      app.resize();
+      updateMediaSceneFit();
+    },
   );
 
   app.ticker.add(updateMediaSceneFit);

--- a/packages/web/src/renderers/pixi-media-scene.ts
+++ b/packages/web/src/renderers/pixi-media-scene.ts
@@ -46,6 +46,20 @@ import type {
   Texture as PixiTexture,
 } from "pixi.js";
 
+export function observePixiContainerResize(
+  container: HTMLElement,
+  queueResize: () => void,
+): () => void {
+  const ResizeObserverConstructor = globalThis.ResizeObserver;
+  if (!ResizeObserverConstructor) {
+    return () => undefined;
+  }
+
+  const observer = new ResizeObserverConstructor(() => queueResize());
+  observer.observe(container);
+  return () => observer.disconnect();
+}
+
 type TextureUploadSource = {
   update(): void;
 };
@@ -404,6 +418,15 @@ export async function createPixiMediaScene(
     drawFocusLayer(currentMediaTime);
     drawInteractionPresentationLayer(currentMediaTime);
   };
+
+  // Pixi's ResizePlugin listens to the window resize event, which does not
+  // fire when an application drawer or split pane changes only this element's
+  // dimensions. Observe the actual host and use Pixi's queued resize so the
+  // renderer screen and the contain/cover fit are recalculated together.
+  const disconnectContainerResizeObserver = observePixiContainerResize(
+    options.container,
+    () => app.queueResize(),
+  );
 
   app.ticker.add(updateMediaSceneFit);
   app.ticker.add(drawAnnotationOverlay);
@@ -841,6 +864,8 @@ export async function createPixiMediaScene(
     },
 
     destroy() {
+      disconnectContainerResizeObserver();
+      app.cancelResize?.();
       app.ticker.remove(updateMediaSceneFit);
       app.ticker.remove(drawAnnotationOverlay);
       app.ticker.remove(tickFocusLayer);

--- a/packages/web/src/renderers/pixi-scene-fit.test.ts
+++ b/packages/web/src/renderers/pixi-scene-fit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { MediaRendererFit } from "#types/media-renderer";
+import { calculatePixiSceneFit } from "./pixi-scene-fit";
+
+describe("Pixi scene fit", () => {
+  it.each([
+    { screenHeight: 900, screenWidth: 1600 },
+    { screenHeight: 1200, screenWidth: 700 },
+  ])(
+    "preserves portrait media proportions in a $screenWidth x $screenHeight host",
+    (screen) => {
+      const mediaWidth = 720;
+      const mediaHeight = 956;
+      const fit = calculatePixiSceneFit({
+        fit: MediaRendererFit.Contain,
+        mediaHeight,
+        mediaWidth,
+        ...screen,
+      });
+
+      expect(fit).toBeDefined();
+      const renderedWidth = mediaWidth * (fit?.scale ?? 0);
+      const renderedHeight = mediaHeight * (fit?.scale ?? 0);
+      expect(renderedWidth / renderedHeight).toBeCloseTo(
+        mediaWidth / mediaHeight,
+        10,
+      );
+      expect(fit?.x).toBeCloseTo((screen.screenWidth - renderedWidth) / 2, 10);
+      expect(fit?.y).toBeCloseTo(
+        (screen.screenHeight - renderedHeight) / 2,
+        10,
+      );
+    },
+  );
+});

--- a/packages/web/src/sessions/media-session.ts
+++ b/packages/web/src/sessions/media-session.ts
@@ -123,6 +123,7 @@ export async function createMediaSession(
       detectionBuffer: sessionDefaults.detectionBuffer,
       detectionFrames: sessionDetections.detectionFrames,
       detectionSource: sessionDetections.detectionSource,
+      detectionTimelineOrigin: options.detections?.timelineOrigin,
       focusStyle: initialPresentation.focusStyle,
       interactionStyle: initialPresentation.interactionStyle,
       labelStyle: initialPresentation.labelStyle,

--- a/packages/web/src/types/media-renderer.ts
+++ b/packages/web/src/types/media-renderer.ts
@@ -39,6 +39,14 @@ export type {
   MediaSourceState,
 } from "supervision-js-core";
 
+/** Clock used by semantic detection frames supplied to a media renderer. */
+export enum DetectionTimelineOrigin {
+  /** Detection times already use the decoded media source's native timeline. */
+  MediaTimeline = "mediaTimeline",
+  /** Detection time zero corresponds to the first decoded media sample. */
+  MediaStart = "mediaStart",
+}
+
 /**
  * Lower-level renderer options.
  *
@@ -68,6 +76,11 @@ export interface MediaRendererOptions extends MediaRendererPresentation {
   readonly detectionFrames?: readonly DetectionFrame[];
   readonly detectionSource?: DetectionFrameSource;
   readonly detectionBuffer?: DetectionBufferOptions;
+  /**
+   * Aligns detection timestamps with media whose first presentation timestamp
+   * is not zero. Defaults to `MediaTimeline` for backward compatibility.
+   */
+  readonly detectionTimelineOrigin?: DetectionTimelineOrigin;
   readonly interaction?: MediaInteractionOptions;
   readonly renderPreparation?: RenderPreparationOptions;
   readonly diagnostics?: MediaRendererDiagnosticsOptions;

--- a/packages/web/src/types/media-session.ts
+++ b/packages/web/src/types/media-session.ts
@@ -22,6 +22,7 @@ import type {
   ProgressiveNormalizedMedia,
 } from "#types/media-normalization";
 import type {
+  DetectionTimelineOrigin,
   MediaFrameDiagnostics,
   MediaRenderer,
   MediaRendererFit,
@@ -177,6 +178,12 @@ export interface MediaSessionDetectionOptions {
    * readiness.
    */
   readonly playbackGate?: DetectionPlaybackGateOptions;
+
+  /**
+   * Clock used by supplied detection frames. Use `MediaStart` when inference
+   * timestamps begin at zero independently of the file's encoded PTS.
+   */
+  readonly timelineOrigin?: DetectionTimelineOrigin;
 }
 
 export interface MediaSessionRendererOptions {

--- a/tools/package-smoke.test.mjs
+++ b/tools/package-smoke.test.mjs
@@ -22,6 +22,7 @@ const expectedWebRuntimeExports = [
   "DetectionInteractionState",
   "DetectionMaskEncoding",
   "DetectionPickTarget",
+  "DetectionTimelineOrigin",
   "FocusTargetMode",
   "KeypointMarkerShape",
   "KeypointVisibility",
@@ -195,6 +196,7 @@ test("built package entrypoint exposes the public runtime API", async () => {
   assert.equal(typeof entrypoint.BaseLabelStyle, "function");
   assert.equal(entrypoint.MediaSessionStatus.Ready, "ready");
   assert.equal(entrypoint.MediaRendererFit.Contain, "contain");
+  assert.equal(entrypoint.DetectionTimelineOrigin.MediaStart, "mediaStart");
 });
 
 test("built editing entrypoint exposes advanced host-owned editing APIs", async () => {


### PR DESCRIPTION
# Description

Fixes appendable detection coverage bookkeeping so sparse, out-of-order frames in one append are not advertised as one continuous interval. Each append still advances the source version once, while availability and the change journal retain every exact coalesced range.

This prevents prediction-gated playback from advancing into frames whose detections have not arrived yet. It also observes host-element resize changes, so Pixi recalculates its renderer screen and media fit when drawers or split panes change the available width without a window resize. The generated portable tarball will be consumed by roboflow/roboflow#14129.

Source investigation: `/Users/joaomarcoscrs/.local/state/brains/live/work/_reports/bug-investigation-2026-08-04-rapid-buffered-playback-ahead-of-detections.md`

## Acceptance criteria covered

- Sparse gaps remain unavailable until filled.
- One append retains one atomic source version.
- Changed ranges remain separated across untouched gaps.
- Renderer playback remains buffering until the missing prediction interval arrives.
- Media remains centered when its host element is resized by surrounding application layout.

## Verification

- `npm run verify` (453 tests plus typecheck, lint, package, demo, docs, and benchmark builds)
- `npm run package:tarball`
- `npm run package:tarball:smoke` (7 clean-consumer checks)