### PR TITLE
Prepare supervision-js for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug report
+description: Report a reproducible problem in supervision-js.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please include a small, reproducible browser example. Do not include API keys or other secrets.
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Include the media type, detection input, and integration steps.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: supervision-js version or commit
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Browser and operating system
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Propose a focused improvement to supervision-js.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API or behavior
+      description: Explain the browser application use case and any alternatives considered.
+    validations:
+      required: true
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This does not require exposing renderer implementation details.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+
+<!-- What changed and why? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation or example update
+- [ ] Refactor or maintenance
+- [ ] Performance improvement
+
+## Validation
+
+<!-- List the focused checks you ran. -->
+
+- [ ] Tests added or updated where behavior changed
+- [ ] Documentation updated where the public API or workflow changed
+- [ ] Screenshots or recording attached for visual changes
+
+## Notes For Reviewers
+
+<!-- Include migration, compatibility, performance, or deployment considerations. -->

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+title: supervision-js
+message: >-
+  If you use this software, please cite it using the metadata from this file.
+type: software
+authors:
+  - given-names: Roboflow
+    email: support@roboflow.com
+repository-code: https://github.com/roboflow/supervision-js
+url: https://supervision-js-demo.onrender.com/
+abstract: >-
+  supervision-js provides browser-native media rendering, annotation styling,
+  interaction, and editing primitives for computer vision applications.
+keywords:
+  - computer vision
+  - browser
+  - video processing
+  - annotation rendering
+license: MIT

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socioeconomic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- demonstrating empathy and kindness toward others;
+- respecting differing opinions, viewpoints, and experiences;
+- giving and gracefully accepting constructive feedback;
+- accepting responsibility and learning from mistakes;
+- focusing on what is best for the overall community.
+
+Examples of unacceptable behavior include sexualized language or imagery,
+trolling, insulting or derogatory comments, personal or political attacks,
+public or private harassment, publishing another person's private information
+without permission, or other conduct that is inappropriate in a professional
+setting.
+
+## Enforcement
+
+Community leaders are responsible for clarifying and enforcing these standards.
+They may remove, edit, or reject contributions that are not aligned with this
+Code of Conduct and will communicate moderation decisions when appropriate.
+
+Report abusive, harassing, or otherwise unacceptable behavior to
+community-reports@roboflow.com. Reports are reviewed promptly and fairly, and
+community leaders must respect the reporter's privacy and security.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to supervision-js
+
+Thanks for helping improve `supervision-js`. We welcome bug reports,
+documentation corrections, examples, performance investigations, and focused
+code contributions.
+
+## Before You Start
+
+- Search existing issues and pull requests before opening a new one.
+- Keep browser renderer changes aligned with the session-first public API.
+- Do not expose PixiJS, Mediabunny, worker, or prepared-artifact internals as
+  public API without a concrete consumer need.
+- Treat React Native as experimental and keep it independent of the browser
+  package.
+
+For project boundaries and commands, read
+[docs/internal/agent-guidance.md](docs/internal/agent-guidance.md).
+
+## Local Development
+
+Use Node.js 20.19 or newer.
+
+```sh
+npm install
+npm run dev
+```
+
+Useful checks:
+
+```sh
+npm run format:check
+npm run lint
+npm run typecheck
+npm run test
+npm run verify
+```
+
+`npm run verify` is the full local validation suite used by CI. For package
+changes, also run:
+
+```sh
+npm run package:tarball
+npm run package:tarball:smoke
+```
+
+The tarball smoke test verifies an external consumer; a monorepo build alone is
+not enough to prove package portability.
+
+## Pull Requests
+
+Keep each pull request focused and include:
+
+- a concise explanation of the user or maintainer impact;
+- tests for behavior changes, or an explanation of why tests are unnecessary;
+- documentation updates for public API or workflow changes;
+- screenshots or a short recording for visual demo/docs changes;
+- performance evidence when changing a renderer hot path.
+
+Run the relevant checks before requesting review. Maintainers may ask to split
+unrelated refactors from behavioral changes so they can be reviewed safely.
+
+## Documentation And Examples
+
+Public API changes must update the corresponding facade under
+`docs/public/api/` and the relevant guide or recipe. Keep copyable examples
+browser-safe and avoid requiring a Roboflow API key unless the guide explicitly
+describes that integration.
+
+## Reporting Security Issues
+
+Do not open a public issue for a suspected vulnerability. See
+[SECURITY.md](SECURITY.md) for the private reporting path.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Roboflow
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,22 @@
 # supervision-js
 
-Browser-native computer vision media rendering and annotation engine.
+Browser-native tools for building interactive computer vision applications.
 
-`supervision-js` is an early TypeScript-first prototype for rendering computer
-vision detections over browser media with high-performance, renderer-owned
-composition. It is intended to become the JavaScript ecosystem counterpart to
-Roboflow's Python `supervision` ecosystem.
+`supervision-js` is the TypeScript-first, browser-focused subset of
+[Roboflow Supervision](https://github.com/roboflow/supervision). It provides
+renderer-owned media sessions, detection rendering, styling, interaction, and
+editing for images, video, and browser media streams.
 
-This repository is prototype-stage. The public API is being shaped around the
-rendering foundation first, not a large final annotation hierarchy.
+It does not aim for one-to-one API parity with Python Supervision. Python
+Supervision remains the broad toolkit for computer vision workflows; this
+package focuses on the browser runtime needed to build rich CV media UIs.
 
-## Why This Exists
+## What You Can Build
 
-Computer vision media UIs need more than a DOM `<video>` with a separate canvas
-overlay. Dense boxes, masks, labels, tracks, and future temporal/3D overlays
-need one timing and rendering system.
-
-The core approach:
-
-- media and annotations are composed in one renderer-owned scene;
-- Mediabunny prepares and normalizes browser media;
-- PixiJS v8 is the first 2D rendering backend;
-- detections stay semantic and compact in cold storage;
-- hot windows and prepared render artifacts keep playback responsive;
-- styles define presentation without mutating detections.
+- media viewers where playback and annotations share one timing source;
+- interactive boxes, masks, polygons, polylines, keypoints, and labels;
+- model demos, review tooling, and browser-native CV applications;
+- streaming or static detection overlays with app-owned data and persistence.
 
 ## Quick Start
 
@@ -40,36 +33,56 @@ const session = await createMediaSession({
 await session.play();
 ```
 
-Add detections when you have them:
+Add detections as semantic data, then change their presentation independently:
 
 ```ts
 const session = await createMediaSession({
   container,
   media,
-  detections: {
-    appendable: {
-      datasetId: "upload-1",
-    },
-  },
+  detections: { appendable: { datasetId: "upload-1" } },
   normalize: { stream: true },
 });
 
 await session.appendDetectionFrames(frames);
+
+session.setPresentation({ boxStyle, maskStyle, labelStyle });
 ```
 
-Change rendering without rewriting detection data:
+## Installation
+
+The first npm version has not been published yet. Until it is, build a portable
+release archive from a checkout and install it in a browser application:
+
+```sh
+# In this repository
+npm install
+npm run package:tarball
+
+# In the consuming application
+npm install ./vendor/supervision-js-0.0.0.tgz
+```
+
+The archive includes the internal core dependency. Consumers import only the
+public browser entrypoints:
 
 ```ts
-session.setPresentation({
-  boxStyle,
-  maskStyle,
-  labelStyle,
-});
+import { createMediaSession } from "supervision-js";
+import { createMaskBrushEditor } from "supervision-js/editing";
 ```
 
-## Docs And Demo
+## Documentation And Demo
 
-Run from the repository root:
+The public demo and generated API reference are hosted on Render:
+
+- [Demo](https://supervision-js-demo.onrender.com/)
+- [Documentation](https://supervision-js-demo.onrender.com/docs/)
+- [Vanilla example](https://supervision-js-demo.onrender.com/examples/vanilla/)
+
+Hosted surfaces deliberately use public fixtures only. Media upload and SAM3
+inference flows remain local development features because they require the Vite
+proxy and app-owned credentials.
+
+Run everything locally from the repository root:
 
 ```sh
 npm install
@@ -78,97 +91,36 @@ npm run dev
 
 Useful commands:
 
-- `npm run demo:dev` runs the Vite demo.
-- `npm run example:vanilla:dev` runs the minimal vanilla example.
-- `npm run example:react-native:dev` runs the experimental Expo mobile proof.
+- `npm run demo:dev` runs the browser demo.
+- `npm run example:vanilla:dev` runs the minimal vanilla integration.
 - `npm run docs:dev` builds and serves the generated docs.
-- `npm run docs:build` builds the TypeDoc site.
-- `npm run pages:build` assembles the static GitHub Pages artifact.
-- `npm run verify` runs the full local verification suite.
+- `npm run pages:build` assembles the deployable site.
+- `npm run verify` runs the full repository validation suite.
 
-The public POC is deployed on
-[Render](https://supervision-js-demo.onrender.com/):
+Start with [Application Integration](docs/public/guides/application-integration.md),
+[Media Sessions](docs/public/guides/media-sessions.md), and the
+[Public API guide](docs/public/guides/public-api.md).
 
-- the fixture demo is served at the project root;
-- generated docs are served at
-  [`/docs/`](https://supervision-js-demo.onrender.com/docs/);
-- the vanilla example is served at
-  [`/examples/vanilla/`](https://supervision-js-demo.onrender.com/examples/vanilla/).
+## Current API Status
 
-The same static artifact is deployed to the repository-authenticated
-[GitHub Pages mirror](https://roboflow.github.io/supervision-js/). Both hosted
-demos intentionally offer fixture selection only. Upload media and SAM3
-inference remain available locally through the Vite proxy:
+**Supported browser APIs** include `createMediaSession`, media preparation and
+playback controls, detections, boxes, masks, polygons, polylines, keypoints,
+labels, presentation styles, picking, and the advanced editing subpath.
 
-```sh
-npm run demo:dev
-```
+**Advanced browser APIs** expose lower-level renderer construction, detection
+sources, streaming ingestion, normalization, interaction, and diagnostics for
+serious integrations.
 
-Start with:
+**Experimental APIs** include React Native support. It is not part of the
+browser package promise and may change independently.
 
-- [Application Integration](docs/public/guides/application-integration.md)
-- [Media Sessions](docs/public/guides/media-sessions.md)
-- [Public API](docs/public/guides/public-api.md)
-- [Media Preparation](docs/public/guides/media-preparation.md)
-- [Detections And Rendering](docs/public/guides/detections-and-rendering.md)
-- [Presentation Styles](docs/public/guides/presentation-styles.md)
+## Contributing
 
-Recipes:
-
-- [React Integration](docs/public/recipes/react-integration.md)
-- [Static Detections](docs/public/recipes/static-detections.md)
-- [Streaming Detections](docs/public/recipes/streaming-detections.md)
-- [Progressive Upload Normalization](docs/public/recipes/progressive-upload-normalization.md)
-- [Session Lifecycle](docs/public/recipes/session-lifecycle.md)
-
-The minimal vanilla example is served locally and on both hosted artifacts at
-`/examples/vanilla/`.
-
-## Installable Tarball
-
-The repository is private, so consumers install a packed archive instead of a
-published package:
-
-```sh
-npm run package:tarball
-```
-
-That builds the core and browser packages and writes one
-`artifacts/supervision-js-<version>.tgz`. A website installs it by path:
-
-```sh
-npm install ./supervision-js-0.0.0.tgz
-```
-
-Both `supervision-js` and `supervision-js/editing` then resolve normally, and
-the private core package travels inside the archive. See
-[Tarball Packaging](docs/internal/tarball-packaging.md) for the mechanism and
-for `npm run package:tarball:smoke`, which verifies the artifact from a clean
-temporary consumer. For consumer-side instructions and integration rules, use
-[Application Integration](docs/public/guides/application-integration.md).
-
-## Current Status
-
-Implemented foundation:
-
-- session-first API with media preparation, playback, detections, state, and
-  presentation updates;
-- progressive browser media normalization;
-- cold detection storage, hot buffering, and appendable detection ingestion;
-- worker-backed prepared mask artifacts with PNG ID-mask rendering;
-- box, mask, and label styles;
-- interaction and picking;
-- focus highlights and runtime render-quality controls;
-- decision-oriented mask rendering benchmarks;
-- generated API docs.
-
-Still intentionally evolving:
-
-- package publishing and ownership;
-- React wrapper packages;
-- additional annotation shapes beyond boxes, masks, and labels;
-- long-term 3D renderer direction.
+We welcome issues, documentation improvements, examples, and code
+contributions. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull
+request, and follow the [Code of Conduct](CODE_OF_CONDUCT.md) in all project
+spaces.
 
 ## License
 
-Apache-2.0
+MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,9 @@ Please do not report suspected vulnerabilities through public GitHub issues.
 
 Use [GitHub's private vulnerability reporting](https://github.com/roboflow/supervision-js/security/advisories/new)
 with a description, affected versions, reproduction steps, and any proof of
-concept. Maintainers must enable private vulnerability reporting before the
-repository is made public.
+concept. GitHub makes this reporting channel available for public repositories;
+maintainers must enable it immediately after changing repository visibility and
+before announcing a release or accepting external reports.
 
 We will acknowledge the report, investigate it, and coordinate disclosure with
 you before publishing a fix.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting A Vulnerability
+
+Please do not report suspected vulnerabilities through public GitHub issues.
+
+Use [GitHub's private vulnerability reporting](https://github.com/roboflow/supervision-js/security/advisories/new)
+with a description, affected versions, reproduction steps, and any proof of
+concept. Maintainers must enable private vulnerability reporting before the
+repository is made public.
+
+We will acknowledge the report, investigate it, and coordinate disclosure with
+you before publishing a fix.

--- a/docs/internal/agent-guidance.md
+++ b/docs/internal/agent-guidance.md
@@ -18,8 +18,8 @@ Before making project-direction or architecture changes, read:
 - [`tarball-packaging.md`](tarball-packaging.md)
 - [`../public/guides/public-api.md`](../public/guides/public-api.md)
 
-Those docs define the current product intent: prove the browser rendering
-foundation before designing a broad annotation framework.
+Those docs define the current product intent: maintain a focused, session-first
+browser API without promising a broad Python-parity annotation framework.
 
 ## Project Direction
 
@@ -28,8 +28,8 @@ foundation before designing a broad annotation framework.
   future wrapper packages.
 - Keep media and overlays visually composed inside the renderer-owned scene.
 - Treat PixiJS as the first 2D backend implementation, not as the public architecture.
-- Avoid final public APIs, primitive hierarchies, or annotation schemas until
-  renderer milestones create real constraints.
+- Keep the documented public API deliberate. Add primitives or schemas only when
+  renderer constraints and real consumer use cases justify them.
 
 ## Repo Shape
 
@@ -107,7 +107,7 @@ Run from the repository root:
 - `npm run package:tarball:smoke`
 
 `package:tarball` builds the core and browser packages and writes one portable
-`artifacts/supervision-js-<version>.tgz` with the private core bundled inside.
+`artifacts/supervision-js-<version>.tgz` with the internal core bundled inside.
 `package:tarball:smoke` installs that archive in a temporary consumer outside
 the repository; it needs the registry and is not part of `npm run verify`. See
 [`tarball-packaging.md`](tarball-packaging.md).

--- a/docs/internal/problem-framing.md
+++ b/docs/internal/problem-framing.md
@@ -1,10 +1,9 @@
 # Problem Framing
 
-`supervision-js` is intended to become the browser and TypeScript-first
-counterpart to Roboflow's Python `supervision` ecosystem. The immediate goal is
-not to recreate the full Python library in JavaScript. The immediate goal is to
-prove that a browser-native rendering foundation can handle serious computer
-vision media workloads.
+`supervision-js` is the browser and TypeScript-first subset of Roboflow's
+Python `supervision` ecosystem. It does not recreate the full Python library in
+JavaScript. Its job is to provide the browser-native rendering foundation needed
+for serious computer vision media workloads.
 
 ## The Real Problem
 
@@ -36,9 +35,9 @@ The first credible uses should be small but real:
 - future open-source workflows where users need a reliable, framework-agnostic
   rendering library.
 
-The project should feel production-minded from the beginning, even while it is a
-private stealth prototype. That means careful boundaries, measured performance,
-and plain JavaScript usability alongside TypeScript-first authoring.
+The project should feel production-minded from the beginning: careful
+boundaries, measured performance, and plain JavaScript usability alongside
+TypeScript-first authoring.
 
 ## Non-Goals For The First Phase
 
@@ -51,9 +50,9 @@ The first phase should not design the whole product surface. In particular:
 - do not route the rendering hot path through React state;
 - do not visually compose media as a DOM element underneath a separate
   annotation renderer;
-- do not settle final npm package naming or ownership;
-- do not assume the repo will remain under a personal account or move to
-  Roboflow until the prototype earns that decision.
+- do not promise full Python Supervision API parity;
+- do not make experimental React Native work part of the browser package
+  compatibility promise.
 
 The safe first bet is to prove the rendering engine, then let the annotation
 model emerge from measured needs.

--- a/docs/internal/render-deployment.md
+++ b/docs/internal/render-deployment.md
@@ -8,15 +8,12 @@ The public demo and documentation are served by the existing Render web service:
 - docs: <https://supervision-js-demo.onrender.com/docs/>
 
 The canonical source remains
-`https://github.com/roboflow/supervision-js`. Render deploys the same `main`
-commit from the private, deployment-only mirror at
+`https://github.com/roboflow/supervision-js`. Render currently deploys the same
+`main` commit from the deployment mirror at
 `https://github.com/joaomarcoscrs/supervision-js-render`.
 
-Render's GitHub App is installed for the Roboflow organization but does not
-have access to the private canonical repository. Only a Roboflow organization
-owner can add that repository to the installation. Do not develop in or merge
-changes into the mirror. Push the canonical `main` commit to it only after the
-canonical push succeeds:
+Do not develop in or merge changes into the mirror. Push the canonical `main`
+commit to it only after the canonical push succeeds:
 
 ```sh
 git fetch origin main
@@ -24,8 +21,7 @@ test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
 git push git@github.com:joaomarcoscrs/supervision-js-render.git main:main
 ```
 
-This preserves a single source of truth while allowing Render to clone the
-private code. If the Render GitHub App later receives access to
+This preserves a single source of truth. When Infra gives Render access to
 `roboflow/supervision-js`, point the service back to the canonical repository
 and retire the mirror.
 

--- a/docs/internal/tarball-packaging.md
+++ b/docs/internal/tarball-packaging.md
@@ -1,8 +1,7 @@
 # Tarball Packaging
 
-This repository is private, so websites cannot install `supervision-js` from a
-registry or from a Git URL. The supported distribution for now is one portable
-npm tarball.
+The first npm release has not been published yet. The supported distribution
+until then is one portable npm tarball built from this repository.
 
 ## Build The Tarball
 

--- a/docs/public/guides/application-integration.md
+++ b/docs/public/guides/application-integration.md
@@ -9,10 +9,11 @@ summary: The installation, runtime, data, and lifecycle contract for integrating
 Use this page as the integration contract for humans and coding agents adding
 `supervision-js` to another web application.
 
-## Current Distribution
+## Installation Before The First npm Release
 
-`supervision-js` is a private preview package. It is not published to the npm
-registry, and there is no CDN, UMD, or `<script>` build.
+`supervision-js` is not published to the npm registry yet, and there is no CDN,
+UMD, or `<script>` build. Build a portable archive from this public repository
+until the first npm release is available.
 
 Build the portable archive from the `supervision-js` repository:
 
@@ -47,7 +48,7 @@ must be able to read it. Commit the archive when the consuming repository allows
 vendored dependencies; otherwise store it in the team's artifact system and
 make retrieval part of the build.
 
-The archive contains the private `supervision-js-core` package. Consumers must
+The archive contains the internal `supervision-js-core` package. Consumers must
 not install `supervision-js-core` separately.
 
 ## Supported Consumer
@@ -63,7 +64,7 @@ The renderer requires browser APIs. In an SSR application, create sessions only
 on the client after the container element exists. The package can be imported by
 build tooling, but `createMediaSession()` must not run during server rendering.
 
-Do not import Pixi, Mediabunny, worker files, or private core modules. Import the
+Do not import Pixi, Mediabunny, worker files, or internal core modules. Import the
 supported entrypoints:
 
 ```ts

--- a/docs/public/guides/public-api.md
+++ b/docs/public/guides/public-api.md
@@ -1,7 +1,7 @@
 ---
 title: Public API
 group: Guides
-summary: What the package surface is intended to promise at this prototype stage.
+summary: The supported browser package surface and its advanced boundaries.
 ---
 
 # Public API
@@ -20,9 +20,9 @@ import from `supervision-js`:
 import { createMediaSession } from "supervision-js";
 ```
 
-The current private preview is installed from the portable
-`supervision-js-0.0.0.tgz` archive. It is not available from the npm registry.
-See [Application Integration](application-integration.md) for the supported
+The first npm release is still being prepared. Until then, install the portable
+`supervision-js-0.0.0.tgz` archive built from this repository. See
+[Application Integration](application-integration.md) for the supported
 consumer workflow.
 
 The split keeps detections, timelines, styles, retention policies, source
@@ -167,7 +167,7 @@ renderer is introduced.
 
 ## Compatibility Posture
 
-This is still a prototype. The strongest compatibility promise is around the
+The package is pre-1.0. The strongest compatibility promise is around the
 session-first model:
 
 1. one media item maps to one session;

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -1,41 +1,41 @@
 # supervision-js
 
-`supervision-js` is a browser-native computer vision media rendering library.
-It owns media playback and annotation rendering in one Pixi-powered scene so
-detections are selected from the same timing reference as the displayed frame.
+`supervision-js` is a browser-native TypeScript library for interactive
+computer vision media applications. It is the browser-focused subset of
+[Roboflow Supervision](https://github.com/roboflow/supervision): focused on
+media sessions, detection rendering, styles, interaction, and editing rather
+than Python API parity.
 
-The main API is `createMediaSession()`. Start there.
+The main API is `createMediaSession()`. It renders media and annotations in one
+renderer-owned scene, so the visible media frame and its detections share the
+same timing reference.
 
-The current `supervision-js` package is the browser package. Internally, it is
-built on a platform-neutral core package so detections, timelines, styles, and
-picking contracts can eventually support other renderers without changing the
-browser quickstart.
+## Installation
 
-## Install The Private Preview
-
-The package is currently distributed as a portable tarball, not through the npm
-registry. Build it in the library repository, copy it into a stable path in the
-consumer, and install that path:
+The first npm release is still being prepared. Build the portable archive from
+this repository and install it in a browser application:
 
 ```sh
-# In the supervision-js repository:
+# In this repository
+npm install
 npm run package:tarball
 
-# In the consuming application:
+# In the consuming application
 npm install ./vendor/supervision-js-0.0.0.tgz
 ```
 
-The archive already bundles the private core package. Do not install
-`supervision-js-core` or the old `supervision-web` name.
+The archive includes the internal core dependency. Consumers should import the
+public browser package only:
 
-Read [Application Integration](guides/application-integration.md) before
-changing another app. It is the complete installation, runtime, data, lifecycle,
-and verification contract for humans and coding agents.
+```ts
+import { createMediaSession } from "supervision-js";
+import { createMaskBrushEditor } from "supervision-js/editing";
+```
 
-## Quickstart
+Read [Application Integration](guides/application-integration.md) for the
+complete browser, lifecycle, and verification contract.
 
-Render media inside a container with the default renderer, media preparation,
-playback state, and render-preparation behavior:
+## Quick Start
 
 ```ts
 import { createMediaSession } from "supervision-js";
@@ -49,10 +49,7 @@ if (!container) {
 const session = await createMediaSession({
   container,
   media: fileOrUrl,
-  renderer: {
-    autoPlay: true,
-    loop: true,
-  },
+  renderer: { autoPlay: true, loop: true },
 });
 
 session.subscribe((state) => {
@@ -60,100 +57,25 @@ session.subscribe((state) => {
 });
 ```
 
-That is enough to get a renderer-owned media scene. The session chooses the
-default browser media path, Pixi renderer, playback loop, and render-preparation
-settings. The container must have a non-zero width and height.
+## Capabilities
 
-## Add Detections Later
+The supported browser surface covers images, video, and browser media streams;
+static and streaming detections; boxes, masks, polygons, polylines, keypoints,
+and labels; presentation styles; picking; and advanced annotation editing.
 
-For model outputs that arrive after the media session starts, create an
-appendable detection source. The session stores detections in a cold source,
-hydrates a hot window near playback, prepares renderer-friendly artifacts, and
-presents only the active frame.
+React Native is experimental and separately versioned. It is not a dependency
+of the browser package or a compatibility promise.
 
-```ts
-const session = await createMediaSession({
-  container,
-  media: file,
-  detections: {
-    appendable: {
-      datasetId: "upload-session-1",
-    },
-  },
-  renderer: {
-    autoPlay: true,
-  },
-});
+## Learn More
 
-await session.appendDetectionFrames([
-  {
-    frameIndex: 0,
-    mediaTime: 0,
-    detections: [
-      {
-        id: "person-1",
-        className: "person",
-        confidence: 0.92,
-        rect: { x: 240, y: 290, width: 240, height: 420 },
-      },
-    ],
-  },
-]);
-```
-
-`rect.x` and `rect.y` are the box center in media pixels (not its top-left
-corner).
-
-## What The Session Owns
-
-- media preparation and optional normalization;
-- Pixi scene lifecycle;
-- playback, seek, pause, and loop behavior;
-- cold detection storage;
-- hot detection buffering around the current time;
-- prepared render artifacts such as PNG ID-mask frames;
-- presentation style updates;
-- interaction and picking;
-- loading, processing, buffering, and error state.
-
-## What The Host App Owns
-
-- user interface;
-- file upload;
-- model and API calls;
-- authentication and API keys;
-- business workflows;
-- deciding when detections should be appended.
-
-## Why Renderer-Owned Composition Matters
-
-The media frame and detections are not split between a DOM `<video>` and a
-separate overlay canvas. `supervision-js` presents media and annotations in the
-same renderer-owned visual system. That keeps playback and detections tied to
-one timing source and avoids drift caused by separate composition layers.
-
-## Where To Go Next
-
-- Start with [Application Integration](guides/application-integration.md) when
-  adding the package to another app.
-- Read [Media Sessions](guides/media-sessions.md) for the working session model.
-- Read [Public API](guides/public-api.md) for the intended package boundary
-  between primary APIs, advanced APIs, and internals.
-- Read [Media Preparation](guides/media-preparation.md) for probe,
-  normalization, and progressive upload handling.
-- Read [Detections And Rendering](guides/detections-and-rendering.md) for the
-  cold, hot, prepared, and active render pipeline.
-- Read [Presentation Styles](guides/presentation-styles.md) for the
-  `supervision-js` equivalent of Python supervision annotators.
-- Use the recipes for common integrations:
-  [React Integration](recipes/react-integration.md),
-  [Static Detections](recipes/static-detections.md),
-  [Streaming Detections](recipes/streaming-detections.md),
-  [Multiple Detection Sources](recipes/multiple-detection-sources.md),
-  [Interactive Picking](recipes/interactive-picking.md), and
-  [Progressive Upload Normalization](recipes/progressive-upload-normalization.md).
-- Read [Session Lifecycle](recipes/session-lifecycle.md) for replacing media,
-  cleaning up viewers, and recovering after session errors.
-- Browse the generated API reference by domain. The Modules page groups exports
-  into Media Sessions, Detections, Rendering, Styles, Interactions, Media
-  Preparation, and Editing.
+- [Application Integration](guides/application-integration.md)
+- [Media Sessions](guides/media-sessions.md)
+- [Public API](guides/public-api.md)
+- [Media Preparation](guides/media-preparation.md)
+- [Detections And Rendering](guides/detections-and-rendering.md)
+- [Presentation Styles](guides/presentation-styles.md)
+- [React Integration](recipes/react-integration.md)
+- [Static Detections](recipes/static-detections.md)
+- [Streaming Detections](recipes/streaming-detections.md)
+- [Interactive Picking](recipes/interactive-picking.md)
+- [Session Lifecycle](recipes/session-lifecycle.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "supervision-js-workspace",
       "version": "0.0.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "workspaces": [
         "packages/core",
         "packages/react-native",
@@ -10332,12 +10332,12 @@
     "packages/core": {
       "name": "supervision-js-core",
       "version": "0.0.0",
-      "license": "Apache-2.0"
+      "license": "MIT"
     },
     "packages/react-native": {
       "name": "supervision-js-react-native",
       "version": "0.0.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "supervision-js-core": "file:../core"
       },
@@ -10407,7 +10407,7 @@
     "packages/web": {
       "name": "supervision-js",
       "version": "0.0.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.43.1",
         "pixi.js": "^8.18.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "examples/vanilla"
   ],
   "type": "module",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "engines": {
     "node": ">=20.19"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "Platform-neutral detection, timeline, style, and interaction primitives for supervision-js.",
   "private": true,
   "type": "module",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -4,7 +4,7 @@
   "description": "Experimental React Native rendering adapter for supervision-js core primitives.",
   "private": true,
   "type": "module",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,7 @@
     "typescript"
   ],
   "type": "module",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
# Description

Prepares `supervision-js` for public release without changing the renderer or package runtime.

- Reframes the project as the browser-focused, TypeScript-first subset of Roboflow Supervision and documents the supported, advanced, and experimental API boundaries.
- Changes repository and workspace metadata from Apache-2.0 to MIT, matching Roboflow Supervision.
- Adds contribution, conduct, security, citation, pull-request, and issue-reporting guidance adapted to this JavaScript repository.
- Keeps the portable tarball as the documented installation path until the first npm release, and records the existing Render deployment path.

## Type of change

- [x] Maintenance (non-breaking change which fixes repository and release readiness)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `npm run verify` (463 Vitest tests; package boundaries, docs contract tests, builds, package smoke, demo, examples, and benchmark builds)
- `npm run pages:build` (demo, TypeDoc docs, and vanilla Pages artifact)

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

- Render remains the current public demo and docs host.
- Before making the repository public, enable GitHub private vulnerability reporting as required by `SECURITY.md`.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
