### PR TITLE
Add Dataset Management code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Dataset Management owns all changes in supervision-js.
+* @roboflow/dataset-management


### PR DESCRIPTION
# Description

Adds the Dataset Management team as the global code owner for supervision-js. This prepares the repository to require a team approval for every pull request once the main ruleset is enabled.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Confirmed the CODEOWNERS syntax and the @roboflow/dataset-management team reference
- Verified the staged diff with git diff --check

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- None

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)