### PR TITLE
Prepare supervision-js for npm releases

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,64 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: npm dist-tag for this release
+        required: true
+        default: next
+        type: choice
+        options:
+          - next
+          - latest
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    name: Verify and publish supervision-js
+    runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Verify repository
+        run: npm run verify
+
+      - name: Build portable tarball
+        run: npm run package:tarball
+
+      - name: Smoke-test clean consumer
+        run: npm run package:tarball:smoke
+
+      - name: Publish generated tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          archives=(artifacts/supervision-js-*.tgz)
+          if [ "${#archives[@]}" -ne 1 ]; then
+            echo "Expected exactly one generated supervision-js tarball." >&2
+            exit 1
+          fi
+          npm publish "./${archives[0]}" --access public --tag "${{ inputs.dist_tag }}"

--- a/README.md
+++ b/README.md
@@ -50,13 +50,19 @@ session.setPresentation({ boxStyle, maskStyle, labelStyle });
 
 ## Installation
 
-Install the browser package from npm:
+The first npm version has not been published yet. Until it is, build a portable
+release archive from a checkout and install it in a browser application:
 
 ```sh
-npm install supervision-js
+# In this repository
+npm install
+npm run package:tarball
+
+# In the consuming application
+npm install ./vendor/supervision-js-0.1.0.tgz
 ```
 
-The package includes the internal core dependency. Consumers import only the
+The archive includes the internal core dependency. Consumers import only the
 public browser entrypoints:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm install
 npm run package:tarball
 
 # In the consuming application
-npm install ./vendor/supervision-js-0.0.0.tgz
+npm install ./vendor/supervision-js-0.1.0.tgz
 ```
 
 The archive includes the internal core dependency. Consumers import only the

--- a/README.md
+++ b/README.md
@@ -50,19 +50,13 @@ session.setPresentation({ boxStyle, maskStyle, labelStyle });
 
 ## Installation
 
-The first npm version has not been published yet. Until it is, build a portable
-release archive from a checkout and install it in a browser application:
+Install the browser package from npm:
 
 ```sh
-# In this repository
-npm install
-npm run package:tarball
-
-# In the consuming application
-npm install ./vendor/supervision-js-0.1.0.tgz
+npm install supervision-js
 ```
 
-The archive includes the internal core dependency. Consumers import only the
+The package includes the internal core dependency. Consumers import only the
 public browser entrypoints:
 
 ```ts

--- a/docs/internal/agent-guidance.md
+++ b/docs/internal/agent-guidance.md
@@ -16,6 +16,8 @@ Before making project-direction or architecture changes, read:
 - [`react-native-architecture.md`](react-native-architecture.md)
 - [`react-native-live-rendering.md`](react-native-live-rendering.md)
 - [`tarball-packaging.md`](tarball-packaging.md)
+- [`npm-release.md`](npm-release.md) when changing package publication or
+  release automation
 - [`../public/guides/public-api.md`](../public/guides/public-api.md)
 
 Those docs define the current product intent: maintain a focused, session-first
@@ -105,12 +107,17 @@ Run from the repository root:
 - `npm run benchmark:masks`
 - `npm run package:tarball`
 - `npm run package:tarball:smoke`
+- `npm run package:publish:dry-run`
 
 `package:tarball` builds the core and browser packages and writes one portable
 `artifacts/supervision-js-<version>.tgz` with the internal core bundled inside.
 `package:tarball:smoke` installs that archive in a temporary consumer outside
 the repository; it needs the registry and is not part of `npm run verify`. See
 [`tarball-packaging.md`](tarball-packaging.md).
+
+The manual npm workflow publishes that generated tarball after environment
+approval; it never publishes `packages/web` directly. See
+[`npm-release.md`](npm-release.md) before running or modifying it.
 
 For focused iterative work, use separate terminals:
 

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -1,0 +1,88 @@
+# npm Release Operations
+
+This repository publishes one public package: `supervision-js`. The root
+workspace, `supervision-js-core`, and `supervision-js-react-native` remain
+private. The npm registry artifact is the portable tarball assembled by
+`tools/pack-web-tarball.mjs`; it embeds the private core package without
+exposing the workspace-relative `file:../core` dependency.
+
+## Release Boundary
+
+Never publish from `packages/web` directly. A release must publish exactly one
+generated file matching:
+
+```text
+artifacts/supervision-js-<version>.tgz
+```
+
+The manual GitHub Actions workflow at
+`.github/workflows/publish-npm.yml` recreates and independently validates that
+artifact before publishing it. It accepts only the `next` and `latest` tags,
+runs only from `main`, and is gated by the `npm-publish` GitHub environment.
+
+`next` is the safe default for the first release. Promote a version to `latest`
+only after the release owner explicitly makes that decision.
+
+## One-Time Bootstrap
+
+The package name is `supervision-js`, not `supervision`. The separately owned
+`supervision` npm package does not block this package's release.
+
+Before the first automated release, an npm administrator must:
+
+1. Confirm that `supervision-js` is available or arrange a transfer if its
+   ownership changes.
+2. Create or use the Roboflow npm owner that will own the first public release,
+   with two-factor authentication enabled.
+3. Publish the reviewed generated tarball once using that administrator's
+   interactive npm authentication. This claims the package; it is the only
+   bootstrap exception to the trusted-publisher flow.
+4. Add at least two active Roboflow maintainers to the npm package.
+5. Open the package's npm **Settings → Trusted publisher** and configure:
+   - provider: **GitHub Actions**;
+   - organization: `roboflow`;
+   - repository: `supervision-js`;
+   - workflow filename: `publish-npm.yml`;
+   - environment name: `npm-publish`;
+   - allowed action: **npm publish**.
+6. In GitHub, create the `npm-publish` environment and require approval from
+   the release owners. Do not store an npm write token in GitHub secrets.
+7. After one successful OIDC publish, set npm **Publishing access** to require
+   two-factor authentication and disallow tokens, then remove any obsolete
+   automation tokens.
+
+The trusted publisher must match the organization, repository, workflow file,
+and environment name exactly. Each npm package supports one trusted publisher.
+
+## Release Procedure
+
+1. Update the public package version in `packages/web/package.json` and refresh
+   `package-lock.json`.
+2. Run the normal validation plus the clean-consumer artifact smoke test:
+
+   ```sh
+   npm run verify
+   npm run package:tarball
+   npm run package:tarball:smoke
+   npm run package:publish:dry-run
+   ```
+
+3. Merge the reviewed release-preparation pull request to `main`.
+4. In GitHub Actions, run **Publish npm package** from `main`. Select `next`
+   unless the release owner has explicitly approved `latest`.
+5. Approve the `npm-publish` environment deployment. The workflow verifies,
+   packs, smoke-tests, and then publishes the generated archive through npm
+   trusted publishing (OIDC). It has no long-lived npm credential.
+6. Verify the published package metadata, provenance, tarball contents, and a
+   clean installation in a separate consumer. Then update public installation
+   docs from the local-tarball instructions to `npm install supervision-js`.
+
+## Recovery
+
+If a publish fails before uploading the package, fix the failure in a pull
+request and rerun the workflow from `main`. npm versions are immutable once
+published: never try to overwrite one. Publish a new patch version instead.
+
+If OIDC authentication fails, compare the npm trusted-publisher configuration
+with the workflow's organization, repository, filename, and environment. Do
+not work around the issue by adding a long-lived npm write token to GitHub.

--- a/docs/internal/tarball-packaging.md
+++ b/docs/internal/tarball-packaging.md
@@ -13,7 +13,7 @@ That command builds `supervision-js-core` and `supervision-js`, then writes a
 single archive to the ignored `artifacts/` directory:
 
 ```
-artifacts/supervision-js-0.0.0.tgz
+artifacts/supervision-js-0.1.0.tgz
 ```
 
 `artifacts/` is cleared of previous `supervision-js-*.tgz` archives on every
@@ -29,7 +29,7 @@ node tools/pack-web-tarball.mjs --skip-build --out-dir=/tmp/supervision-js
 Copy the archive next to the consuming project and install it by path:
 
 ```sh
-npm install ./supervision-js-0.0.0.tgz
+npm install ./supervision-js-0.1.0.tgz
 ```
 
 Both supported entrypoints then resolve normally:
@@ -85,3 +85,14 @@ the OS temp directory — outside this repository — to check that:
 a Vite build, so it is deliberately kept out of `npm run verify`. Run it when
 changing packaging, dependencies, or package entrypoints. Point it at another
 archive with `SUPERVISION_JS_TARBALL=<path>`.
+
+## npm Publishing
+
+The portable archive is the only artifact that may be published. Do not run
+`npm publish` from `packages/web`: its workspace manifest intentionally points
+at the private core package through `file:../core`.
+
+See [npm-release.md](npm-release.md) for the one-time npm ownership bootstrap,
+trusted-publisher configuration, and the protected manual release workflow.
+Use `npm run package:publish:dry-run` to recreate the artifact and validate the
+exact local archive argument that npm will receive, without publishing it.

--- a/docs/public/guides/application-integration.md
+++ b/docs/public/guides/application-integration.md
@@ -25,7 +25,7 @@ npm run package:tarball
 The archive is written to:
 
 ```text
-artifacts/supervision-js-0.0.0.tgz
+artifacts/supervision-js-0.1.0.tgz
 ```
 
 Copy that archive into a stable path in the consuming application, then install
@@ -35,11 +35,11 @@ it from there:
 my-app/
 ├── package.json
 └── vendor/
-    └── supervision-js-0.0.0.tgz
+    └── supervision-js-0.1.0.tgz
 ```
 
 ```sh
-npm install ./vendor/supervision-js-0.0.0.tgz
+npm install ./vendor/supervision-js-0.1.0.tgz
 ```
 
 Keeping the archive at a stable project-relative path is important:

--- a/docs/public/guides/public-api.md
+++ b/docs/public/guides/public-api.md
@@ -21,7 +21,7 @@ import { createMediaSession } from "supervision-js";
 ```
 
 The first npm release is still being prepared. Until then, install the portable
-`supervision-js-0.0.0.tgz` archive built from this repository. See
+`supervision-js-0.1.0.tgz` archive built from this repository. See
 [Application Integration](application-integration.md) for the supported
 consumer workflow.
 

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -21,7 +21,7 @@ npm install
 npm run package:tarball
 
 # In the consuming application
-npm install ./vendor/supervision-js-0.0.0.tgz
+npm install ./vendor/supervision-js-0.1.0.tgz
 ```
 
 The archive includes the internal core dependency. Consumers should import the

--- a/package-lock.json
+++ b/package-lock.json
@@ -10406,7 +10406,7 @@
     },
     "packages/web": {
       "name": "supervision-js",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.43.1",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "package:smoke": "node --test tools/package-smoke.test.mjs",
     "package:tarball": "node tools/pack-web-tarball.mjs",
     "package:tarball:smoke": "node --test tools/tarball-smoke.test.mjs",
+    "package:publish:dry-run": "npm run package:tarball && npm publish ./artifacts/supervision-js-*.tgz --access public --tag next --dry-run",
     "test:watch": "vitest",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,23 @@
+# supervision-js
+
+Browser-native tools for building interactive computer vision applications.
+
+`supervision-js` provides renderer-owned media sessions, detection rendering,
+styling, interaction, and editing for images, video, and browser media streams.
+
+## Installation
+
+```sh
+npm install supervision-js
+```
+
+The package includes its internal core dependency. Consumers import the public
+browser entrypoints:
+
+```ts
+import { createMediaSession } from "supervision-js";
+import { createMaskBrushEditor } from "supervision-js/editing";
+```
+
+See the [project README](https://github.com/roboflow/supervision-js#readme) for
+the public API, demo, and documentation links.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,8 +1,7 @@
 {
   "name": "supervision-js",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Browser-native computer vision media rendering and annotation engine.",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/roboflow/supervision-js.git"
@@ -22,6 +21,9 @@
   ],
   "type": "module",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/tools/pack-web-tarball.mjs
+++ b/tools/pack-web-tarball.mjs
@@ -11,6 +11,7 @@
  */
 import { spawnSync } from "node:child_process";
 import {
+  copyFileSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -170,6 +171,12 @@ function clearPreviousArchives(outDir) {
   }
 }
 
+function copyPackageDocuments(packageDir) {
+  for (const filename of ["LICENSE", "README.md"]) {
+    copyFileSync(path.join(rootDir, filename), path.join(packageDir, filename));
+  }
+}
+
 function main() {
   const options = parseArgs(process.argv.slice(2));
 
@@ -198,6 +205,7 @@ function main() {
       path.join(packageDir, "node_modules", corePackageName),
       1,
     );
+    copyPackageDocuments(packageDir);
 
     const coreManifest = readManifest(
       path.join(packageDir, "node_modules", corePackageName, "package.json"),

--- a/tools/pack-web-tarball.mjs
+++ b/tools/pack-web-tarball.mjs
@@ -171,10 +171,8 @@ function clearPreviousArchives(outDir) {
   }
 }
 
-function copyPackageDocuments(packageDir) {
-  for (const filename of ["LICENSE", "README.md"]) {
-    copyFileSync(path.join(rootDir, filename), path.join(packageDir, filename));
-  }
+function copyPackageLicense(packageDir) {
+  copyFileSync(path.join(rootDir, "LICENSE"), path.join(packageDir, "LICENSE"));
 }
 
 function main() {
@@ -205,7 +203,7 @@ function main() {
       path.join(packageDir, "node_modules", corePackageName),
       1,
     );
-    copyPackageDocuments(packageDir);
+    copyPackageLicense(packageDir);
 
     const coreManifest = readManifest(
       path.join(packageDir, "node_modules", corePackageName, "package.json"),

--- a/tools/package-smoke.test.mjs
+++ b/tools/package-smoke.test.mjs
@@ -163,6 +163,20 @@ const expectedReactNativeRuntimeExports = [
   "resolveReactNativeLiveIdMaskUniforms",
 ];
 
+test("browser package manifest is ready for public npm publishing", () => {
+  const manifest = JSON.parse(
+    readFileSync(
+      new URL("../packages/web/package.json", import.meta.url),
+      "utf8",
+    ),
+  );
+
+  assert.equal(manifest.name, "supervision-js");
+  assert.match(manifest.version, /^(?!0\.0\.0$)\d+\.\d+\.\d+(?:-.+)?$/);
+  assert.notEqual(manifest.private, true);
+  assert.equal(manifest.publishConfig?.access, "public");
+});
+
 test("built core package imports without browser APIs", async () => {
   const entrypoint = await import("../packages/core/dist/index.js");
 

--- a/tools/tarball-smoke.test.mjs
+++ b/tools/tarball-smoke.test.mjs
@@ -138,6 +138,17 @@ test("tarball ships both entrypoints with declarations and source maps", () => {
   assert.equal(manifest.exports["./editing"].import, "./dist/editing.js");
 });
 
+test("tarball ships the project license and package README", () => {
+  const license = readFileSync(path.join(extractedDir, "LICENSE"), "utf8");
+
+  assert.match(license, /MIT License/);
+  assert.equal(license, readFileSync(path.join(rootDir, "LICENSE"), "utf8"));
+  assert.ok(
+    existsSync(path.join(extractedDir, "README.md")),
+    "Expected README.md in the tarball",
+  );
+});
+
 test("tarball ships the render-preparation worker and the chunks it imports", () => {
   const workerPath = path.join(extractedDir, "dist/mask-preparation.worker.js");
 

--- a/tools/tarball-smoke.test.mjs
+++ b/tools/tarball-smoke.test.mjs
@@ -140,13 +140,16 @@ test("tarball ships both entrypoints with declarations and source maps", () => {
 
 test("tarball ships the project license and package README", () => {
   const license = readFileSync(path.join(extractedDir, "LICENSE"), "utf8");
+  const readme = readFileSync(path.join(extractedDir, "README.md"), "utf8");
 
   assert.match(license, /MIT License/);
   assert.equal(license, readFileSync(path.join(rootDir, "LICENSE"), "utf8"));
-  assert.ok(
-    existsSync(path.join(extractedDir, "README.md")),
-    "Expected README.md in the tarball",
+  assert.match(
+    readme,
+    /npm install supervision-js/,
+    "Expected the tarball README to document npm installation",
   );
+  assert.doesNotMatch(readme, /has not been published yet/);
 });
 
 test("tarball ships the render-preparation worker and the chunks it imports", () => {


### PR DESCRIPTION
# Description

Prepares the browser package for its first public npm release without publishing it. The package is versioned as `0.1.0`, opt-in public publishing is configured, and a manual OIDC workflow rebuilds and smoke-tests the portable tarball before it can publish.

The release workflow runs only from `main`, defaults to the `next` dist-tag, and is gated by the `npm-publish` environment. Internal documentation records the one-time npm ownership bootstrap and trusted-publisher setup; public installation docs remain tarball-based until the package is actually released.

## Type of change

- [x] Maintenance (non-breaking change which fixes release and package readiness)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `npm run verify`
- `npm run package:tarball:smoke` (clean external consumer)
- `npm run package:publish:dry-run` (validates the exact generated archive argument without publishing)
- `npm run docs:check`

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- No package is published by this PR.
- Before the first workflow release, configure the npm package trusted publisher for `roboflow/supervision-js`, create the protected `npm-publish` environment, and complete the documented one-time ownership bootstrap.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
