### PR TITLE
Align demo with canonical annotation presentation

### DIFF
--- a/demo/src/components/RenderControls.tsx
+++ b/demo/src/components/RenderControls.tsx
@@ -128,6 +128,12 @@ function GlobalRenderControls({
             onChange={(checked) => onChange("polygonsEnabled", checked)}
           />
           <ToggleControl
+            checked={settings.polylinesEnabled}
+            disabled={availability?.polylinesEnabled === false}
+            label="Polylines"
+            onChange={(checked) => onChange("polylinesEnabled", checked)}
+          />
+          <ToggleControl
             checked={settings.keypointsEnabled}
             disabled={availability?.keypointsEnabled === false}
             label="Keypoints"
@@ -206,6 +212,16 @@ function GlobalRenderControls({
         />
         <SliderControl
           disabled={!settings.masksEnabled}
+          label="Fill"
+          max={1}
+          min={0}
+          onChange={(value) => onChange("maskFillAlpha", value)}
+          step={0.01}
+          value={settings.maskFillAlpha}
+          valueLabel={formatPercent(settings.maskFillAlpha)}
+        />
+        <SliderControl
+          disabled={!settings.masksEnabled}
           label="Opacity"
           max={1}
           min={0}
@@ -259,14 +275,27 @@ function GlobalRenderControls({
         />
       </ControlSection>
 
+      <ControlSection title="Polylines">
+        <SliderControl
+          disabled={!settings.polylinesEnabled}
+          label="Stroke"
+          max={8}
+          min={1}
+          onChange={(value) => onChange("polylineStrokeWidth", value)}
+          step={1}
+          value={settings.polylineStrokeWidth}
+          valueLabel={`${settings.polylineStrokeWidth}px`}
+        />
+      </ControlSection>
+
       <ControlSection title="Keypoints">
         <SliderControl
           disabled={!settings.keypointsEnabled}
           label="Radius"
           max={12}
-          min={2}
+          min={1}
           onChange={(value) => onChange("keypointRadius", value)}
-          step={1}
+          step={0.5}
           value={settings.keypointRadius}
           valueLabel={`${settings.keypointRadius}px`}
         />
@@ -276,13 +305,19 @@ function GlobalRenderControls({
           max={8}
           min={1}
           onChange={(value) => onChange("keypointEdgeWidth", value)}
-          step={1}
+          step={0.5}
           value={settings.keypointEdgeWidth}
           valueLabel={`${settings.keypointEdgeWidth}px`}
         />
       </ControlSection>
 
       <ControlSection title="Labels">
+        <ToggleControl
+          checked={settings.labelIncludeConfidence}
+          disabled={!settings.labelsEnabled}
+          label="Confidence"
+          onChange={(checked) => onChange("labelIncludeConfidence", checked)}
+        />
         <SegmentedControl
           disabled={!settings.labelsEnabled}
           label="Placement"
@@ -393,9 +428,9 @@ function GlobalRenderControls({
         <SliderControl
           label="Hover Stroke"
           max={12}
-          min={1}
+          min={0.5}
           onChange={(value) => onChange("interactionHoverStrokeWidth", value)}
-          step={1}
+          step={0.5}
           value={settings.interactionHoverStrokeWidth}
           valueLabel={`${settings.interactionHoverStrokeWidth}px`}
         />
@@ -411,11 +446,11 @@ function GlobalRenderControls({
         <SliderControl
           label="Selected Stroke"
           max={16}
-          min={1}
+          min={0.5}
           onChange={(value) =>
             onChange("interactionSelectedStrokeWidth", value)
           }
-          step={1}
+          step={0.5}
           value={settings.interactionSelectedStrokeWidth}
           valueLabel={`${settings.interactionSelectedStrokeWidth}px`}
         />
@@ -427,6 +462,7 @@ function GlobalRenderControls({
           label="Target"
           onChange={(value) => onChange("focusTargetMode", value)}
           options={[
+            { label: "Ambient", value: FocusTargetMode.Ambient },
             { label: "Selected", value: FocusTargetMode.Selected },
             { label: "Hover", value: FocusTargetMode.Hovered },
             { label: "Both", value: FocusTargetMode.HoveredAndSelected },

--- a/demo/src/presentation/demo-presentation.test.ts
+++ b/demo/src/presentation/demo-presentation.test.ts
@@ -551,6 +551,53 @@ describe("demo presentation", () => {
     });
   });
 
+  it("keeps ambient focus targets aligned with the confidence filter", () => {
+    const visibleDetection = {
+      className: "horse",
+      confidence: 0.9,
+      rect: { height: 20, width: 20, x: 20, y: 20 },
+    };
+    const filteredDetection = {
+      className: "horse",
+      confidence: 0.4,
+      rect: { height: 20, width: 20, x: 50, y: 50 },
+    };
+    const frame = {
+      detections: [visibleDetection, filteredDetection],
+      mediaTime: 0,
+    };
+    const presentation = createDemoPresentation({
+      ...defaultDemoPresentationSettings,
+      confidenceThreshold: 0.5,
+    });
+
+    expect(
+      presentation.focusStyle?.resolve({
+        frame,
+        hoveredPick: null,
+        mediaTime: 0,
+        selectedPick: null,
+      }),
+    ).toMatchObject({
+      ambient: true,
+      targets: [expect.objectContaining({ detection: visibleDetection })],
+    });
+
+    const hiddenPresentation = createDemoPresentation({
+      ...defaultDemoPresentationSettings,
+      confidenceThreshold: 1,
+    });
+
+    expect(
+      hiddenPresentation.focusStyle?.resolve({
+        frame,
+        hoveredPick: null,
+        mediaTime: 0,
+        selectedPick: null,
+      }),
+    ).toBeUndefined();
+  });
+
   it("maps demo focus controls to target mode, tone, and fallback geometry", () => {
     const presentation = createDemoPresentation({
       ...defaultDemoPresentationSettings,

--- a/demo/src/presentation/demo-presentation.test.ts
+++ b/demo/src/presentation/demo-presentation.test.ts
@@ -583,6 +583,25 @@ describe("demo presentation", () => {
       targets: [expect.objectContaining({ detection: visibleDetection })],
     });
 
+    expect(
+      presentation.focusStyle?.resolve({
+        frame,
+        hoveredPick: null,
+        mediaTime: 0,
+        selectedPick: {
+          detection: filteredDetection,
+          detectionIndex: 1,
+          frame,
+          mediaTime: 0,
+          point: { x: 50, y: 50 },
+          target: DetectionPickTarget.Box,
+        },
+      }),
+    ).toMatchObject({
+      ambient: true,
+      targets: [expect.objectContaining({ detection: visibleDetection })],
+    });
+
     const hiddenPresentation = createDemoPresentation({
       ...defaultDemoPresentationSettings,
       confidenceThreshold: 1,

--- a/demo/src/presentation/demo-presentation.test.ts
+++ b/demo/src/presentation/demo-presentation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   BoxShape,
   BoxStrokeAlignment,
+  createDefaultAnnotationPresentation,
   DetectionMaskEncoding,
   type Detection,
   DetectionPickTarget,
@@ -27,6 +28,12 @@ const detection: Detection = {
     height: 2,
     width: 2,
   },
+  rect: { height: 40, width: 20, x: 10, y: 12 },
+};
+
+const rectangleDetection: Detection = {
+  className: "horse",
+  confidence: 0.9,
   rect: { height: 40, width: 20, x: 10, y: 12 },
 };
 
@@ -87,18 +94,18 @@ describe("demo presentation", () => {
     });
 
     expect(
-      rectPresentation.boxStyle?.resolve(detection, {
+      rectPresentation.boxStyle?.resolve(rectangleDetection, {
         detectionIndex: 0,
-        frame: { detections: [detection], mediaTime: 0 },
+        frame: { detections: [rectangleDetection], mediaTime: 0 },
         mediaTime: 0,
       }),
     ).toMatchObject({
       shape: BoxShape.Rect,
     });
     expect(
-      roundedPresentation.boxStyle?.resolve(detection, {
+      roundedPresentation.boxStyle?.resolve(rectangleDetection, {
         detectionIndex: 0,
-        frame: { detections: [detection], mediaTime: 0 },
+        frame: { detections: [rectangleDetection], mediaTime: 0 },
         mediaTime: 0,
       }),
     ).toMatchObject({
@@ -130,8 +137,49 @@ describe("demo presentation", () => {
     expect(
       lowOpacityPresentation.maskStyle?.resolve(detection, context),
     ).toMatchObject({
-      alpha: 1,
+      alpha: defaultDemoPresentationSettings.maskFillAlpha,
     });
+  });
+
+  it("matches the Core annotation presentation before demo controls override it", () => {
+    const demo = createDemoPresentation(defaultDemoPresentationSettings);
+    const canonical = createDefaultAnnotationPresentation();
+    const frame = { detections: [detection, vectorDetection], mediaTime: 0 };
+    const context = { detectionIndex: 0, frame, mediaTime: 0 };
+    const rectangle = {
+      className: "person",
+      confidence: 0.9,
+      rect: { height: 40, width: 20, x: 10, y: 12 },
+    };
+    const polyline = {
+      className: "person",
+      polyline: {
+        points: [
+          { x: 0, y: 0 },
+          { x: 4, y: 4 },
+        ],
+      },
+    };
+
+    expect(demo.backgroundColor).toBe(0xf3f4f6);
+    expect(demo.boxStyle?.resolve(rectangle, context)).toEqual(
+      canonical.boxStyle?.resolve(rectangle, context),
+    );
+    expect(demo.maskStyle?.resolve(detection, context)).toEqual(
+      canonical.maskStyle?.resolve(detection, context),
+    );
+    expect(demo.labelStyle?.resolve(detection, context)).toEqual(
+      canonical.labelStyle?.resolve(detection, context),
+    );
+    expect(demo.polygonStyle?.resolve(vectorDetection, context)).toEqual(
+      canonical.polygonStyle?.resolve(vectorDetection, context),
+    );
+    expect(demo.polylineStyle?.resolve(polyline, context)).toEqual(
+      canonical.polylineStyle?.resolve(polyline, context),
+    );
+    expect(demo.keypointStyle?.resolve(vectorDetection, context)).toEqual(
+      canonical.keypointStyle?.resolve(vectorDetection, context),
+    );
   });
 
   it("maps demo style controls to renderer-neutral draw instructions", () => {
@@ -153,13 +201,11 @@ describe("demo presentation", () => {
       mediaTime: 0,
     };
 
-    expect(presentation.backgroundColor).toBe(0xfafafa);
+    expect(presentation.backgroundColor).toBe(0xf3f4f6);
 
-    expect(presentation.boxStyle?.resolve(detection, context)).toMatchObject({
-      stroke: {
-        alignment: BoxStrokeAlignment.Inside,
-      },
-    });
+    expect(
+      presentation.boxStyle?.resolve(rectangleDetection, context),
+    ).toMatchObject({ stroke: { alignment: BoxStrokeAlignment.Inside } });
     expect(presentation.labelStyle?.resolve(detection, context)).toMatchObject({
       background: {
         cornerRadius: 9,
@@ -195,7 +241,13 @@ describe("demo presentation", () => {
       },
     );
 
-    expect(hoverPresentation?.boxStyle).toBeNull();
+    expect(
+      hoverPresentation?.boxStyle?.resolve(detection, {
+        detectionIndex: 0,
+        frame,
+        mediaTime: 0,
+      }),
+    ).toBeUndefined();
     expect(
       hoverPresentation?.maskStyle?.resolve(detection, {
         detectionIndex: 0,
@@ -239,16 +291,19 @@ describe("demo presentation", () => {
       },
     );
 
-    const hoverBox = hoverPresentation?.boxStyle?.resolve(detection, {
+    const hoverBox = hoverPresentation?.boxStyle?.resolve(rectangleDetection, {
       detectionIndex: 0,
       frame,
       mediaTime: 0,
     });
-    const selectedBox = selectedPresentation?.boxStyle?.resolve(detection, {
-      detectionIndex: 0,
-      frame,
-      mediaTime: 0,
-    });
+    const selectedBox = selectedPresentation?.boxStyle?.resolve(
+      rectangleDetection,
+      {
+        detectionIndex: 0,
+        frame,
+        mediaTime: 0,
+      },
+    );
     const hoverMask = hoverPresentation?.maskStyle?.resolve(detection, {
       detectionIndex: 0,
       frame,
@@ -262,39 +317,37 @@ describe("demo presentation", () => {
 
     expect(hoverBox).toMatchObject({
       fill: {
-        alpha: 0.12,
+        alpha: defaultDemoPresentationSettings.interactionHoverFillAlpha,
         color: 0x38bdf8,
       },
       stroke: {
-        alignment: BoxStrokeAlignment.Outside,
-        alpha: 0.88,
-        color: 0x7dd3fc,
+        alpha: 1,
+        color: 0x38bdf8,
       },
     });
     expect(selectedBox).toMatchObject({
       fill: {
-        alpha: 0.22,
+        alpha: defaultDemoPresentationSettings.interactionSelectedFillAlpha,
         color: 0x38bdf8,
       },
       stroke: {
-        alignment: BoxStrokeAlignment.Outside,
         alpha: 1,
-        color: 0x7dd3fc,
+        color: 0x38bdf8,
       },
     });
     expect(hoverMask).toMatchObject({
-      alpha: 0.12,
+      alpha: defaultDemoPresentationSettings.interactionHoverFillAlpha,
       color: 0x38bdf8,
       stroke: {
-        color: 0x7dd3fc,
+        color: 0x38bdf8,
       },
     });
     expect(selectedMask).toMatchObject({
-      alpha: 0.22,
+      alpha: defaultDemoPresentationSettings.interactionSelectedFillAlpha,
       color: 0x38bdf8,
       stroke: {
         alpha: 1,
-        color: 0x7dd3fc,
+        color: 0x38bdf8,
       },
     });
     expect(selectedBox?.stroke?.width).toBeGreaterThan(
@@ -377,13 +430,17 @@ describe("demo presentation", () => {
     expect(instruction?.markers[0]).toMatchObject({
       fill: { color: personStyle.fill },
       radius: 7,
-      stroke: { color: personStyle.stroke },
+      stroke: { color: 0xffffff },
     });
     expect(instruction?.edges).toHaveLength(1);
     expect(instruction?.edges[0]).toMatchObject({
       stroke: { color: personStyle.stroke, width: 4 },
     });
-    expect(instruction?.edges[0]?.shadowStroke).toBeUndefined();
+    expect(instruction?.edges[0]?.shadowStroke).toMatchObject({
+      alpha: 0.25,
+      color: 0x000000,
+      width: 3,
+    });
   });
 
   it("filters vector layers through the shared confidence threshold", () => {
@@ -451,12 +508,16 @@ describe("demo presentation", () => {
     expect(keypointInstruction?.markers).toHaveLength(2);
     expect(keypointInstruction?.markers[0]).toMatchObject({
       fill: { color: personStyle.fill },
-      stroke: { color: personStyle.stroke },
+      stroke: { color: 0xffffff },
     });
     expect(keypointInstruction?.edges[0]).toMatchObject({
       stroke: { color: personStyle.stroke },
     });
-    expect(keypointInstruction?.edges[0]?.shadowStroke).toBeUndefined();
+    expect(keypointInstruction?.edges[0]?.shadowStroke).toMatchObject({
+      alpha: 0.25,
+      color: 0x000000,
+      width: 3,
+    });
   });
 
   it("creates a selected-or-hovered focus style for dimming the surrounding frame", () => {
@@ -485,7 +546,7 @@ describe("demo presentation", () => {
         alpha: defaultDemoPresentationSettings.focusDimAlpha,
         color: defaultDemoPresentationSettings.focusDimColor,
       },
-      targetMode: FocusTargetMode.HoveredAndSelected,
+      targetMode: FocusTargetMode.Ambient,
       targets: [selectedPick],
     });
   });

--- a/demo/src/presentation/demo-presentation.ts
+++ b/demo/src/presentation/demo-presentation.ts
@@ -4,7 +4,9 @@ import {
   BaseFocusStyle,
   BaseInteractionStyle,
   BaseKeypointStyle,
+  BaseLabelStyle,
   BasePolygonStyle,
+  BasePolylineStyle,
   DEFAULT_DETECTION_CLASS_STYLES,
   DetectionInteractionState,
   type DetectionClassColorStyle,
@@ -17,12 +19,12 @@ import {
   type FocusStyle,
   type InteractionStyle,
   type KeypointStyle,
-  type LabelDrawInstruction,
   type LabelStyle,
   type MaskDrawInstruction,
   type MaskStyle,
   type MediaRendererPresentation,
   type PolygonStyle,
+  type PolylineStyle,
   resolveDetectionClassColorStyle,
 } from "supervision-js";
 
@@ -35,6 +37,7 @@ export interface DemoPresentationSettings {
   readonly labelsEnabled: boolean;
   readonly masksEnabled: boolean;
   readonly polygonsEnabled: boolean;
+  readonly polylinesEnabled: boolean;
   readonly boxCornerRadius: number;
   readonly boxStrokeWidth: number;
   readonly boxStrokeAlignment: BoxStrokeAlignment;
@@ -43,17 +46,20 @@ export interface DemoPresentationSettings {
   readonly labelBackgroundAlpha: number;
   readonly labelCornerRadius: number;
   readonly labelFontSize: number;
+  readonly labelIncludeConfidence: boolean;
   readonly labelOffsetX: number;
   readonly labelOffsetY: number;
   readonly labelPaddingX: number;
   readonly labelPaddingY: number;
   readonly labelPlacement: LabelPlacement;
   readonly maskMode: MaskRenderMode;
+  readonly maskFillAlpha: number;
   readonly maskOpacity: number;
   readonly maskStrokeAlpha: number;
   readonly maskStrokeWidth: number;
   readonly polygonFillAlpha: number;
   readonly polygonStrokeWidth: number;
+  readonly polylineStrokeWidth: number;
   readonly keypointRadius: number;
   readonly keypointEdgeWidth: number;
   readonly confidenceThreshold: number;
@@ -73,7 +79,8 @@ export type DemoPresentationLayerSetting =
   | "keypointsEnabled"
   | "labelsEnabled"
   | "masksEnabled"
-  | "polygonsEnabled";
+  | "polygonsEnabled"
+  | "polylinesEnabled";
 
 export type DemoPresentationAvailability = Partial<
   Record<DemoPresentationLayerSetting, boolean>
@@ -86,6 +93,7 @@ const demoPresentationLayerSettings: readonly DemoPresentationLayerSetting[] = [
   "labelsEnabled",
   "masksEnabled",
   "polygonsEnabled",
+  "polylinesEnabled",
 ];
 
 export function constrainDemoPresentationSettings(
@@ -106,51 +114,61 @@ export function constrainDemoPresentationSettings(
 export const defaultDemoClassNames = ["person", "horse", "cow"];
 
 const defaultDemoClassStyles: Record<string, DemoClassStyle> = {
-  basketball: DEFAULT_DETECTION_CLASS_STYLES.basketball,
-  cow: DEFAULT_DETECTION_CLASS_STYLES.cow,
-  horse: DEFAULT_DETECTION_CLASS_STYLES.horse,
-  person: DEFAULT_DETECTION_CLASS_STYLES.person,
-  "white team player": DEFAULT_DETECTION_CLASS_STYLES["white team player"],
-  "yellow team player": DEFAULT_DETECTION_CLASS_STYLES["yellow team player"],
+  basketball: createCanonicalDemoClassStyle(
+    DEFAULT_DETECTION_CLASS_STYLES.basketball,
+  ),
+  cow: createCanonicalDemoClassStyle(DEFAULT_DETECTION_CLASS_STYLES.cow),
+  horse: createCanonicalDemoClassStyle(DEFAULT_DETECTION_CLASS_STYLES.horse),
+  person: createCanonicalDemoClassStyle(DEFAULT_DETECTION_CLASS_STYLES.person),
+  "white team player": createCanonicalDemoClassStyle(
+    DEFAULT_DETECTION_CLASS_STYLES["white team player"],
+  ),
+  "yellow team player": createCanonicalDemoClassStyle(
+    DEFAULT_DETECTION_CLASS_STYLES["yellow team player"],
+  ),
 };
 
 export const defaultDemoPresentationSettings: DemoPresentationSettings = {
-  boxesEnabled: false,
-  boxCornerRadius: 8,
-  boxFillAlpha: 0.1,
+  boxesEnabled: true,
+  boxCornerRadius: 1,
+  boxFillAlpha: 0.08,
   boxStrokeAlignment: BoxStrokeAlignment.Center,
-  boxStrokeWidth: 4,
+  boxStrokeWidth: 2,
   classStyles: defaultDemoClassStyles,
-  confidenceThreshold: 0.5,
-  focusCornerRadius: 10,
-  focusDimAlpha: 0.45,
-  focusDimColor: 0x020617,
+  confidenceThreshold: 0,
+  focusCornerRadius: 1,
+  focusDimAlpha: 0.4,
+  focusDimColor: 0x000000,
   focusEnabled: true,
-  focusTargetMode: FocusTargetMode.HoveredAndSelected,
-  interactionHoverFillAlpha: 0.12,
-  interactionHoverStrokeWidth: 5,
+  focusTargetMode: FocusTargetMode.Ambient,
+  interactionHoverFillAlpha: 0.08,
+  interactionHoverStrokeWidth: 2,
   interactionSelectedFillAlpha: 0.22,
-  interactionSelectedStrokeWidth: 7,
-  keypointEdgeWidth: 3,
-  keypointRadius: 5,
+  interactionSelectedStrokeWidth: 3.5,
+  keypointEdgeWidth: 1.5,
+  keypointRadius: 3.5,
   keypointsEnabled: true,
-  labelBackgroundAlpha: 0.78,
-  labelCornerRadius: 5,
-  labelFontSize: 14,
+  labelBackgroundAlpha: 1,
+  labelCornerRadius: 4,
+  labelFontSize: 12,
+  labelIncludeConfidence: false,
   labelOffsetX: 0,
   labelOffsetY: 0,
-  labelPaddingX: 7,
-  labelPaddingY: 4,
+  labelPaddingX: 6,
+  labelPaddingY: 3,
   labelPlacement: LabelPlacement.Top,
   labelsEnabled: true,
   maskMode: MaskRenderMode.FillAndStroke,
-  maskOpacity: 0.7,
+  maskFillAlpha: 0.45,
+  maskOpacity: 1,
   maskStrokeAlpha: 1,
-  maskStrokeWidth: 5,
+  maskStrokeWidth: 2,
   masksEnabled: true,
-  polygonFillAlpha: 0.12,
-  polygonStrokeWidth: 3,
+  polygonFillAlpha: 0.08,
+  polygonStrokeWidth: 2,
   polygonsEnabled: true,
+  polylineStrokeWidth: 2,
+  polylinesEnabled: true,
 };
 
 export function createDemoPresentation(
@@ -159,7 +177,7 @@ export function createDemoPresentation(
   return {
     // The demo uses contain-fit media, so this colour is visible in the
     // letterbox around non-matching aspect ratios.
-    backgroundColor: 0xfafafa,
+    backgroundColor: 0xf3f4f6,
     boxStyle: settings.boxesEnabled ? createDemoBoxStyle(settings) : null,
     focusStyle: settings.focusEnabled ? createDemoFocusStyle(settings) : null,
     interactionStyle: createDemoInteractionStyle(settings),
@@ -170,6 +188,9 @@ export function createDemoPresentation(
     maskStyle: settings.masksEnabled ? createDemoMaskStyle(settings) : null,
     polygonStyle: settings.polygonsEnabled
       ? createDemoPolygonStyle(settings)
+      : null,
+    polylineStyle: settings.polylinesEnabled
+      ? createDemoPolylineStyle(settings)
       : null,
   };
 }
@@ -184,9 +205,22 @@ function createDemoPolygonStyle(
     }),
     shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
     stroke: (detection) => ({
-      alpha: 0.95,
+      alpha: 1,
       color: resolveClassStyle(detection, settings).stroke,
       width: settings.polygonStrokeWidth,
+    }),
+  });
+}
+
+function createDemoPolylineStyle(
+  settings: DemoPresentationSettings,
+): PolylineStyle {
+  return new BasePolylineStyle({
+    shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
+    stroke: (detection) => ({
+      alpha: 1,
+      color: resolveClassStyle(detection, settings).stroke,
+      width: settings.polylineStrokeWidth,
     }),
   });
 }
@@ -195,9 +229,13 @@ function createDemoKeypointStyle(
   settings: DemoPresentationSettings,
 ): KeypointStyle {
   return new BaseKeypointStyle({
-    edgeShadowStroke: null,
+    edgeShadowStroke: {
+      alpha: 0.25,
+      color: 0x000000,
+      width: 3,
+    },
     edgeStroke: (detection) => ({
-      alpha: 0.95,
+      alpha: 1,
       color: resolveClassStyle(detection, settings).stroke,
       width: settings.keypointEdgeWidth,
     }),
@@ -205,10 +243,10 @@ function createDemoKeypointStyle(
       alpha: 1,
       color: resolveClassStyle(detection, settings).fill,
     }),
-    markerStroke: (detection) => ({
+    markerStroke: () => ({
       alpha: 1,
-      color: resolveClassStyle(detection, settings).stroke,
-      width: 2,
+      color: 0xffffff,
+      width: 1,
     }),
     radius: settings.keypointRadius,
     shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
@@ -218,7 +256,14 @@ function createDemoKeypointStyle(
 function createDemoBoxStyle(settings: DemoPresentationSettings): BoxStyle {
   return {
     resolve(detection: Detection): BoxDrawInstruction | undefined {
-      if (!detection.rect || !passesConfidenceThreshold(detection, settings)) {
+      if (
+        !detection.rect ||
+        detection.mask ||
+        detection.polygon ||
+        detection.polyline ||
+        detection.keypoints ||
+        !passesConfidenceThreshold(detection, settings)
+      ) {
         return undefined;
       }
 
@@ -235,8 +280,10 @@ function createDemoBoxStyle(settings: DemoPresentationSettings): BoxStyle {
         rect: detection.rect,
         shape,
         stroke: {
-          alignment: settings.boxStrokeAlignment,
-          alpha: 0.95,
+          ...(settings.boxStrokeAlignment === BoxStrokeAlignment.Center
+            ? {}
+            : { alignment: settings.boxStrokeAlignment }),
+          alpha: 1,
           color: style.stroke,
           width: settings.boxStrokeWidth,
         },
@@ -253,7 +300,9 @@ function createDemoFocusStyle(settings: DemoPresentationSettings): FocusStyle {
       color: settings.focusDimColor,
     },
     shape: resolveBoxShape(settings.focusCornerRadius),
-    shouldRender: (context) => hasRenderableFocusTarget(context, settings),
+    shouldRender: (context) =>
+      settings.focusTargetMode === FocusTargetMode.Ambient ||
+      hasRenderableFocusTarget(context, settings),
     targetMode: settings.focusTargetMode,
   });
 }
@@ -295,6 +344,7 @@ function createDemoMaskStyle(settings: DemoPresentationSettings): MaskStyle {
       "demo-mask",
       settings.confidenceThreshold,
       settings.maskMode,
+      settings.maskFillAlpha,
       settings.maskStrokeAlpha,
       settings.maskStrokeWidth,
       serializeMaskClassStyles(settings.classStyles),
@@ -309,7 +359,10 @@ function createDemoMaskStyle(settings: DemoPresentationSettings): MaskStyle {
       const style = resolveClassStyle(detection, settings);
 
       return {
-        alpha: settings.maskMode === MaskRenderMode.StrokeOnly ? 0 : 1,
+        alpha:
+          settings.maskMode === MaskRenderMode.StrokeOnly
+            ? 0
+            : settings.maskFillAlpha,
         color: style.fill,
         mask: detection.mask,
         stroke:
@@ -328,42 +381,30 @@ function createDemoMaskStyle(settings: DemoPresentationSettings): MaskStyle {
 }
 
 function createDemoLabelStyle(settings: DemoPresentationSettings): LabelStyle {
-  return {
-    resolve(detection: Detection): LabelDrawInstruction | undefined {
-      if (!detection.rect || !passesConfidenceThreshold(detection, settings)) {
-        return undefined;
-      }
-
-      const className = detection.className ?? "detection";
-      const style = resolveClassStyle(detection, settings);
-      const confidence =
-        detection.confidence === undefined
-          ? ""
-          : ` ${Math.round(detection.confidence * 100)}%`;
-
-      return {
-        background: {
-          alpha: settings.labelBackgroundAlpha,
-          color: style.labelBackground,
-          cornerRadius: settings.labelCornerRadius,
-          paddingX: settings.labelPaddingX,
-          paddingY: settings.labelPaddingY,
-        },
-        offsetX: settings.labelOffsetX,
-        offsetY: settings.labelOffsetY,
-        placement: settings.labelPlacement,
-        rect: detection.rect,
-        text: `${className}${confidence}`,
-        textStyle: {
-          alpha: 1,
-          color: style.labelText,
-          fontFamily: "Inter, sans-serif",
-          fontSize: settings.labelFontSize,
-          fontWeight: "750",
-        },
-      };
+  return new BaseLabelStyle({
+    background: (detection) => ({
+      alpha: settings.labelBackgroundAlpha,
+      color: resolveClassStyle(detection, settings).labelBackground,
+      cornerRadius: settings.labelCornerRadius,
+      paddingX: settings.labelPaddingX,
+      paddingY: settings.labelPaddingY,
+      topCornersOnly: true,
+    }),
+    includeConfidence: settings.labelIncludeConfidence,
+    offset: {
+      ...(settings.labelOffsetX === 0 ? {} : { x: settings.labelOffsetX }),
+      y: settings.labelOffsetY,
     },
-  };
+    placement: settings.labelPlacement,
+    shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
+    textStyle: (detection) => ({
+      color: resolveClassStyle(detection, settings).labelText,
+      fontFamily:
+        "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+      fontSize: settings.labelFontSize,
+      fontWeight: "600",
+    }),
+  });
 }
 
 function createDemoInteractionStyle(
@@ -383,6 +424,7 @@ function createDemoInteractionStyle(
       (settings.boxesEnabled ||
         settings.masksEnabled ||
         settings.polygonsEnabled ||
+        settings.polylinesEnabled ||
         settings.keypointsEnabled),
   });
 }
@@ -404,6 +446,9 @@ function createDemoInteractionPresentation(
     polygonStyle: settings.polygonsEnabled
       ? createDemoInteractionPolygonStyle(settings, state)
       : null,
+    polylineStyle: settings.polylinesEnabled
+      ? createDemoInteractionPolylineStyle(settings, state)
+      : null,
   };
 }
 
@@ -422,7 +467,25 @@ function createDemoInteractionPolygonStyle(
     }),
     shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
     stroke: (detection) => ({
-      alpha: isSelected ? 1 : 0.9,
+      alpha: 1,
+      color: resolveClassStyle(detection, settings).stroke,
+      width: isSelected
+        ? settings.interactionSelectedStrokeWidth
+        : settings.interactionHoverStrokeWidth,
+    }),
+  });
+}
+
+function createDemoInteractionPolylineStyle(
+  settings: DemoPresentationSettings,
+  state: DetectionInteractionState,
+): PolylineStyle {
+  const isSelected = state === DetectionInteractionState.Selected;
+
+  return new BasePolylineStyle({
+    shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
+    stroke: (detection) => ({
+      alpha: 1,
       color: resolveClassStyle(detection, settings).stroke,
       width: isSelected
         ? settings.interactionSelectedStrokeWidth
@@ -438,22 +501,28 @@ function createDemoInteractionKeypointStyle(
   const isSelected = state === DetectionInteractionState.Selected;
 
   return new BaseKeypointStyle({
-    edgeShadowStroke: null,
+    edgeShadowStroke: {
+      alpha: 0.25,
+      color: 0x000000,
+      width: 3,
+    },
     edgeStroke: (detection) => ({
-      alpha: isSelected ? 1 : 0.9,
+      alpha: 1,
       color: resolveClassStyle(detection, settings).stroke,
-      width: settings.keypointEdgeWidth + (isSelected ? 2 : 1),
+      width: isSelected
+        ? settings.interactionSelectedStrokeWidth
+        : settings.interactionHoverStrokeWidth,
     }),
     markerFill: (detection) => ({
       alpha: 1,
       color: resolveClassStyle(detection, settings).fill,
     }),
-    markerStroke: (detection) => ({
+    markerStroke: () => ({
       alpha: 1,
-      color: resolveClassStyle(detection, settings).stroke,
-      width: 2,
+      color: 0xffffff,
+      width: 1,
     }),
-    radius: settings.keypointRadius + (isSelected ? 2 : 1),
+    radius: settings.keypointRadius,
     shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
   });
 }
@@ -464,7 +533,14 @@ function createDemoInteractionBoxStyle(
 ): BoxStyle {
   return {
     resolve(detection: Detection): BoxDrawInstruction | undefined {
-      if (!detection.rect || !passesConfidenceThreshold(detection, settings)) {
+      if (
+        !detection.rect ||
+        detection.mask ||
+        detection.polygon ||
+        detection.polyline ||
+        detection.keypoints ||
+        !passesConfidenceThreshold(detection, settings)
+      ) {
         return undefined;
       }
 
@@ -484,8 +560,7 @@ function createDemoInteractionBoxStyle(
         rect: detection.rect,
         shape,
         stroke: {
-          alignment: BoxStrokeAlignment.Outside,
-          alpha: isSelected ? 1 : 0.88,
+          alpha: 1,
           color: style.stroke,
           width: isSelected
             ? settings.interactionSelectedStrokeWidth
@@ -516,7 +591,7 @@ function createDemoInteractionMaskStyle(
         color: style.fill,
         mask: detection.mask,
         stroke: {
-          alpha: isSelected ? 1 : 0.9,
+          alpha: 1,
           color: style.stroke,
           width: isSelected
             ? settings.interactionSelectedStrokeWidth
@@ -540,7 +615,7 @@ export function resolveDemoClassStyle(
 ) {
   return (
     settings.classStyles[className] ??
-    resolveDetectionClassColorStyle(className)
+    createCanonicalDemoClassStyle(resolveDetectionClassColorStyle(className))
   );
 }
 
@@ -550,7 +625,27 @@ function resolveClassStyle(
 ) {
   return detection.className
     ? resolveDemoClassStyle(settings, detection.className)
-    : resolveDetectionClassColorStyle(undefined);
+    : createCanonicalDemoClassStyle(resolveDetectionClassColorStyle(undefined));
+}
+
+function createCanonicalDemoClassStyle(
+  style: DetectionClassColorStyle,
+): DemoClassStyle {
+  return {
+    fill: style.fill,
+    labelBackground: style.fill,
+    labelText: resolveDemoLabelTextColor(style.fill),
+    stroke: style.fill,
+  };
+}
+
+function resolveDemoLabelTextColor(color: number) {
+  const red = (color >> 16) & 0xff;
+  const green = (color >> 8) & 0xff;
+  const blue = color & 0xff;
+  const luminance = (red * 299 + green * 587 + blue * 114) / 1000;
+
+  return luminance >= 150 ? 0x111111 : 0xffffff;
 }
 
 function serializeMaskClassStyles(styles: Record<string, DemoClassStyle>) {

--- a/demo/src/presentation/demo-presentation.ts
+++ b/demo/src/presentation/demo-presentation.ts
@@ -314,12 +314,18 @@ function createDemoFocusStyle(settings: DemoPresentationSettings): FocusStyle {
               ...context,
               hoveredPick:
                 context.hoveredPick &&
-                passesConfidenceThreshold(context.hoveredPick.detection, settings)
+                passesConfidenceThreshold(
+                  context.hoveredPick.detection,
+                  settings,
+                )
                   ? context.hoveredPick
                   : null,
               selectedPick:
                 context.selectedPick &&
-                passesConfidenceThreshold(context.selectedPick.detection, settings)
+                passesConfidenceThreshold(
+                  context.selectedPick.detection,
+                  settings,
+                )
                   ? context.selectedPick
                   : null,
             }

--- a/demo/src/presentation/demo-presentation.ts
+++ b/demo/src/presentation/demo-presentation.ts
@@ -308,7 +308,23 @@ function createDemoFocusStyle(settings: DemoPresentationSettings): FocusStyle {
 
   return {
     resolve(context) {
-      const instruction = baseStyle.resolve(context);
+      const contextWithVisiblePicks =
+        settings.focusTargetMode === FocusTargetMode.Ambient
+          ? {
+              ...context,
+              hoveredPick:
+                context.hoveredPick &&
+                passesConfidenceThreshold(context.hoveredPick.detection, settings)
+                  ? context.hoveredPick
+                  : null,
+              selectedPick:
+                context.selectedPick &&
+                passesConfidenceThreshold(context.selectedPick.detection, settings)
+                  ? context.selectedPick
+                  : null,
+            }
+          : context;
+      const instruction = baseStyle.resolve(contextWithVisiblePicks);
 
       if (!instruction) {
         return undefined;

--- a/demo/src/presentation/demo-presentation.ts
+++ b/demo/src/presentation/demo-presentation.ts
@@ -293,7 +293,7 @@ function createDemoBoxStyle(settings: DemoPresentationSettings): BoxStyle {
 }
 
 function createDemoFocusStyle(settings: DemoPresentationSettings): FocusStyle {
-  return new BaseFocusStyle({
+  const baseStyle = new BaseFocusStyle({
     cornerRadius: settings.focusCornerRadius,
     fill: {
       alpha: settings.focusDimAlpha,
@@ -305,6 +305,22 @@ function createDemoFocusStyle(settings: DemoPresentationSettings): FocusStyle {
       hasRenderableFocusTarget(context, settings),
     targetMode: settings.focusTargetMode,
   });
+
+  return {
+    resolve(context) {
+      const instruction = baseStyle.resolve(context);
+
+      if (!instruction) {
+        return undefined;
+      }
+
+      const targets = instruction.targets.filter((target) =>
+        passesConfidenceThreshold(target.detection, settings),
+      );
+
+      return targets.length === 0 ? undefined : { ...instruction, targets };
+    },
+  };
 }
 
 function hasRenderableFocusTarget(


### PR DESCRIPTION
# Description

Aligns the demo's default detection rendering with the canonical Core annotation presentation extracted from the annotation-editor integration. The default now uses primary geometry, compact label pills, translucent mask fills with opaque borders, canonical keypoint treatment, and ambient focus.

The demo controls remain available as overrides and now expose mask fill alpha, label confidence, polyline styling, and ambient focus.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `npm run verify`
- Ran `npx vitest run demo/src/presentation/demo-presentation.test.ts`
- Ran `npm run demo:build`

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

- Hosting: deploy the demo site after merge.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)