### PR TITLE
Keep MediaStream rendering at the live edge

### DIFF
--- a/docs/public/guides/public-api.md
+++ b/docs/public/guides/public-api.md
@@ -73,7 +73,9 @@ not the first thing most users should reach for:
 
 - `createMediaRenderer()` for lower-level renderer ownership;
 - `createMediaStreamRendererSource()` for adapting a browser `MediaStream`
-  without adding a second visible video layer;
+  without adding a second visible video layer; its bounded snapshot queue is
+  latest-frame-wins, so a temporarily slow renderer resumes at the live edge
+  instead of replaying stale frames;
 - `DetectionFrameSource` for caller-owned range loading;
 - `WritableDetectionFrameSource` and `createWritableDetectionFrameSource()` for
   streaming inference ingestion;

--- a/packages/web/src/media/media-stream-media-source.test.ts
+++ b/packages/web/src/media/media-stream-media-source.test.ts
@@ -183,6 +183,35 @@ describe("createMediaStreamRendererSource", () => {
     decoded.input.dispose();
   });
 
+  it("returns to the live edge after an active consumer falls behind", async () => {
+    const track = new FakeTrack();
+    const stream = new FakeStream(track);
+    const opening = createMediaStreamRendererSource(
+      stream as unknown as MediaStream,
+      { maxBufferedFrames: 4 },
+    ).open();
+
+    await fakeVideo.present(0);
+    const decoded = await opening;
+    const iterator = decoded.sampleSink.samples(0);
+    const first = await iterator.next();
+    expect(first.value?.timestamp).toBe(0);
+    first.value?.close();
+
+    await fakeVideo.present(0.1);
+    await fakeVideo.present(0.2);
+    await fakeVideo.present(0.3);
+
+    const resumed = await iterator.next();
+    expect(resumed.value?.timestamp).toBe(0.3);
+    expect(bitmaps[1]?.close).toHaveBeenCalledOnce();
+    expect(bitmaps[2]?.close).toHaveBeenCalledOnce();
+
+    resumed.value?.close();
+    await iterator.return();
+    decoded.input.dispose();
+  });
+
   it("can normalize the live timeline to the first presented frame", async () => {
     const track = new FakeTrack();
     const stream = new FakeStream(track);

--- a/packages/web/src/media/media-stream-media-source.ts
+++ b/packages/web/src/media/media-stream-media-source.ts
@@ -276,13 +276,15 @@ async function openMediaStreamMediaSource(
       return frame ? createDecodedSample(frame) : null;
     },
     async *samples(startTimestamp) {
-      let preferLatest = true;
-
       while (!disposed) {
-        const frame = await nextFrame(startTimestamp, preferLatest);
+        // MediaStream is a live source, not a replayable queue. Rendering every
+        // captured snapshot after a slow frame would permanently move playback
+        // behind the live edge. Always discard superseded snapshots before the
+        // next presentation so latency stays bounded by current work rather
+        // than by historical decoder backlog.
+        const frame = await nextFrame(startTimestamp, true);
         if (!frame) return;
 
-        preferLatest = false;
         startTimestamp = frame.timestamp + TIMESTAMP_EPSILON_SECONDS;
         yield createDecodedSample(frame);
       }


### PR DESCRIPTION
# Description

Make browser MediaStream playback latest-frame-wins after any renderer slowdown, preventing stale decoded snapshots from accumulating latency in live WebRTC previews. Adds a regression test for an already-active consumer falling behind and documents the live-edge behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added a MediaStream source regression test covering recovery after multiple queued frames
- Ran the full `npm run verify` suite: 66 test files and 471 tests passed, plus builds, boundary checks, docs checks, demos, and benchmarks

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Regenerate the private supervision-js tarball for Core consumers

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)