### PR TITLE
refactor(rn): centralize prepared frame ownership

### DIFF
--- a/packages/react-native/src/renderers/prepared-frame-packet.ts
+++ b/packages/react-native/src/renderers/prepared-frame-packet.ts
@@ -1,0 +1,37 @@
+import type { PlatformMediaFrame } from "supervision-js-core";
+
+import type { MediaFrameProcessorResult } from "../types/frame-processor";
+
+/**
+ * The renderer-private unit of presentation. A packet keeps every resource
+ * derived from one media frame together, so media, semantic state, and native
+ * render handles can never be promoted independently.
+ *
+ * This is deliberately not exported from a package entry point. Callers pass
+ * semantic frames into a session; prepared artifacts belong to its renderer.
+ */
+export interface PreparedFramePacket<TPayload, TRendererPacket extends object> {
+  readonly diagnostics: MediaFrameProcessorResult["diagnostics"];
+  readonly frame: PlatformMediaFrame<TPayload>;
+  readonly packetId: number;
+  readonly rendererPacket: TRendererPacket;
+  readonly result: MediaFrameProcessorResult;
+}
+
+export function createPreparedFramePacket<
+  TPayload,
+  TRendererPacket extends object,
+>(
+  packetId: number,
+  frame: PlatformMediaFrame<TPayload>,
+  result: MediaFrameProcessorResult,
+  rendererPacket: TRendererPacket,
+): PreparedFramePacket<TPayload, TRendererPacket> {
+  return {
+    diagnostics: result.diagnostics,
+    frame,
+    packetId,
+    rendererPacket,
+    result,
+  };
+}

--- a/packages/react-native/src/renderers/prepared-frame-store.test.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createPreparedFramePacket,
+  type PreparedFramePacket,
+} from "./prepared-frame-packet";
+import { PreparedFrameStore } from "./prepared-frame-store";
+
+type RendererPacket = { readonly id: number };
+type Packet = PreparedFramePacket<"frame", RendererPacket>;
+
+function packet(id: number): Packet {
+  return createPreparedFramePacket(
+    id,
+    {
+      metadata: {
+        duration: 1,
+        frameIndex: id,
+        height: 1,
+        mediaTime: id,
+        width: 1,
+      },
+      payload: "frame",
+    },
+    { detectionFrame: { detections: [], mediaTime: id } },
+    { id },
+  );
+}
+
+describe("PreparedFrameStore", () => {
+  it("keeps one retired packet alive before releasing it", async () => {
+    const dispose = vi.fn();
+    const store = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+    const first = packet(1);
+    const second = packet(2);
+    const third = packet(3);
+
+    await store.present(first);
+    await store.present(second);
+    expect(dispose).not.toHaveBeenCalled();
+
+    await store.present(third);
+    expect(dispose).toHaveBeenCalledWith(1);
+    expect(store.active?.packetId).toBe(3);
+
+    await store.dispose();
+    expect(dispose.mock.calls.map(([id]) => id)).toEqual([1, 3, 2]);
+  });
+
+  it("discards an unpresented packet without disturbing active ownership", async () => {
+    const dispose = vi.fn();
+    const store = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+    const active = packet(1);
+    const abandoned = packet(2);
+
+    await store.present(active);
+    await store.discard(abandoned);
+    await store.discard(abandoned);
+
+    expect(store.active).toBe(active);
+    expect(dispose.mock.calls.map(([id]) => id)).toEqual([2]);
+  });
+
+  it("clears ownership before disposal, so repeated cleanup cannot double-release", async () => {
+    const dispose = vi.fn();
+    const store = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+
+    await store.present(packet(1));
+    await store.present(packet(2));
+    await store.dispose();
+    await store.dispose();
+
+    expect(dispose.mock.calls.map(([id]) => id)).toEqual([2, 1]);
+  });
+
+  it("continues cleanup after one packet fails to release", async () => {
+    const dispose = vi.fn((next: Packet) => {
+      if (next.packetId === 2) {
+        throw new Error("release failed");
+      }
+    });
+    const store = new PreparedFrameStore(dispose);
+
+    await store.present(packet(1));
+    await store.present(packet(2));
+    await expect(store.dispose()).rejects.toThrow("release failed");
+    expect(dispose.mock.calls.map(([next]) => next.packetId)).toEqual([2, 1]);
+  });
+
+  it("restores worklet-owned packets and disposes them synchronously", () => {
+    const dispose = vi.fn();
+    const initial = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+
+    initial.presentNow(packet(1));
+    initial.presentNow(packet(2));
+    const resumed = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+
+    resumed.restore(initial.snapshot());
+    resumed.presentNow(packet(3));
+    resumed.disposeNow();
+
+    expect(dispose.mock.calls.map(([id]) => id)).toEqual([1, 3, 2]);
+  });
+});

--- a/packages/react-native/src/renderers/prepared-frame-store.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.ts
@@ -1,0 +1,155 @@
+/**
+ * Owns prepared packets after their renderer has acquired native resources.
+ *
+ * A newly presented packet replaces `active`; the old active packet becomes
+ * `retired` and is released only after one further successful presentation.
+ * That one-packet grace period prevents Skia from drawing an image that was
+ * disposed while its UI render still references the previous shared value.
+ */
+export class PreparedFrameStore<TPacket extends object> {
+  private activePacket: TPacket | null = null;
+  private retiredPacket: TPacket | null = null;
+  private readonly releasedPackets = new WeakSet<object>();
+
+  constructor(
+    private readonly disposePacket: (packet: TPacket) => void | Promise<void>,
+  ) {
+    "worklet";
+  }
+
+  get active() {
+    "worklet";
+    return this.activePacket;
+  }
+
+  /** Captures store ownership so a paused worklet can resume safely. */
+  snapshot() {
+    "worklet";
+
+    return { active: this.activePacket, retired: this.retiredPacket };
+  }
+
+  /** Restores a snapshot into a newly created single-writer worklet store. */
+  restore(snapshot: {
+    readonly active: TPacket | null;
+    readonly retired: TPacket | null;
+  }) {
+    "worklet";
+
+    this.activePacket = snapshot.active;
+    this.retiredPacket = snapshot.retired;
+  }
+
+  /**
+   * Promotes a packet only after the renderer has presented it successfully.
+   * The store is the single lifecycle writer: callers must not retain or
+   * dispose packets once they pass them here.
+   */
+  async present(packet: TPacket) {
+    await this.release(this.promote(packet));
+  }
+
+  /** Synchronous worklet variant for native render-handle disposal. */
+  presentNow(packet: TPacket) {
+    "worklet";
+
+    this.releaseNow(this.promote(packet));
+  }
+
+  /** Releases a prepared packet that never reached presentation. */
+  async discard(packet: TPacket) {
+    if (this.activePacket === packet || this.retiredPacket === packet) {
+      return;
+    }
+
+    await this.release(packet);
+  }
+
+  /** Synchronous worklet variant for a packet that never reached the screen. */
+  discardNow(packet: TPacket) {
+    "worklet";
+
+    if (this.activePacket !== packet && this.retiredPacket !== packet) {
+      this.releaseNow(packet);
+    }
+  }
+
+  /** Idempotently releases every packet still owned by the store. */
+  async dispose() {
+    const activePacket = this.activePacket;
+    const retiredPacket = this.retiredPacket;
+
+    this.activePacket = null;
+    this.retiredPacket = null;
+
+    const errors: unknown[] = [];
+
+    for (const packet of [activePacket, retiredPacket]) {
+      try {
+        await this.release(packet);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+
+    if (errors.length > 0) {
+      throw errors[0];
+    }
+  }
+
+  /** Synchronously releases all packets owned by a worklet store. */
+  disposeNow() {
+    "worklet";
+
+    const activePacket = this.activePacket;
+    const retiredPacket = this.retiredPacket;
+
+    this.activePacket = null;
+    this.retiredPacket = null;
+    let firstError: unknown = null;
+
+    for (const packet of [activePacket, retiredPacket]) {
+      try {
+        this.releaseNow(packet);
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+
+    if (firstError) {
+      throw firstError;
+    }
+  }
+
+  private promote(packet: TPacket) {
+    const packetToDispose = this.retiredPacket;
+
+    this.retiredPacket = this.activePacket;
+    this.activePacket = packet;
+    return packetToDispose;
+  }
+
+  private async release(packet: TPacket | null) {
+    if (packet && !this.releasedPackets.has(packet)) {
+      // Mark before calling into a native adapter: a disposal error cannot make
+      // it safe to call a possibly destructive native release twice.
+      this.releasedPackets.add(packet);
+      await this.disposePacket(packet);
+    }
+  }
+
+  private releaseNow(packet: TPacket | null) {
+    if (!packet || this.releasedPackets.has(packet)) {
+      return;
+    }
+
+    this.releasedPackets.add(packet);
+    const result = this.disposePacket(packet);
+
+    if (result && typeof (result as PromiseLike<void>).then === "function") {
+      throw new Error(
+        "PreparedFrameStore synchronous disposal received an async disposer.",
+      );
+    }
+  }
+}

--- a/packages/react-native/src/renderers/prepared-frame-store.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.ts
@@ -7,6 +7,7 @@
  * disposed while its UI render still references the previous shared value.
  */
 export class PreparedFrameStore<TPacket extends object> {
+  __workletClass = true;
   private activePacket: TPacket | null = null;
   private retiredPacket: TPacket | null = null;
   private readonly releasedPackets = new WeakSet<object>();

--- a/packages/react-native/src/renderers/prepared-frame-store.worklet.test.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.worklet.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+// @ts-expect-error Vitest supplies Vite's raw-module loader at test time.
+import preparedFrameStoreSource from "./prepared-frame-store.ts?raw";
+
+describe("PreparedFrameStore worklet transform", () => {
+  it("emits a worklet-class factory for the saved-video packet owner", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const babel = require("@babel/core") as {
+      transformSync(source: string, options: object): { code?: string } | null;
+    };
+    const result = babel.transformSync(preparedFrameStoreSource, {
+      filename: "packages/react-native/src/renderers/prepared-frame-store.ts",
+      plugins: [
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require("@babel/plugin-transform-typescript"),
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        require("react-native-worklets/plugin"),
+      ],
+    });
+
+    expect(result?.code).toContain("PreparedFrameStore__classFactory");
+  });
+});

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -27,6 +27,7 @@ import {
   disposeReactNativeSkiaImage,
   type ReactNativeSkiaMaskFrame,
 } from "./skia";
+import { PreparedFrameStore } from "./renderers/prepared-frame-store";
 import {
   createReactNativeVideoFrameSource,
   type ReactNativeBoxedVideoFrameSource,
@@ -182,6 +183,21 @@ export interface ReactNativeVideoSession {
   destroy(): void;
 }
 
+/** Renderer-private saved-video packet; never part of the public session API. */
+interface ReactNativeVideoPreparedFramePacket {
+  readonly detections: readonly ReactNativeVideoSessionDetection[];
+  readonly frameImage: SkImage;
+  readonly maskImage: SkImage | null;
+  readonly maskUniforms: ReactNativeIdMaskUniforms;
+  readonly packetId: number;
+  readonly timestampMs: number;
+}
+
+interface ReactNativeVideoPreparedFrameStoreState {
+  readonly active: ReactNativeVideoPreparedFramePacket | null;
+  readonly retired: ReactNativeVideoPreparedFramePacket | null;
+}
+
 interface WorkletVendorModules {
   makeMutable<TValue>(value: TValue): ReactNativeSharedValue<TValue>;
   scheduleOnRN(fn: (...args: never[]) => void, ...args: unknown[]): void;
@@ -278,8 +294,12 @@ export function createReactNativeVideoSession(
   const frameImage = vendors.makeMutable<SkImage | null>(null);
   const maskImage = vendors.makeMutable<SkImage | null>(null);
   const maskUniforms = vendors.makeMutable(emptyUniforms);
-  const retiredFrameImage = vendors.makeMutable<SkImage | null>(null);
-  const retiredMaskImage = vendors.makeMutable<SkImage | null>(null);
+  const preparedFrameStoreState =
+    vendors.makeMutable<ReactNativeVideoPreparedFrameStoreState>({
+      active: null,
+      retired: null,
+    });
+  const nextPacketId = vendors.makeMutable(0);
   const playingShared = vendors.makeMutable(false);
   const pausedShared = vendors.makeMutable(false);
   const mediaRectShared = vendors.makeMutable<TopLeftRect>({
@@ -300,6 +320,18 @@ export function createReactNativeVideoSession(
   const scheduleOnRN = vendors.scheduleOnRN;
 
   let destroyed = false;
+  const createPreparedFrameStore = () => {
+    "worklet";
+
+    const store = new PreparedFrameStore<ReactNativeVideoPreparedFramePacket>(
+      (packet) => {
+        disposeReactNativeSkiaImage(packet.frameImage);
+        disposeReactNativeSkiaImage(packet.maskImage);
+      },
+    );
+    store.restore(preparedFrameStoreState.value);
+    return store;
+  };
 
   const reportDetections = (
     detections: readonly ReactNativeVideoSessionDetection[],
@@ -323,6 +355,7 @@ export function createReactNativeVideoSession(
     "worklet";
 
     const pumpSource = boxedSource.unbox();
+    const preparedFrameStore = createPreparedFrameStore();
     const startedAt = Date.now();
     const framePixels = pumpSource.frameWidth * pumpSource.frameHeight;
     const returnMasksAtOriginalResolution = framePixels <= fullResMaskMaxPixels;
@@ -447,23 +480,26 @@ export function createReactNativeVideoSession(
           continue;
         }
 
-        // Release the images from two ticks ago, retire the previous ones,
-        // and present the new packet.
-        const previousFrameImage = frameImage.value;
-        const previousMaskImage = maskImage.value;
-        const retiredImage = retiredFrameImage.value;
-        const retiredMask = retiredMaskImage.value;
+        // Promote one coherent packet. The store retires the old packet for
+        // one further presentation before it disposes either Skia image.
+        const packet: ReactNativeVideoPreparedFramePacket = {
+          detections: overlayDetections,
+          frameImage: presentedImage,
+          maskImage: preparedMask ? preparedMask.image : null,
+          maskUniforms: preparedMask ? preparedMask.uniforms : emptyUniforms,
+          packetId: nextPacketId.value,
+          timestampMs: frameTimestampMs,
+        };
 
-        maskUniforms.value = preparedMask
-          ? preparedMask.uniforms
-          : emptyUniforms;
-        maskImage.value = preparedMask ? preparedMask.image : null;
-        frameImage.value = presentedImage;
-        retiredFrameImage.value = previousFrameImage;
-        retiredMaskImage.value = previousMaskImage;
-
-        disposeReactNativeSkiaImage(retiredImage);
-        disposeReactNativeSkiaImage(retiredMask);
+        nextPacketId.value += 1;
+        maskUniforms.value = packet.maskUniforms;
+        maskImage.value = packet.maskImage;
+        frameImage.value = packet.frameImage;
+        try {
+          preparedFrameStore.presentNow(packet);
+        } finally {
+          preparedFrameStoreState.value = preparedFrameStore.snapshot();
+        }
 
         processedFrames += 1;
 
@@ -516,21 +552,13 @@ export function createReactNativeVideoSession(
   const cleanupPackets = () => {
     "worklet";
 
-    const packetFrame = frameImage.value;
-    const packetMask = maskImage.value;
-    const retiredFrame = retiredFrameImage.value;
-    const retiredMask = retiredMaskImage.value;
-
     frameImage.value = null;
     maskImage.value = null;
     maskUniforms.value = emptyUniforms;
-    retiredFrameImage.value = null;
-    retiredMaskImage.value = null;
+    const preparedFrameStore = createPreparedFrameStore();
 
-    disposeReactNativeSkiaImage(packetFrame);
-    disposeReactNativeSkiaImage(packetMask);
-    disposeReactNativeSkiaImage(retiredFrame);
-    disposeReactNativeSkiaImage(retiredMask);
+    preparedFrameStoreState.value = { active: null, retired: null };
+    preparedFrameStore.disposeNow();
   };
 
   const schedulePump = () => {

--- a/packages/react-native/src/sessions/media-session-core.test.ts
+++ b/packages/react-native/src/sessions/media-session-core.test.ts
@@ -65,7 +65,7 @@ describe("createMediaSession", () => {
 
     expect(renderer.prepared.map((entry) => entry.packetId)).toEqual([0, 1]);
     expect(renderer.presentedPacketIds).toEqual([0, 1]);
-    expect(renderer.disposedPacketIds).toEqual([0]);
+    expect(renderer.disposedPacketIds).toEqual([]);
     expect(session.getState()).toMatchObject({
       renderPreparation: { activePacketId: 1, preparedFrames: 2 },
       renderer: {
@@ -92,7 +92,7 @@ describe("createMediaSession", () => {
     expect(session.getState().status).toBe(MediaSessionStatus.Ready);
 
     await session.destroy();
-    expect(renderer.disposedPacketIds).toEqual([0, 1]);
+    expect(renderer.disposedPacketIds).toEqual([1, 0]);
     expect(renderer.destroyed).toBe(true);
     expect(source.destroyed).toBe(true);
     expect(session.getState().status).toBe(MediaSessionStatus.Destroyed);

--- a/packages/react-native/src/sessions/media-session-core.ts
+++ b/packages/react-native/src/sessions/media-session-core.ts
@@ -9,6 +9,11 @@ import {
 
 import type { MediaFrameSourceConsumer } from "../types/frame-source";
 import {
+  createPreparedFramePacket,
+  type PreparedFramePacket,
+} from "../renderers/prepared-frame-packet";
+import { PreparedFrameStore } from "../renderers/prepared-frame-store";
+import {
   MediaSessionError,
   type MediaSession,
   type MediaSessionOptions,
@@ -33,14 +38,13 @@ export async function createMediaSession<TPayload, TPacket extends object>(
   let destroyed = false;
   let opened = false;
   let started = false;
-  let activePacket: TPacket | null = null;
   let activeDetectionFrame: MediaSessionRendererState["activeDetectionFrame"] =
     null;
   let activePacketId: number | null = null;
   let error: MediaSessionError | null = null;
   let presentation = options.presentation ?? {};
   let presentedFrames = 0;
-  let preparedFrames = 0;
+  let preparedFrameCount = 0;
   let nextPacketId = 0;
   let processing = false;
   let playing = false;
@@ -54,6 +58,9 @@ export async function createMediaSession<TPayload, TPacket extends object>(
   const teardownErrors: unknown[] = [];
   let lastDiagnostics: MediaSessionRenderPreparationState["lastDiagnostics"] =
     null;
+  const preparedFrameStore = new PreparedFrameStore<
+    PreparedFramePacket<TPayload, TPacket>
+  >(async (packet) => options.renderer.disposePacket?.(packet.rendererPacket));
 
   const state = (): MediaSessionState => {
     const activities = [];
@@ -76,7 +83,7 @@ export async function createMediaSession<TPayload, TPacket extends object>(
         kind: MediaSessionActivityKind.RenderPreparing,
         label: "Preparing frame",
         pendingCount: 1,
-        preparedCount: preparedFrames,
+        preparedCount: preparedFrameCount,
         status: MediaSessionActivityStatus.Running,
       });
     }
@@ -124,7 +131,7 @@ export async function createMediaSession<TPayload, TPacket extends object>(
       renderPreparation: {
         activePacketId,
         lastDiagnostics,
-        preparedFrames,
+        preparedFrames: preparedFrameCount,
       },
       renderer: {
         activeDetectionFrame,
@@ -158,12 +165,6 @@ export async function createMediaSession<TPayload, TPacket extends object>(
     emit();
   };
 
-  const disposePacket = async (packet: TPacket | null) => {
-    if (packet) {
-      await options.renderer.disposePacket?.(packet);
-    }
-  };
-
   const onFrame = async (frame: PlatformMediaFrame<TPayload>) => {
     if (shouldAbandonFrame()) {
       return;
@@ -172,7 +173,7 @@ export async function createMediaSession<TPayload, TPacket extends object>(
     processing = true;
     emit();
 
-    let nextPacket: TPacket | null = null;
+    let nextPacket: PreparedFramePacket<TPayload, TPacket> | null = null;
     let stage: "processor" | "renderer" = "processor";
 
     try {
@@ -186,35 +187,38 @@ export async function createMediaSession<TPayload, TPacket extends object>(
 
       nextPacketId += 1;
       stage = "renderer";
-      nextPacket = await options.renderer.prepare({
+      const rendererPacket = await options.renderer.prepare({
         frame,
         packetId,
         presentation,
         result,
       });
+      nextPacket = createPreparedFramePacket(
+        packetId,
+        frame,
+        result,
+        rendererPacket,
+      );
 
       if (shouldAbandonFrame()) {
         await disposeNextPacket();
         return;
       }
 
-      await options.renderer.present(nextPacket);
+      await options.renderer.present(nextPacket.rendererPacket);
 
       if (shouldAbandonFrame()) {
         await disposeNextPacket();
         return;
       }
 
-      const previousPacket = activePacket;
-
-      activePacket = nextPacket;
       activePacketId = packetId;
       activeDetectionFrame = result.detectionFrame;
       lastDiagnostics = result.diagnostics ?? null;
-      preparedFrames += 1;
+      preparedFrameCount += 1;
       presentedFrames += 1;
+      await preparedFrameStore.present(nextPacket);
       nextPacket = null;
-      await disposePacket(previousPacket);
     } catch (cause) {
       try {
         await disposeNextPacket();
@@ -240,7 +244,9 @@ export async function createMediaSession<TPayload, TPacket extends object>(
 
       nextPacket = null;
       try {
-        await disposePacket(packet);
+        if (packet) {
+          await preparedFrameStore.discard(packet);
+        }
       } catch (cause) {
         if (destroyed) {
           teardownErrors.push(cause);
@@ -344,8 +350,12 @@ export async function createMediaSession<TPayload, TPacket extends object>(
     pick(point, pickOptions) {
       assertActive("pick");
 
-      return activePacket && options.renderer.pick
-        ? options.renderer.pick(activePacket, point, pickOptions)
+      return preparedFrameStore.active && options.renderer.pick
+        ? options.renderer.pick(
+            preparedFrameStore.active.rendererPacket,
+            point,
+            pickOptions,
+          )
         : null;
     },
     async play() {
@@ -403,13 +413,10 @@ export async function createMediaSession<TPayload, TPacket extends object>(
   };
 
   async function destroyResources() {
-    const packet = activePacket;
-
-    activePacket = null;
     activePacketId = null;
     activeDetectionFrame = null;
 
-    await runCleanup(() => disposePacket(packet));
+    await runCleanup(() => preparedFrameStore.dispose());
     await releaseSource();
     await runCleanup(() => options.renderer.destroy?.());
 


### PR DESCRIPTION
# Description

Implements React Native hardening checkpoint 2 by internalizing prepared-frame ownership. The generic media session and saved-video pump now use a single internal packet store with one-packet retirement before Skia disposal, idempotent teardown, rollback for unpresented packets, and packet identity retained across pause/resume.

This is stacked on #16, which establishes the session core.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `npm run verify`
- Added prepared-frame-store lifecycle tests covering retirement, rollback, repeated cleanup, release failure, and resumed worklet ownership

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- None; experimental private React Native package only.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)