### PR TITLE
Restore smooth playback for dense demo fixture

### DIFF
--- a/demo/fixtures/horse_trail/fixture.meta.json
+++ b/demo/fixtures/horse_trail/fixture.meta.json
@@ -9,6 +9,7 @@
     "readyStatusLabel": "70s horse trail source media | browser-normalized WebM 30fps"
   },
   "presentation": {
+    "confidenceThreshold": 0.5,
     "keypointsEnabled": false,
     "polygonsEnabled": false
   },

--- a/demo/src/fixtures/demo-fixtures.test.ts
+++ b/demo/src/fixtures/demo-fixtures.test.ts
@@ -62,12 +62,13 @@ describe("geometry showcase fixture", () => {
     ]);
   });
 
-  it("disables unavailable vector layers by default for the horse trail", () => {
+  it("keeps the dense horse trail sample above its smooth-playback threshold", () => {
     const fixture = demoFixtures.find(
       ({ sampleName }) => sampleName === "horse_trail",
     );
 
     expect(fixture?.presentationDefaults).toEqual({
+      confidenceThreshold: 0.5,
       keypointsEnabled: false,
       polygonsEnabled: false,
     });

--- a/demo/src/fixtures/demo-fixtures.ts
+++ b/demo/src/fixtures/demo-fixtures.ts
@@ -76,6 +76,7 @@ interface DemoFixtureMeta {
 
 export interface DemoFixturePresentationDefaults {
   readonly boxesEnabled?: boolean;
+  readonly confidenceThreshold?: number;
   readonly focusEnabled?: boolean;
   readonly keypointsEnabled?: boolean;
   readonly labelsEnabled?: boolean;


### PR DESCRIPTION
# Description

Restores smooth preparation and playback for the default horse-trail demo without changing the canonical Roboflow annotation styling.

PR #14 lowered the shared demo confidence threshold from 0.5 to 0. On this unusually dense fixture, that increased mask preparation from 17.50 to 47.59 masks per frame on average. This change gives only the horse-trail fixture an explicit 0.5 initial threshold; other fixtures, upload mode, and the global canonical presentation defaults remain unchanged.

Local mask benchmarks measured PNG ID-mask preparation falling from 104.0 ms mean / 158.7 ms p95 to 41.4 ms mean / 47.5 ms p95 at the restored threshold.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran focused fixture and canonical presentation tests: 25 passed
- Ran the complete `npm run verify` suite: 494 Vitest tests plus formatting, lint, types, package/docs contracts, smoke tests, demo, examples, and benchmark builds
- Ran the mask compositor benchmark against representative horse-trail frames at thresholds 0 and 0.5
- Independent exact-commit review returned APPROVE with no actionable findings

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

- Hosting: deploy the demo site after merge.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)