### PR TITLE
Centralize React Native media session state

### DIFF
--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -108,6 +108,8 @@ export { MediaSessionError } from "./types/media-session";
 export type {
   MediaSession,
   MediaSessionErrorCode,
+  MediaSessionErrorStage,
+  MediaSessionErrorState,
   MediaSessionMediaState,
   MediaSessionOptions,
   MediaSessionState,

--- a/packages/react-native/src/media-session.ts
+++ b/packages/react-native/src/media-session.ts
@@ -25,6 +25,8 @@ export {
   MediaSessionError,
   type MediaSession,
   type MediaSessionErrorCode,
+  type MediaSessionErrorStage,
+  type MediaSessionErrorState,
   type MediaSessionMediaState,
   type MediaSessionOptions,
   type MediaSessionState,

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -39,6 +39,8 @@ export {
   MediaSessionError,
   type MediaSession,
   type MediaSessionErrorCode,
+  type MediaSessionErrorStage,
+  type MediaSessionErrorState,
   type MediaSessionMediaState,
   type MediaSessionOptions,
   type MediaSessionState,

--- a/packages/react-native/src/sessions/media-session-core.ts
+++ b/packages/react-native/src/sessions/media-session-core.ts
@@ -1,8 +1,4 @@
 import {
-  MediaSessionActivityKind,
-  MediaSessionActivityStatus,
-  MediaSessionMode,
-  MediaSessionStatus,
   type MediaRendererPresentation,
   type PlatformMediaFrame,
 } from "supervision-js-core";
@@ -13,6 +9,7 @@ import {
   type PreparedFramePacket,
 } from "../renderers/prepared-frame-packet";
 import { PreparedFrameStore } from "../renderers/prepared-frame-store";
+import { createMediaSessionStateSnapshot } from "./media-session-state";
 import {
   MediaSessionError,
   type MediaSession,
@@ -63,83 +60,25 @@ export async function createMediaSession<TPayload, TPacket extends object>(
   >(async (packet) => options.renderer.disposePacket?.(packet.rendererPacket));
 
   const state = (): MediaSessionState => {
-    const activities = [];
-
-    if (!opened) {
-      activities.push({
-        blockingPlayback: true,
-        blockingPresentation: true,
-        kind: MediaSessionActivityKind.MediaOpening,
-        label: "Opening media",
-        status: MediaSessionActivityStatus.Running,
-      });
-    }
-
-    if (processing) {
-      activities.push({
-        artifactKind: "mobile-frame",
-        blockingPlayback: options.source.mode !== MediaSessionMode.Stream,
-        blockingPresentation: true,
-        kind: MediaSessionActivityKind.RenderPreparing,
-        label: "Preparing frame",
-        pendingCount: 1,
-        preparedCount: preparedFrameCount,
-        status: MediaSessionActivityStatus.Running,
-      });
-    }
-
-    if (error) {
-      activities.push({
-        blockingPlayback: true,
-        blockingPresentation: true,
-        errorMessage: error.message,
-        kind: MediaSessionActivityKind.Error,
-        label: "Media session error",
-        status: MediaSessionActivityStatus.Error,
-      });
-    }
-
-    const status = destroyed
-      ? MediaSessionStatus.Destroyed
-      : error
-        ? MediaSessionStatus.Error
-        : !opened
-          ? MediaSessionStatus.Loading
-          : processing
-            ? MediaSessionStatus.Processing
-            : playing
-              ? MediaSessionStatus.Playing
-              : stopped || ended
-                ? MediaSessionStatus.Ready
-                : started && options.source.capabilities.pausable
-                  ? MediaSessionStatus.Paused
-                  : MediaSessionStatus.Ready;
-
-    return {
-      activities,
-      errorMessage: error?.message ?? null,
-      media: {
-        capabilities: options.source.capabilities,
-        opened,
-        timeline: options.source.timeline,
-      },
-      normalization: null,
-      playbackBlocked: activities.some((activity) => activity.blockingPlayback),
-      presentationBlocked: activities.some(
-        (activity) => activity.blockingPresentation,
-      ),
-      renderPreparation: {
-        activePacketId,
-        lastDiagnostics,
-        preparedFrames: preparedFrameCount,
-      },
-      renderer: {
-        activeDetectionFrame,
-        backend: options.renderer.backend,
-        presentedFrames,
-      },
-      status,
-    };
+    return createMediaSessionStateSnapshot({
+      activeDetectionFrame,
+      activePacketId,
+      capabilities: options.source.capabilities,
+      destroyed,
+      ended,
+      error,
+      lastDiagnostics,
+      mode: options.source.mode,
+      opened,
+      playing,
+      presentedFrames,
+      preparedFrames: preparedFrameCount,
+      processing,
+      rendererBackend: options.renderer.backend,
+      started,
+      stopped,
+      timeline: options.source.timeline,
+    });
   };
 
   const emit = () => {

--- a/packages/react-native/src/sessions/media-session-state.test.ts
+++ b/packages/react-native/src/sessions/media-session-state.test.ts
@@ -1,0 +1,79 @@
+import {
+  MediaSessionMode,
+  MediaSessionStatus,
+  MediaSourceStatus,
+} from "supervision-js-core";
+import { describe, expect, it } from "vitest";
+
+import { createMediaSessionStateSnapshot } from "./media-session-state";
+import { MediaSessionError } from "../types/media-session";
+
+const baseInput = {
+  activeDetectionFrame: null,
+  activePacketId: null,
+  capabilities: {
+    live: false,
+    pausable: true,
+    seekable: true,
+    stoppable: true,
+  },
+  destroyed: false,
+  ended: false,
+  error: null,
+  lastDiagnostics: null,
+  mode: MediaSessionMode.File,
+  opened: true,
+  playing: false,
+  presentedFrames: 0,
+  preparedFrames: 0,
+  processing: false,
+  rendererBackend: "fake",
+  started: true,
+  stopped: false,
+  timeline: { duration: 1, frameRate: 30, height: 10, width: 10 },
+} as const;
+
+describe("createMediaSessionStateSnapshot", () => {
+  it("reports explicit source readiness and stable source failure detail", () => {
+    const state = createMediaSessionStateSnapshot({
+      ...baseInput,
+      error: new MediaSessionError("source-open-failed", "file unavailable"),
+      opened: false,
+    });
+
+    expect(state).toMatchObject({
+      errorMessage: "file unavailable",
+      media: {
+        error: {
+          code: "source-open-failed",
+          message: "file unavailable",
+          stage: "source-open",
+        },
+        sourceStatus: MediaSourceStatus.Error,
+      },
+      status: MediaSessionStatus.Error,
+    });
+  });
+
+  it("keeps processor failures distinct from source readiness", () => {
+    const state = createMediaSessionStateSnapshot({
+      ...baseInput,
+      error: new MediaSessionError("processor-failed", "model failed"),
+    });
+
+    expect(state.media.sourceStatus).toBe(MediaSourceStatus.Ready);
+    expect(state.media.error?.stage).toBe("processor");
+    expect(state.status).toBe(MediaSessionStatus.Error);
+  });
+
+  it("reports destroyed source state after lifecycle teardown", () => {
+    const state = createMediaSessionStateSnapshot({
+      ...baseInput,
+      destroyed: true,
+      playing: false,
+    });
+
+    expect(state.media.sourceStatus).toBe(MediaSourceStatus.Destroyed);
+    expect(state.status).toBe(MediaSessionStatus.Destroyed);
+  });
+});

--- a/packages/react-native/src/sessions/media-session-state.ts
+++ b/packages/react-native/src/sessions/media-session-state.ts
@@ -1,0 +1,158 @@
+import {
+  MediaSessionActivityKind,
+  MediaSessionActivityStatus,
+  MediaSessionMode,
+  MediaSessionStatus,
+  MediaSourceStatus,
+  type MediaTimelineMetadata,
+} from "supervision-js-core";
+
+import type { MediaSessionCapabilities } from "../types/frame-source";
+import type {
+  MediaSessionError,
+  MediaSessionMediaState,
+  MediaSessionState,
+} from "../types/media-session";
+import type {
+  MediaSessionRendererState,
+  MediaSessionRenderPreparationState,
+} from "../types/renderer";
+
+export interface MediaSessionStateSnapshotInput {
+  readonly activeDetectionFrame: MediaSessionRendererState["activeDetectionFrame"];
+  readonly activePacketId: number | null;
+  readonly capabilities: MediaSessionCapabilities;
+  readonly destroyed: boolean;
+  readonly ended: boolean;
+  readonly error: MediaSessionError | null;
+  readonly lastDiagnostics: MediaSessionRenderPreparationState["lastDiagnostics"];
+  readonly mode: MediaSessionMode;
+  readonly opened: boolean;
+  readonly playing: boolean;
+  readonly presentedFrames: number;
+  readonly preparedFrames: number;
+  readonly processing: boolean;
+  readonly rendererBackend: string;
+  readonly started: boolean;
+  readonly stopped: boolean;
+  readonly timeline: MediaTimelineMetadata;
+}
+
+/** Creates one complete mobile lifecycle snapshot from renderer-neutral state. */
+export function createMediaSessionStateSnapshot(
+  input: MediaSessionStateSnapshotInput,
+): MediaSessionState {
+  const activities = [];
+
+  if (!input.opened) {
+    activities.push({
+      blockingPlayback: true,
+      blockingPresentation: true,
+      kind: MediaSessionActivityKind.MediaOpening,
+      label: "Opening media",
+      status: MediaSessionActivityStatus.Running,
+    });
+  }
+
+  if (input.processing) {
+    activities.push({
+      artifactKind: "mobile-frame",
+      blockingPlayback: input.mode !== MediaSessionMode.Stream,
+      blockingPresentation: true,
+      kind: MediaSessionActivityKind.RenderPreparing,
+      label: "Preparing frame",
+      pendingCount: 1,
+      preparedCount: input.preparedFrames,
+      status: MediaSessionActivityStatus.Running,
+    });
+  }
+
+  if (input.error) {
+    activities.push({
+      blockingPlayback: true,
+      blockingPresentation: true,
+      errorMessage: input.error.message,
+      kind: MediaSessionActivityKind.Error,
+      label: "Media session error",
+      status: MediaSessionActivityStatus.Error,
+    });
+  }
+
+  const media: MediaSessionMediaState = {
+    capabilities: input.capabilities,
+    error: input.error
+      ? {
+          code: input.error.code,
+          message: input.error.message,
+          stage: input.error.stage,
+        }
+      : null,
+    opened: input.opened,
+    sourceStatus: resolveSourceStatus(input),
+    timeline: input.timeline,
+  };
+
+  return {
+    activities,
+    errorMessage: input.error?.message ?? null,
+    media,
+    normalization: null,
+    playbackBlocked: activities.some((activity) => activity.blockingPlayback),
+    presentationBlocked: activities.some(
+      (activity) => activity.blockingPresentation,
+    ),
+    renderPreparation: {
+      activePacketId: input.activePacketId,
+      lastDiagnostics: input.lastDiagnostics,
+      preparedFrames: input.preparedFrames,
+    },
+    renderer: {
+      activeDetectionFrame: input.activeDetectionFrame,
+      backend: input.rendererBackend,
+      presentedFrames: input.presentedFrames,
+    },
+    status: resolveSessionStatus(input),
+  };
+}
+
+function resolveSessionStatus(input: MediaSessionStateSnapshotInput) {
+  if (input.destroyed) {
+    return MediaSessionStatus.Destroyed;
+  }
+
+  if (input.error) {
+    return MediaSessionStatus.Error;
+  }
+
+  if (!input.opened) {
+    return MediaSessionStatus.Loading;
+  }
+
+  if (input.processing) {
+    return MediaSessionStatus.Processing;
+  }
+
+  if (input.playing) {
+    return MediaSessionStatus.Playing;
+  }
+
+  if (input.stopped || input.ended) {
+    return MediaSessionStatus.Ready;
+  }
+
+  return input.started && input.capabilities.pausable
+    ? MediaSessionStatus.Paused
+    : MediaSessionStatus.Ready;
+}
+
+function resolveSourceStatus(input: MediaSessionStateSnapshotInput) {
+  if (input.destroyed) {
+    return MediaSourceStatus.Destroyed;
+  }
+
+  if (input.error?.stage === "source" || input.error?.stage === "source-open") {
+    return MediaSourceStatus.Error;
+  }
+
+  return input.opened ? MediaSourceStatus.Ready : MediaSourceStatus.Loading;
+}

--- a/packages/react-native/src/types/media-session.ts
+++ b/packages/react-native/src/types/media-session.ts
@@ -6,6 +6,7 @@ import type {
   MediaSessionStateListener as CoreMediaSessionStateListener,
   MediaSessionStateUnsubscribe as CoreMediaSessionStateUnsubscribe,
   MediaTimelineMetadata,
+  MediaSourceStatus,
 } from "supervision-js-core";
 
 import type { MediaFrameProcessor } from "./frame-processor";
@@ -27,6 +28,16 @@ export type MediaSessionErrorCode =
   | "source-open-failed"
   | "unsupported-operation";
 
+export type MediaSessionErrorStage =
+  "control" | "processor" | "renderer" | "source" | "source-open";
+
+/** Stable failure detail included in state snapshots without native causes. */
+export interface MediaSessionErrorState {
+  readonly code: MediaSessionErrorCode;
+  readonly message: string;
+  readonly stage: MediaSessionErrorStage;
+}
+
 /** Stable error shape for host UI, logs, and tests. */
 export class MediaSessionError extends Error {
   readonly code: MediaSessionErrorCode;
@@ -34,17 +45,25 @@ export class MediaSessionError extends Error {
   constructor(
     code: MediaSessionErrorCode,
     message: string,
-    options?: { readonly cause?: unknown },
+    options?: {
+      readonly cause?: unknown;
+      readonly stage?: MediaSessionErrorStage;
+    },
   ) {
     super(message, options);
     this.name = "MediaSessionError";
     this.code = code;
+    this.stage = options?.stage ?? resolveErrorStage(code);
   }
+
+  readonly stage: MediaSessionErrorStage;
 }
 
 export interface MediaSessionMediaState {
   readonly capabilities: MediaSessionCapabilities;
+  readonly error: MediaSessionErrorState | null;
   readonly opened: boolean;
+  readonly sourceStatus: MediaSourceStatus;
   readonly timeline: MediaTimelineMetadata;
 }
 
@@ -65,6 +84,28 @@ export interface MediaSessionOptions<TPayload, TPacket extends object> {
   readonly processor: MediaFrameProcessor<TPayload>;
   readonly renderer: MediaRendererAdapter<TPayload, TPacket>;
   readonly source: MediaFrameSource<TPayload>;
+}
+
+function resolveErrorStage(
+  code: MediaSessionErrorCode,
+): MediaSessionErrorStage {
+  if (code === "processor-failed") {
+    return "processor";
+  }
+
+  if (code === "renderer-failed") {
+    return "renderer";
+  }
+
+  if (code === "source-open-failed") {
+    return "source-open";
+  }
+
+  if (code === "source-failed") {
+    return "source";
+  }
+
+  return "control";
 }
 
 /**


### PR DESCRIPTION
# Description

Centralizes React Native media-session snapshot construction and exposes stable source readiness plus code and stage details for failures. This keeps native causes private while giving host UI deterministic lifecycle diagnostics.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added state snapshot tests for source, processor, and destroyed lifecycle states
- Ran npm run lint
- Ran npm run typecheck, including the React Native example
- Ran npm test (497 tests), boundary checks, and docs checks

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- No deployment required; experimental private React Native package only.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
