### PR TITLE
Add React Native saved-video source adapter

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -20,6 +20,11 @@
       "react-native": "./src/adapters/executorch.ts",
       "import": "./dist/adapters/executorch.js"
     },
+    "./adapters/video-file": {
+      "types": "./dist/adapters/video-file.d.ts",
+      "react-native": "./src/adapters/video-file.ts",
+      "import": "./dist/adapters/video-file.js"
+    },
     "./media-session": {
       "types": "./dist/media-session.d.ts",
       "react-native": "./src/media-session.ts",

--- a/packages/react-native/rollup.config.js
+++ b/packages/react-native/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from "@rollup/plugin-typescript";
 export default {
   input: {
     "adapters/executorch": "src/adapters/executorch.ts",
+    "adapters/video-file": "src/adapters/video-file.ts",
     index: "src/index.ts",
     "media-session": "src/media-session.ts",
     react: "src/react/index.ts",

--- a/packages/react-native/src/adapters/video-file.test.ts
+++ b/packages/react-native/src/adapters/video-file.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fixtures = vi.hoisted(() => {
+  const nativeSource = {
+    close: vi.fn(),
+    copyNextFrame: vi.fn(),
+    durationMs: 12_500,
+    frameHeight: 1080,
+    frameWidth: 1920,
+    nominalFrameRate: 30,
+    open: vi.fn(),
+  };
+  const boxedSource = { unbox: vi.fn(() => nativeSource) };
+  const createNativeSource = vi.fn<
+    () => {
+      readonly boxed: typeof boxedSource | null;
+      readonly fallbackReason?: string;
+    }
+  >(() => ({ boxed: boxedSource }));
+
+  return { boxedSource, createNativeSource, nativeSource };
+});
+
+vi.mock("../video-frame-source", () => ({
+  createReactNativeVideoFrameSource: fixtures.createNativeSource,
+}));
+
+import { createReactNativeVideoFileSource } from "./video-file";
+
+describe("createReactNativeVideoFileSource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("owns native open, metadata, and idempotent close", () => {
+    const source = createReactNativeVideoFileSource({
+      fileUri: "file:///basketball.mp4",
+    });
+
+    expect(source.timeline).toEqual({
+      duration: null,
+      frameRate: null,
+      height: 0,
+      width: 0,
+    });
+    expect(() => source.boxedSource).toThrow(/has not been opened/);
+
+    source.open();
+
+    expect(fixtures.createNativeSource).toHaveBeenCalledTimes(1);
+    expect(fixtures.nativeSource.open).toHaveBeenCalledWith(
+      "file:///basketball.mp4",
+    );
+    expect(source.boxedSource).toBe(fixtures.boxedSource);
+    expect(source.timeline).toEqual({
+      duration: 12.5,
+      frameRate: 30,
+      height: 1080,
+      width: 1920,
+    });
+
+    source.close();
+    source.close();
+    expect(fixtures.nativeSource.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps missing optional native dependencies diagnosable", () => {
+    fixtures.createNativeSource.mockReturnValueOnce({
+      boxed: null,
+      fallbackReason: "nitro-module-unavailable",
+    });
+    const source = createReactNativeVideoFileSource({
+      fileUri: "file:///missing.mp4",
+    });
+
+    expect(() => source.open()).toThrow(
+      "video file source unavailable: nitro-module-unavailable",
+    );
+  });
+
+  it("closes a partially opened native source before surfacing its error", () => {
+    fixtures.nativeSource.open.mockImplementationOnce(() => {
+      throw new Error("unsupported codec");
+    });
+    const source = createReactNativeVideoFileSource({
+      fileUri: "file:///unsupported.mp4",
+    });
+
+    expect(() => source.open()).toThrow("unsupported codec");
+    expect(fixtures.nativeSource.close).toHaveBeenCalledTimes(1);
+    expect(() => source.boxedSource).toThrow(/has not been opened/);
+  });
+});

--- a/packages/react-native/src/adapters/video-file.ts
+++ b/packages/react-native/src/adapters/video-file.ts
@@ -1,0 +1,109 @@
+import type { MediaTimelineMetadata } from "supervision-js-core";
+
+import {
+  createReactNativeVideoFrameSource,
+  type ReactNativeBoxedVideoFrameSource,
+  type ReactNativeVideoFrameHandle,
+  type ReactNativeVideoFrameSource,
+} from "../video-frame-source";
+
+/**
+ * File-backed native decoder boundary for the React Native media session.
+ *
+ * This adapter owns creation, opening, metadata lookup, and closing of the
+ * optional Nitro `VideoFrameSource`. The worklet pump remains in the legacy
+ * session for now, so the boxed source is exposed only to that package-owned
+ * implementation — application code never needs to unbox a hybrid object.
+ */
+export interface ReactNativeVideoFileSource {
+  /** Video metadata becomes available after `open()` succeeds. */
+  readonly timeline: MediaTimelineMetadata;
+  /** Stable only while the source is open; intended for package worklets. */
+  readonly boxedSource: ReactNativeBoxedVideoFrameSource;
+  close(): void;
+  open(): void;
+}
+
+export interface ReactNativeVideoFileSourceOptions {
+  readonly fileUri: string;
+}
+
+/**
+ * Creates an unopened saved-video adapter. Opening is separate so callers can
+ * report a stable construction failure and clean up transactionally.
+ */
+export function createReactNativeVideoFileSource(
+  options: ReactNativeVideoFileSourceOptions,
+): ReactNativeVideoFileSource {
+  let source: ReactNativeVideoFrameSource | null = null;
+  let boxedSource: ReactNativeBoxedVideoFrameSource | null = null;
+  let closed = false;
+
+  return {
+    get boxedSource() {
+      if (!boxedSource) {
+        throw new Error("Video file source has not been opened.");
+      }
+
+      return boxedSource;
+    },
+    close() {
+      if (!source || closed) {
+        return;
+      }
+
+      closed = true;
+      source.close();
+    },
+    open() {
+      if (source) {
+        throw new Error("Video file source is already open.");
+      }
+
+      const handle = createReactNativeVideoFrameSource();
+
+      if (!handle.boxed) {
+        throw new Error(
+          `video file source unavailable: ${handle.fallbackReason ?? "no native video frame source"}`,
+        );
+      }
+
+      boxedSource = handle.boxed;
+      source = boxedSource.unbox();
+
+      try {
+        source.open(options.fileUri);
+      } catch (error) {
+        try {
+          source.close();
+        } catch {
+          // Preserve the useful native open failure below.
+        }
+
+        source = null;
+        boxedSource = null;
+        throw error;
+      }
+    },
+    get timeline() {
+      return source
+        ? {
+            duration: source.durationMs / 1000,
+            frameRate: source.nominalFrameRate,
+            height: source.frameHeight,
+            width: source.frameWidth,
+          }
+        : EMPTY_VIDEO_TIMELINE;
+    },
+  };
+}
+
+const EMPTY_VIDEO_TIMELINE: MediaTimelineMetadata = {
+  duration: null,
+  frameRate: null,
+  height: 0,
+  width: 0,
+};
+
+/** Internal payload alias used by the saved-video session adapter. */
+export type ReactNativeVideoFileFrame = ReactNativeVideoFrameHandle;

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -29,10 +29,10 @@ import {
 } from "./skia";
 import { PreparedFrameStore } from "./renderers/prepared-frame-store";
 import {
-  createReactNativeVideoFrameSource,
   type ReactNativeBoxedVideoFrameSource,
   type ReactNativeVideoFrameHandle,
 } from "./video-frame-source";
+import { createReactNativeVideoFileSource } from "./adapters/video-file";
 
 export { createMediaSession } from "./sessions/media-session-core";
 export {
@@ -274,23 +274,16 @@ export function createReactNativeVideoSession(
   options: ReactNativeVideoSessionOptions,
 ): ReactNativeVideoSession {
   const vendors = resolveWorkletVendorModules();
-  const sourceHandle = createReactNativeVideoFrameSource();
+  const source = createReactNativeVideoFileSource({ fileUri: options.fileUri });
 
-  if (!sourceHandle.boxed) {
-    throw new Error(
-      `video session unavailable: ${sourceHandle.fallbackReason ?? "no native video frame source"}`,
-    );
-  }
+  source.open();
 
-  const boxedSource: ReactNativeBoxedVideoFrameSource = sourceHandle.boxed;
-  const source = boxedSource.unbox();
-
-  source.open(options.fileUri);
-
-  const durationMs = source.durationMs;
-  const frameWidth = source.frameWidth;
-  const frameHeight = source.frameHeight;
-  const nominalFrameRate = source.nominalFrameRate;
+  const boxedSource: ReactNativeBoxedVideoFrameSource = source.boxedSource;
+  const timeline = source.timeline;
+  const durationMs = (timeline.duration ?? 0) * 1000;
+  const frameWidth = timeline.width;
+  const frameHeight = timeline.height;
+  const nominalFrameRate = timeline.frameRate ?? 0;
 
   const emptyUniforms = createEmptyReactNativeLiveIdMaskUniforms();
   const frameImage = vendors.makeMutable<SkImage | null>(null);

--- a/tools/package-smoke.test.mjs
+++ b/tools/package-smoke.test.mjs
@@ -320,6 +320,8 @@ test("built style classes can be constructed by package consumers", async () => 
 test("built React Native subpath entries ship and resolve", async () => {
   const adapters =
     await import("../packages/react-native/dist/adapters/executorch.js");
+  const videoFile =
+    await import("../packages/react-native/dist/adapters/video-file.js");
   const mediaSession =
     await import("../packages/react-native/dist/media-session.js");
 
@@ -329,6 +331,7 @@ test("built React Native subpath entries ship and resolve", async () => {
     { x1: 2, y1: 7, x2: 4, y2: 9 },
   );
   assert.equal(typeof mediaSession.createMediaSession, "function");
+  assert.equal(typeof videoFile.createReactNativeVideoFileSource, "function");
   assert.deepEqual(Object.keys(mediaSession).sort(), [
     "MediaSessionActivityKind",
     "MediaSessionActivityStatus",


### PR DESCRIPTION
# Description

Introduces the optional `adapters/video-file` entrypoint, which owns native saved-video source creation, opening, metadata lookup, failed-open cleanup, and idempotent closing. The legacy video session now consumes this boundary instead of accessing the Nitro source directly.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added focused adapter tests for metadata, missing native dependencies, and failed-open cleanup
- Ran `npm run verify` (497 tests, package smoke, example React Native typecheck)

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- None; this is an experimental React Native package boundary.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)