### PR TITLE
Move React Native video worklets into package adapters

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -75,7 +75,6 @@ import {
   type ReactNativeFrameLayout,
   type ReactNativeIdMaskUniforms,
   loadReactNativeLiveIdMaskNativeBuilder,
-  type ReactNativeVideoFrameHandle,
   resolveReactNativeFrameLayout,
   resolveReactNativeLabelLayout,
   createEmptyReactNativeLiveIdMaskUniforms,
@@ -94,6 +93,7 @@ import {
   type ReactNativeSkiaMaskFrame,
 } from "supervision-js-react-native/skia";
 import {
+  createReactNativeClassMaskEffectsResolver,
   createReactNativeVideoSession,
   createReactNativeWorkletRuntime,
   type ReactNativeVideoSession,
@@ -123,7 +123,7 @@ import {
 } from "./src/debug-logging";
 import {
   createDetectionFrameFromExecutorchCocoPoses,
-  unrotateExecutorchUpBbox,
+  createExecutorchVideoFrameSerializer,
 } from "supervision-js-react-native/adapters/executorch";
 import {
   createInstantCvFreeShapeZone,
@@ -3269,89 +3269,18 @@ function VideoFileProof(props: {
     classEffectsShared.value = classEffects;
   }, [classEffects, classEffectsShared]);
 
-  // Inference, injected into the session as a worklet: ExecuTorch RF-DETR on
-  // the decoded frame, outputs un-rotated back into the upright video's
-  // coordinate space (see supervision-js-react-native/adapters/executorch).
-  const serializeVideoFrame = useCallback(
-    (
-      handle: ReactNativeVideoFrameHandle,
-      returnMaskAtOriginalResolution: boolean,
-    ) => {
-      "worklet";
-
-      const segmentFrame = runSegmentationOnFrame;
-
-      if (segmentFrame === null) {
-        return [];
-      }
-
-      // ExecuTorch's Frame type is structural: any object exposing a BGRA
-      // CVPixelBuffer pointer works. release() is a no-op because the packet
-      // lifecycle owns the buffer (it must stay alive for Skia to draw it
-      // after inference).
-      const rawDetections = segmentFrame(
-        {
-          getNativeBuffer: () => ({
-            pointer: handle.pointer,
-            release: () => {},
-          }),
-          isMirrored: false,
-          orientation: "up",
-        } as Parameters<typeof segmentFrame>[0],
-        false,
-        {
-          confidenceThreshold: 0.45,
-          maxInstances: LIVE_MAX_INSTANCES,
-          returnMaskAtOriginalResolution:
-            LIVE_RETURN_MASKS_AT_ORIGINAL_RESOLUTION &&
-            returnMaskAtOriginalResolution,
-        },
-      );
-      const serialized: LiveSerializedDetection[] = [];
-
-      for (let index = 0; index < rawDetections.length; index += 1) {
-        const detection = rawDetections[index]!;
-        const label: string =
-          typeof detection.label === "string" ? detection.label : "";
-
-        serialized[index] = {
-          bbox: unrotateExecutorchUpBbox(detection.bbox, handle.height),
-          color: resolveDetectionClassColorStyle(label).fill,
-          label,
-          mask: detection.mask,
-          maskHeight: detection.maskHeight,
-          maskRotatedCw: true,
-          maskWidth: detection.maskWidth,
-          score: detection.score,
-        };
-      }
-
-      return serialized;
-    },
+  const serializeVideoFrame = useMemo(
+    () =>
+      createExecutorchVideoFrameSerializer({
+        maxInstances: LIVE_MAX_INSTANCES,
+        returnMasksAtOriginalResolution:
+          LIVE_RETURN_MASKS_AT_ORIGINAL_RESOLUTION,
+        runOnFrame: runSegmentationOnFrame,
+      }),
     [runSegmentationOnFrame],
   );
-  // Redacted classes fill as opaque mosaic, spotlit ones punch through the
-  // veil; the session flags mask ids from this per-tick mapping.
-  const resolveVideoMaskEffects = useCallback(
-    (detections: readonly LiveSerializedDetection[]) => {
-      "worklet";
-
-      const effects = classEffectsShared.value;
-      const mosaicMaskIds: number[] = [];
-      const spotlightMaskIds: number[] = [];
-
-      for (let index = 0; index < detections.length; index += 1) {
-        const effect = effects[detections[index]!.label ?? ""];
-
-        if (effect === "redact") {
-          mosaicMaskIds[mosaicMaskIds.length] = index + 1;
-        } else if (effect === "spotlight") {
-          spotlightMaskIds[spotlightMaskIds.length] = index + 1;
-        }
-      }
-
-      return { mosaicMaskIds, spotlightMaskIds };
-    },
+  const resolveVideoMaskEffects = useMemo(
+    () => createReactNativeClassMaskEffectsResolver(classEffectsShared),
     [classEffectsShared],
   );
   const handleVideoEnded = useCallback(

--- a/packages/react-native/src/adapters/executorch.test.ts
+++ b/packages/react-native/src/adapters/executorch.test.ts
@@ -4,6 +4,7 @@ import { KeypointVisibility } from "supervision-js-core";
 
 import {
   createDetectionFrameFromExecutorchCocoPoses,
+  createExecutorchVideoFrameSerializer,
   EXECUTORCH_COCO_KEYPOINT_NAMES,
   unrotateExecutorchUpBbox,
   type ExecutorchBbox,
@@ -118,5 +119,81 @@ describe("createDetectionFrameFromExecutorchCocoPoses", () => {
     });
 
     expect(frame.detections).toEqual([]);
+  });
+});
+
+describe("createExecutorchVideoFrameSerializer", () => {
+  it("keeps decoded video handles alive while restoring upright detections", () => {
+    const runOnFrame = (
+      frame: { getNativeBuffer(): { pointer: bigint; release(): void } },
+      mirrorFrame: boolean,
+      options: {
+        confidenceThreshold: number;
+        maxInstances: number;
+        returnMaskAtOriginalResolution: boolean;
+      },
+    ) => {
+      expect(frame.getNativeBuffer().pointer).toBe(42n);
+      expect(mirrorFrame).toBe(false);
+      expect(options).toEqual({
+        confidenceThreshold: 0.45,
+        maxInstances: 4,
+        returnMaskAtOriginalResolution: false,
+      });
+
+      return [
+        {
+          bbox: { x1: 100, y1: 20, x2: 300, y2: 80 },
+          label: "person",
+          mask: new Uint8Array([1]),
+          maskHeight: 1,
+          maskWidth: 1,
+          score: 0.9,
+        },
+      ];
+    };
+    const serialize = createExecutorchVideoFrameSerializer({
+      maxInstances: 4,
+      runOnFrame,
+    });
+
+    expect(
+      serialize(
+        {
+          height: 200,
+          pointer: 42n,
+          release: () => {},
+          timestampMs: 0,
+          width: 100,
+        },
+        false,
+      ),
+    ).toMatchObject([
+      {
+        bbox: { x1: 20, x2: 80, y1: -100, y2: 100 },
+        label: "person",
+        maskRotatedCw: true,
+        score: 0.9,
+      },
+    ]);
+  });
+
+  it("returns no detections while the host model is unavailable", () => {
+    const serialize = createExecutorchVideoFrameSerializer({
+      runOnFrame: null,
+    });
+
+    expect(
+      serialize(
+        {
+          height: 100,
+          pointer: 0n,
+          release: () => {},
+          timestampMs: 0,
+          width: 100,
+        },
+        true,
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/react-native/src/adapters/executorch.ts
+++ b/packages/react-native/src/adapters/executorch.ts
@@ -1,8 +1,116 @@
 import {
   KeypointVisibility,
+  resolveDetectionClassColorStyle,
   type Detection,
   type DetectionFrame,
 } from "supervision-js-core";
+import type { ReactNativeLiveSerializedDetection } from "../index";
+import type { ReactNativeVideoFrameHandle } from "../video-frame-source";
+
+/**
+ * Worklet-safe structural runner shape. It deliberately does not import
+ * `react-native-executorch`: hosts keep model ownership and pass their
+ * hook-provided runner into this adapter.
+ */
+interface ExecutorchInstanceSegmentationRunner {
+  (
+    frame: {
+      getNativeBuffer(): { pointer: bigint; release(): void };
+      isMirrored: boolean;
+      orientation: "up";
+    },
+    mirrorFrame: boolean,
+    options: {
+      confidenceThreshold: number;
+      maxInstances: number;
+      returnMaskAtOriginalResolution: boolean;
+    },
+  ): readonly {
+    bbox: ExecutorchBbox;
+    label?: string;
+    mask: Uint8Array;
+    maskHeight: number;
+    maskWidth: number;
+    score?: number;
+  }[];
+}
+
+export interface ExecutorchVideoFrameSerializerOptions<TRunOnFrame = unknown> {
+  readonly confidenceThreshold?: number;
+  readonly maxInstances?: number;
+  readonly returnMasksAtOriginalResolution?: boolean;
+  readonly runOnFrame: TRunOnFrame | null;
+}
+
+/** Package-owned worklet passed to the saved-video session. */
+export type ExecutorchVideoFrameSerializer = (
+  handle: ReactNativeVideoFrameHandle,
+  returnMaskAtOriginalResolution: boolean,
+) => ReactNativeLiveSerializedDetection[];
+
+/**
+ * Converts the host's ExecuTorch segmentation runner into the saved-video
+ * session processor. Native-buffer wrapping, upright-frame coordinate repair,
+ * color resolution, and serialized mask ownership stay in the package so a
+ * consuming demo does not define worklets for video inference.
+ */
+export function createExecutorchVideoFrameSerializer<TRunOnFrame>(
+  options: ExecutorchVideoFrameSerializerOptions<TRunOnFrame>,
+): ExecutorchVideoFrameSerializer {
+  const runOnFrame =
+    options.runOnFrame as ExecutorchInstanceSegmentationRunner | null;
+  const confidenceThreshold = options.confidenceThreshold ?? 0.45;
+  const maxInstances = options.maxInstances ?? 6;
+  const returnMasksAtOriginalResolution =
+    options.returnMasksAtOriginalResolution ?? true;
+
+  return (handle, allowOriginalResolution) => {
+    "worklet";
+
+    if (runOnFrame === null) {
+      return [];
+    }
+
+    const rawDetections = runOnFrame(
+      {
+        getNativeBuffer: () => ({
+          pointer: handle.pointer,
+          // The session owns the decoded handle until Skia finishes its
+          // presentation copy; ExecuTorch must not release it.
+          release: () => {},
+        }),
+        isMirrored: false,
+        orientation: "up",
+      },
+      false,
+      {
+        confidenceThreshold,
+        maxInstances,
+        returnMaskAtOriginalResolution:
+          returnMasksAtOriginalResolution && allowOriginalResolution,
+      },
+    );
+    const serialized: ReactNativeLiveSerializedDetection[] = [];
+
+    for (let index = 0; index < rawDetections.length; index += 1) {
+      const detection = rawDetections[index]!;
+      const label = typeof detection.label === "string" ? detection.label : "";
+
+      serialized[index] = {
+        bbox: unrotateExecutorchUpBbox(detection.bbox, handle.height),
+        color: resolveDetectionClassColorStyle(label).fill,
+        label,
+        mask: detection.mask,
+        maskHeight: detection.maskHeight,
+        maskRotatedCw: true,
+        maskWidth: detection.maskWidth,
+        score: detection.score,
+      };
+    }
+
+    return serialized;
+  };
+}
 
 /**
  * ExecuTorch's frame orientation API is camera-centric: there is no value

--- a/packages/react-native/src/sessions.test.ts
+++ b/packages/react-native/src/sessions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  createReactNativeClassMaskEffectsResolver,
   createReactNativeVideoSession,
   createReactNativeWorkletRuntime,
   MediaSessionError,
@@ -34,6 +35,35 @@ describe("createReactNativeWorkletRuntime", () => {
   });
 });
 
+describe("createReactNativeClassMaskEffectsResolver", () => {
+  it("maps class effects to the matching one-based mask IDs", () => {
+    const resolveEffects = createReactNativeClassMaskEffectsResolver({
+      value: { person: "redact", ball: "spotlight" },
+    });
+
+    expect(
+      resolveEffects([
+        {
+          bbox: { x1: 0, x2: 1, y1: 0, y2: 1 },
+          color: 0,
+          label: "person",
+          mask: new Uint8Array([1]),
+          maskHeight: 1,
+          maskWidth: 1,
+        },
+        {
+          bbox: { x1: 0, x2: 1, y1: 0, y2: 1 },
+          color: 0,
+          label: "ball",
+          mask: new Uint8Array([1]),
+          maskHeight: 1,
+          maskWidth: 1,
+        },
+      ]),
+    ).toEqual({ mosaicMaskIds: [1], spotlightMaskIds: [2] });
+  });
+});
+
 describe("sessions entrypoint", () => {
   it("exposes the session-first contract alongside the legacy video factory", () => {
     expect(
@@ -46,6 +76,7 @@ describe("sessions entrypoint", () => {
       "MediaSessionError",
       "REACT_NATIVE_VIDEO_SESSION_DEFAULTS",
       "createMediaSession",
+      "createReactNativeClassMaskEffectsResolver",
       "createReactNativeVideoSession",
       "createReactNativeWorkletRuntime",
     ]);

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -123,6 +123,41 @@ export interface ReactNativeVideoSessionMaskEffects {
   readonly spotlightMaskIds: readonly number[];
 }
 
+export type ReactNativeClassMaskEffect = "redact" | "spotlight";
+export type ReactNativeClassMaskEffects = Readonly<
+  Record<string, ReactNativeClassMaskEffect>
+>;
+
+/**
+ * Creates the package-owned worklet that maps host-selected class effects to
+ * the mask IDs for one presented video frame.
+ */
+export function createReactNativeClassMaskEffectsResolver(
+  classEffects: ReactNativeSharedValue<ReactNativeClassMaskEffects>,
+): (
+  detections: readonly ReactNativeLiveSerializedDetection[],
+) => ReactNativeVideoSessionMaskEffects {
+  return (detections) => {
+    "worklet";
+
+    const effects = classEffects.value;
+    const mosaicMaskIds: number[] = [];
+    const spotlightMaskIds: number[] = [];
+
+    for (let index = 0; index < detections.length; index += 1) {
+      const effect = effects[detections[index]!.label ?? ""];
+
+      if (effect === "redact") {
+        mosaicMaskIds[mosaicMaskIds.length] = index + 1;
+      } else if (effect === "spotlight") {
+        spotlightMaskIds[spotlightMaskIds.length] = index + 1;
+      }
+    }
+
+    return { mosaicMaskIds, spotlightMaskIds };
+  };
+}
+
 export interface ReactNativeVideoSessionPresentationOptions {
   readonly borderWidth?: number;
   readonly edgeSmoothing?: number;

--- a/tools/package-smoke.test.mjs
+++ b/tools/package-smoke.test.mjs
@@ -326,6 +326,13 @@ test("built React Native subpath entries ship and resolve", async () => {
     await import("../packages/react-native/dist/media-session.js");
 
   assert.equal(typeof adapters.unrotateExecutorchUpBbox, "function");
+  assert.deepEqual(Object.keys(adapters).sort(), [
+    "EXECUTORCH_COCO_KEYPOINT_NAMES",
+    "EXECUTORCH_COCO_SKELETON_EDGES",
+    "createDetectionFrameFromExecutorchCocoPoses",
+    "createExecutorchVideoFrameSerializer",
+    "unrotateExecutorchUpBbox",
+  ]);
   assert.deepEqual(
     adapters.unrotateExecutorchUpBbox({ x1: 1, y1: 2, x2: 3, y2: 4 }, 10),
     { x1: 2, y1: 7, x2: 4, y2: 9 },


### PR DESCRIPTION
# Description

Moves saved-video ExecuTorch frame serialization and class mask-effect worklets from the React Native example into reusable package adapters. The demo now supplies model choice and UI state while the package owns the worklet implementations.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added focused serializer and class-effect resolver tests
- Ran `npm run verify` (497 tests, package smoke, and React Native example typecheck)

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Physical-device video validation remains required for the native/worklet checkpoint.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)