### PR TITLE
Expose React Native saved-video capabilities

### DIFF
--- a/docs/public/guides/public-api.md
+++ b/docs/public/guides/public-api.md
@@ -174,6 +174,12 @@ Mobile apps may eventually feed detections from on-device inference engines, but
 inference is outside the rendering package boundary. The library should render
 and interact with detections regardless of how they were produced.
 
+The experimental saved-video session is analysis-paced: it processes each
+decoded frame as quickly as inference permits rather than trying to match wall
+clock playback. It reports explicit capabilities; pause, resume, and stop are
+available, while seeking is intentionally unsupported until native decoding can
+reposition accurately.
+
 React Native currently shares editing geometry, picking, and gesture semantics
 through `createReactNativeAnnotationGestureAdapter`. Native hosts own drawing
 editing affordances from `AnnotationOverlayStyle` until a native overlay

--- a/packages/react-native/src/sessions.test.ts
+++ b/packages/react-native/src/sessions.test.ts
@@ -58,6 +58,14 @@ describe("saved-video session capabilities", () => {
       stoppable: true,
     });
   });
+
+  it("keeps the exported capability contract immutable at runtime", () => {
+    expect(Object.isFrozen(REACT_NATIVE_VIDEO_SESSION_CAPABILITIES)).toBe(true);
+    expect(
+      Reflect.set(REACT_NATIVE_VIDEO_SESSION_CAPABILITIES, "seekable", true),
+    ).toBe(false);
+    expect(REACT_NATIVE_VIDEO_SESSION_CAPABILITIES.seekable).toBe(false);
+  });
 });
 
 describe("createReactNativeWorkletRuntime", () => {

--- a/packages/react-native/src/sessions.test.ts
+++ b/packages/react-native/src/sessions.test.ts
@@ -6,6 +6,8 @@ import {
   createReactNativeWorkletRuntime,
   MediaSessionError,
   REACT_NATIVE_VIDEO_SESSION_DEFAULTS,
+  REACT_NATIVE_VIDEO_SESSION_CAPABILITIES,
+  REACT_NATIVE_VIDEO_SESSION_PLAYBACK_MODE,
 } from "./sessions";
 import {
   REACT_NATIVE_FILE_SESSION_DEFAULTS,
@@ -42,6 +44,18 @@ describe("React Native media session defaults", () => {
     expect(REACT_NATIVE_LIVE_SESSION_DEFAULTS).toEqual({
       maxInstances: 6,
       targetResolution: { height: 1280, width: 720 },
+    });
+  });
+});
+
+describe("saved-video session capabilities", () => {
+  it("declares analysis pacing and the absence of seek support", () => {
+    expect(REACT_NATIVE_VIDEO_SESSION_PLAYBACK_MODE).toBe("analysis-paced");
+    expect(REACT_NATIVE_VIDEO_SESSION_CAPABILITIES).toEqual({
+      live: false,
+      pausable: true,
+      seekable: false,
+      stoppable: true,
     });
   });
 });
@@ -91,7 +105,9 @@ describe("sessions entrypoint", () => {
       ).sort(),
     ).toEqual([
       "MediaSessionError",
+      "REACT_NATIVE_VIDEO_SESSION_CAPABILITIES",
       "REACT_NATIVE_VIDEO_SESSION_DEFAULTS",
+      "REACT_NATIVE_VIDEO_SESSION_PLAYBACK_MODE",
       "createMediaSession",
       "createReactNativeClassMaskEffectsResolver",
       "createReactNativeVideoSession",

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -89,13 +89,12 @@ export const REACT_NATIVE_VIDEO_SESSION_PLAYBACK_MODE = "analysis-paced";
  * The current native file source supports start, pause/resume, and stop. It
  * does not expose seeking until its decoder can reposition accurately.
  */
-export const REACT_NATIVE_VIDEO_SESSION_CAPABILITIES: MediaSessionCapabilities =
-  {
-    live: false,
-    pausable: true,
-    seekable: false,
-    stoppable: true,
-  };
+export const REACT_NATIVE_VIDEO_SESSION_CAPABILITIES = Object.freeze({
+  live: false,
+  pausable: true,
+  seekable: false,
+  stoppable: true,
+} satisfies MediaSessionCapabilities);
 
 /** Slim per-frame detection summary delivered to the JS thread. */
 export interface ReactNativeVideoSessionDetection {

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -29,6 +29,7 @@ import {
 } from "./skia";
 import { PreparedFrameStore } from "./renderers/prepared-frame-store";
 import { REACT_NATIVE_FILE_SESSION_DEFAULTS } from "./sessions/media-session-defaults";
+import type { MediaSessionCapabilities } from "./types/frame-source";
 import {
   type ReactNativeBoxedVideoFrameSource,
   type ReactNativeVideoFrameHandle,
@@ -80,6 +81,21 @@ export type ReactNativeWorkletRuntimeHandle = object;
 /** @deprecated Prefer `REACT_NATIVE_FILE_SESSION_DEFAULTS`. */
 export const REACT_NATIVE_VIDEO_SESSION_DEFAULTS =
   REACT_NATIVE_FILE_SESSION_DEFAULTS;
+
+/** Saved-video playback processes every decoded frame as quickly as inference allows. */
+export const REACT_NATIVE_VIDEO_SESSION_PLAYBACK_MODE = "analysis-paced";
+
+/**
+ * The current native file source supports start, pause/resume, and stop. It
+ * does not expose seeking until its decoder can reposition accurately.
+ */
+export const REACT_NATIVE_VIDEO_SESSION_CAPABILITIES: MediaSessionCapabilities =
+  {
+    live: false,
+    pausable: true,
+    seekable: false,
+    stoppable: true,
+  };
 
 /** Slim per-frame detection summary delivered to the JS thread. */
 export interface ReactNativeVideoSessionDetection {
@@ -197,10 +213,12 @@ export interface ReactNativeVideoSessionOptions {
 }
 
 export interface ReactNativeVideoSession {
+  readonly capabilities: MediaSessionCapabilities;
   readonly durationMs: number;
   readonly frameHeight: number;
   readonly frameWidth: number;
   readonly nominalFrameRate: number;
+  readonly playbackMode: typeof REACT_NATIVE_VIDEO_SESSION_PLAYBACK_MODE;
   /** Presentation lanes for the UI: media frame, mask, and its uniforms. */
   readonly frameImage: ReactNativeSharedValue<SkImage | null>;
   readonly maskImage: ReactNativeSharedValue<SkImage | null>;
@@ -610,6 +628,7 @@ export function createReactNativeVideoSession(
   schedulePump();
 
   return {
+    capabilities: REACT_NATIVE_VIDEO_SESSION_CAPABILITIES,
     durationMs,
     frameHeight,
     frameImage,
@@ -617,6 +636,7 @@ export function createReactNativeVideoSession(
     maskImage,
     maskUniforms,
     nominalFrameRate,
+    playbackMode: REACT_NATIVE_VIDEO_SESSION_PLAYBACK_MODE,
     destroy() {
       if (destroyed) {
         return;


### PR DESCRIPTION
# Description

Makes saved-video analysis pacing and source capabilities explicit in the experimental React Native session API. Hosts can now see that the current source is finite, pausable, stoppable, and non-seekable instead of inferring behavior from platform details.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added capability and playback-mode tests
- Ran `npm run verify` (495 tests, package smoke, example React Native typecheck)

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- No behavior change; physical-device video validation remains required for native playback.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)