### PR TITLE
Harden React Native prepared frame teardown

### DIFF
--- a/packages/react-native/src/renderers/prepared-frame-store.test.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.test.ts
@@ -133,7 +133,7 @@ describe("PreparedFrameStore", () => {
     expect(dispose.mock.calls.map(([next]) => next.packetId)).toEqual([2, 1]);
   });
 
-  it("restores worklet-owned packets and disposes them synchronously", () => {
+  it("transfers worklet-owned packets across successive pump ticks", () => {
     const dispose = vi.fn();
     const initial = new PreparedFrameStore((next: Packet) =>
       dispose(next.packetId),
@@ -141,14 +141,37 @@ describe("PreparedFrameStore", () => {
 
     initial.presentNow(packet(1));
     initial.presentNow(packet(2));
-    const resumed = new PreparedFrameStore((next: Packet) =>
+    const secondTick = new PreparedFrameStore((next: Packet) =>
       dispose(next.packetId),
     );
 
-    resumed.restore(initial.snapshot());
-    resumed.presentNow(packet(3));
-    resumed.disposeNow();
+    const snapshot = initial.snapshot();
+    expect(initial.active).toBeNull();
+    initial.disposeNow();
+    expect(dispose).not.toHaveBeenCalled();
+
+    secondTick.restore(snapshot);
+    secondTick.presentNow(packet(3));
+    const secondSnapshot = secondTick.snapshot();
+    const finalTick = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+
+    finalTick.restore(secondSnapshot);
+    finalTick.disposeNow();
 
     expect(dispose.mock.calls.map(([id]) => id)).toEqual([1, 3, 2]);
+  });
+
+  it("rejects restore into a store that already owns packets", async () => {
+    const store = new PreparedFrameStore(() => undefined);
+    const source = new PreparedFrameStore(() => undefined);
+
+    await store.present(packet(1));
+    const snapshot = source.snapshot();
+
+    expect(() => store.restore(snapshot)).toThrow(
+      "Cannot restore over owned PreparedFrameStore packets.",
+    );
   });
 });

--- a/packages/react-native/src/renderers/prepared-frame-store.test.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.test.ts
@@ -79,6 +79,46 @@ describe("PreparedFrameStore", () => {
     expect(dispose.mock.calls.map(([id]) => id)).toEqual([2, 1]);
   });
 
+  it("shares concurrent teardown and releases a packet that arrives afterward", async () => {
+    const dispose = vi.fn();
+    const store = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+
+    await store.present(packet(1));
+    await store.present(packet(2));
+
+    const firstDispose = store.dispose();
+    const secondDispose = store.dispose();
+    expect(secondDispose).toBe(firstDispose);
+    await Promise.all([firstDispose, secondDispose]);
+
+    await store.present(packet(3));
+
+    expect(store.active).toBeNull();
+    expect(dispose.mock.calls.map(([id]) => id)).toEqual([2, 1, 3]);
+  });
+
+  it("releases every packet exactly once across a long presentation run", async () => {
+    const dispose = vi.fn();
+    const store = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+    const packetCount = 1_000;
+
+    for (let packetId = 0; packetId < packetCount; packetId += 1) {
+      await store.present(packet(packetId));
+    }
+    await store.dispose();
+
+    const releasedIds = dispose.mock.calls
+      .map(([id]) => id)
+      .sort((a, b) => a - b);
+    expect(releasedIds).toEqual(
+      Array.from({ length: packetCount }, (_, packetId) => packetId),
+    );
+  });
+
   it("continues cleanup after one packet fails to release", async () => {
     const dispose = vi.fn((next: Packet) => {
       if (next.packetId === 2) {

--- a/packages/react-native/src/renderers/prepared-frame-store.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.ts
@@ -10,6 +10,8 @@ export class PreparedFrameStore<TPacket extends object> {
   __workletClass = true;
   private activePacket: TPacket | null = null;
   private retiredPacket: TPacket | null = null;
+  private disposed = false;
+  private disposePromise: Promise<void> | null = null;
   private readonly releasedPackets = new WeakSet<object>();
 
   constructor(
@@ -37,6 +39,10 @@ export class PreparedFrameStore<TPacket extends object> {
   }) {
     "worklet";
 
+    if (this.disposed) {
+      throw new Error("Cannot restore a disposed PreparedFrameStore.");
+    }
+
     this.activePacket = snapshot.active;
     this.retiredPacket = snapshot.retired;
   }
@@ -47,12 +53,22 @@ export class PreparedFrameStore<TPacket extends object> {
    * dispose packets once they pass them here.
    */
   async present(packet: TPacket) {
+    if (this.disposed) {
+      await this.release(packet);
+      return;
+    }
+
     await this.release(this.promote(packet));
   }
 
   /** Synchronous worklet variant for native render-handle disposal. */
   presentNow(packet: TPacket) {
     "worklet";
+
+    if (this.disposed) {
+      this.releaseNow(packet);
+      return;
+    }
 
     this.releaseNow(this.promote(packet));
   }
@@ -76,32 +92,46 @@ export class PreparedFrameStore<TPacket extends object> {
   }
 
   /** Idempotently releases every packet still owned by the store. */
-  async dispose() {
+  dispose() {
+    if (this.disposePromise) {
+      return this.disposePromise;
+    }
+
+    this.disposed = true;
     const activePacket = this.activePacket;
     const retiredPacket = this.retiredPacket;
 
     this.activePacket = null;
     this.retiredPacket = null;
 
-    const errors: unknown[] = [];
+    this.disposePromise = (async () => {
+      const errors: unknown[] = [];
 
-    for (const packet of [activePacket, retiredPacket]) {
-      try {
-        await this.release(packet);
-      } catch (error) {
-        errors.push(error);
+      for (const packet of [activePacket, retiredPacket]) {
+        try {
+          await this.release(packet);
+        } catch (error) {
+          errors.push(error);
+        }
       }
-    }
 
-    if (errors.length > 0) {
-      throw errors[0];
-    }
+      if (errors.length > 0) {
+        throw errors[0];
+      }
+    })();
+
+    return this.disposePromise;
   }
 
   /** Synchronously releases all packets owned by a worklet store. */
   disposeNow() {
     "worklet";
 
+    if (this.disposed) {
+      return;
+    }
+
+    this.disposed = true;
     const activePacket = this.activePacket;
     const retiredPacket = this.retiredPacket;
 

--- a/packages/react-native/src/renderers/prepared-frame-store.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.ts
@@ -25,11 +25,24 @@ export class PreparedFrameStore<TPacket extends object> {
     return this.activePacket;
   }
 
-  /** Captures store ownership so a paused worklet can resume safely. */
+  /**
+   * Transfers packet ownership to a fresh store, such as the next worklet
+   * invocation. The source store is sealed without disposing those packets:
+   * the returned snapshot is now their sole owner until `restore()` claims it.
+   */
   snapshot() {
     "worklet";
 
-    return { active: this.activePacket, retired: this.retiredPacket };
+    const snapshot = {
+      active: this.activePacket,
+      retired: this.retiredPacket,
+    };
+
+    this.activePacket = null;
+    this.retiredPacket = null;
+    this.disposed = true;
+
+    return snapshot;
   }
 
   /** Restores a snapshot into a newly created single-writer worklet store. */
@@ -41,6 +54,9 @@ export class PreparedFrameStore<TPacket extends object> {
 
     if (this.disposed) {
       throw new Error("Cannot restore a disposed PreparedFrameStore.");
+    }
+    if (this.activePacket || this.retiredPacket) {
+      throw new Error("Cannot restore over owned PreparedFrameStore packets.");
     }
 
     this.activePacket = snapshot.active;

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -355,7 +355,7 @@ export function createReactNativeVideoSession(
     "worklet";
 
     const pumpSource = boxedSource.unbox();
-    const preparedFrameStore = createPreparedFrameStore();
+    let preparedFrameStore = createPreparedFrameStore();
     const startedAt = Date.now();
     const framePixels = pumpSource.frameWidth * pumpSource.frameHeight;
     const returnMasksAtOriginalResolution = framePixels <= fullResMaskMaxPixels;
@@ -499,6 +499,7 @@ export function createReactNativeVideoSession(
           preparedFrameStore.presentNow(packet);
         } finally {
           preparedFrameStoreState.value = preparedFrameStore.snapshot();
+          preparedFrameStore = createPreparedFrameStore();
         }
 
         processedFrames += 1;


### PR DESCRIPTION
# Description

Hardens the internal React Native prepared-frame owner against teardown races. A late prepared packet is released instead of becoming active after teardown, concurrent asynchronous teardown shares one cleanup promise, and a stress test verifies exactly-once disposal across 1,000 packet swaps.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added teardown-race and 1,000-swap lifecycle tests for PreparedFrameStore
- Ran npm run verify (496 tests, package smoke, and demo build)
- Ran the worklet transform fixture and React Native package typecheck

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Saved-video physical-device lifecycle validation remains pending because no iPhone is currently connected.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)