### PR TITLE
Transfer React Native prepared frame ownership safely

### DIFF
--- a/packages/react-native/src/renderers/prepared-frame-store.test.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.test.ts
@@ -133,7 +133,7 @@ describe("PreparedFrameStore", () => {
     expect(dispose.mock.calls.map(([next]) => next.packetId)).toEqual([2, 1]);
   });
 
-  it("restores worklet-owned packets and disposes them synchronously", () => {
+  it("transfers worklet-owned packets and disposes them synchronously", () => {
     const dispose = vi.fn();
     const initial = new PreparedFrameStore((next: Packet) =>
       dispose(next.packetId),
@@ -145,10 +145,27 @@ describe("PreparedFrameStore", () => {
       dispose(next.packetId),
     );
 
-    resumed.restore(initial.snapshot());
+    const snapshot = initial.snapshot();
+    expect(initial.active).toBeNull();
+    initial.disposeNow();
+    expect(dispose).not.toHaveBeenCalled();
+
+    resumed.restore(snapshot);
     resumed.presentNow(packet(3));
     resumed.disposeNow();
 
     expect(dispose.mock.calls.map(([id]) => id)).toEqual([1, 3, 2]);
+  });
+
+  it("rejects restore into a store that already owns packets", async () => {
+    const store = new PreparedFrameStore(() => undefined);
+    const source = new PreparedFrameStore(() => undefined);
+
+    await store.present(packet(1));
+    const snapshot = source.snapshot();
+
+    expect(() => store.restore(snapshot)).toThrow(
+      "Cannot restore over owned PreparedFrameStore packets.",
+    );
   });
 });

--- a/packages/react-native/src/renderers/prepared-frame-store.test.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.test.ts
@@ -133,7 +133,7 @@ describe("PreparedFrameStore", () => {
     expect(dispose.mock.calls.map(([next]) => next.packetId)).toEqual([2, 1]);
   });
 
-  it("transfers worklet-owned packets and disposes them synchronously", () => {
+  it("transfers worklet-owned packets across successive pump ticks", () => {
     const dispose = vi.fn();
     const initial = new PreparedFrameStore((next: Packet) =>
       dispose(next.packetId),
@@ -141,7 +141,7 @@ describe("PreparedFrameStore", () => {
 
     initial.presentNow(packet(1));
     initial.presentNow(packet(2));
-    const resumed = new PreparedFrameStore((next: Packet) =>
+    const secondTick = new PreparedFrameStore((next: Packet) =>
       dispose(next.packetId),
     );
 
@@ -150,9 +150,15 @@ describe("PreparedFrameStore", () => {
     initial.disposeNow();
     expect(dispose).not.toHaveBeenCalled();
 
-    resumed.restore(snapshot);
-    resumed.presentNow(packet(3));
-    resumed.disposeNow();
+    secondTick.restore(snapshot);
+    secondTick.presentNow(packet(3));
+    const secondSnapshot = secondTick.snapshot();
+    const finalTick = new PreparedFrameStore((next: Packet) =>
+      dispose(next.packetId),
+    );
+
+    finalTick.restore(secondSnapshot);
+    finalTick.disposeNow();
 
     expect(dispose.mock.calls.map(([id]) => id)).toEqual([1, 3, 2]);
   });

--- a/packages/react-native/src/renderers/prepared-frame-store.ts
+++ b/packages/react-native/src/renderers/prepared-frame-store.ts
@@ -25,11 +25,24 @@ export class PreparedFrameStore<TPacket extends object> {
     return this.activePacket;
   }
 
-  /** Captures store ownership so a paused worklet can resume safely. */
+  /**
+   * Transfers packet ownership to a fresh store, such as the next worklet
+   * invocation. The source store is sealed without disposing those packets:
+   * the returned snapshot is now their sole owner until `restore()` claims it.
+   */
   snapshot() {
     "worklet";
 
-    return { active: this.activePacket, retired: this.retiredPacket };
+    const snapshot = {
+      active: this.activePacket,
+      retired: this.retiredPacket,
+    };
+
+    this.activePacket = null;
+    this.retiredPacket = null;
+    this.disposed = true;
+
+    return snapshot;
   }
 
   /** Restores a snapshot into a newly created single-writer worklet store. */
@@ -41,6 +54,9 @@ export class PreparedFrameStore<TPacket extends object> {
 
     if (this.disposed) {
       throw new Error("Cannot restore a disposed PreparedFrameStore.");
+    }
+    if (this.activePacket || this.retiredPacket) {
+      throw new Error("Cannot restore over owned PreparedFrameStore packets.");
     }
 
     this.activePacket = snapshot.active;

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -355,7 +355,7 @@ export function createReactNativeVideoSession(
     "worklet";
 
     const pumpSource = boxedSource.unbox();
-    const preparedFrameStore = createPreparedFrameStore();
+    let preparedFrameStore = createPreparedFrameStore();
     const startedAt = Date.now();
     const framePixels = pumpSource.frameWidth * pumpSource.frameHeight;
     const returnMasksAtOriginalResolution = framePixels <= fullResMaskMaxPixels;
@@ -499,6 +499,7 @@ export function createReactNativeVideoSession(
           preparedFrameStore.presentNow(packet);
         } finally {
           preparedFrameStoreState.value = preparedFrameStore.snapshot();
+          preparedFrameStore = createPreparedFrameStore();
         }
 
         processedFrames += 1;


### PR DESCRIPTION
# Description

Makes PreparedFrameStore snapshot state an ownership transfer instead of a copy. The source store is sealed without disposing the transferred packets, and restore now rejects overwriting packets already owned by its target store. This prevents double-disposal when a saved-video worklet resumes with the same prepared resources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added transfer and overwrite-protection lifecycle tests
- Ran npm run verify (497 tests, package smoke, and demo build)
- Ran focused worklet-transform, session, typecheck, and boundary checks

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Merge after PR #25 because this is a stacked ownership hardening change.
- Saved-video physical-device lifecycle validation remains pending because no iPhone is currently connected.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)