### PR TITLE
Fix rolling detection buffer playback stalls

### DIFF
--- a/packages/core/src/detections/buffered-detection-timeline.test.ts
+++ b/packages/core/src/detections/buffered-detection-timeline.test.ts
@@ -125,9 +125,10 @@ describe("buffered detection timeline", () => {
     version += 1;
     await timeline.prepare(0);
 
-    expect(getBufferedDetectionTimelineFrameSnapshot(timeline)).not.toBe(
-      firstSnapshot,
-    );
+    const revisedSnapshot = getBufferedDetectionTimelineFrameSnapshot(timeline);
+
+    expect(revisedSnapshot).not.toBe(firstSnapshot);
+    expect(revisedSnapshot[0]).not.toBe(firstSnapshot[0]);
     expect(source.loadFrames).toHaveBeenCalledTimes(2);
   });
 
@@ -288,6 +289,106 @@ describe("buffered detection timeline", () => {
     });
     expect(source.loadFrames).toHaveBeenNthCalledWith(1, 0, 5);
     expect(source.loadFrames).toHaveBeenNthCalledWith(2, 0, 5.5);
+  });
+
+  it("coalesces rolling prefetch while allowing the active load to commit", async () => {
+    const firstRefresh = createDeferred<DetectionFrame[]>();
+    const latestRefresh = createDeferred<DetectionFrame[]>();
+    const source = {
+      loadFrames: vi
+        .fn()
+        .mockResolvedValueOnce(frames)
+        .mockImplementationOnce(() => firstRefresh.promise)
+        .mockImplementationOnce(() => latestRefresh.promise),
+    };
+    const timeline = createBufferedDetectionTimeline({
+      bufferAheadSeconds: 5,
+      bufferBehindSeconds: 0.5,
+      refreshIntervalSeconds: 0.5,
+      source,
+    });
+
+    await timeline.prepare(0);
+    timeline.prefetch(0.5);
+    await vi.waitFor(() => expect(source.loadFrames).toHaveBeenCalledTimes(2));
+
+    for (let frameIndex = 18; frameIndex <= 36; frameIndex += 1) {
+      timeline.prefetch(frameIndex / 30);
+    }
+
+    expect(source.loadFrames).toHaveBeenCalledTimes(2);
+
+    firstRefresh.resolve(frames);
+    await vi.waitFor(() => expect(timeline.getState().bufferEndTime).toBe(5.5));
+    await vi.waitFor(() => expect(source.loadFrames).toHaveBeenCalledTimes(3));
+    expect(source.loadFrames).toHaveBeenLastCalledWith(0.7, 6.2);
+
+    latestRefresh.resolve(frames);
+    await vi.waitFor(() => expect(timeline.getState().bufferEndTime).toBe(6.2));
+    expect(source.loadFrames).toHaveBeenCalledTimes(3);
+  });
+
+  it("drops queued rolling work after a newer navigation load starts", async () => {
+    const rollingRefresh = createDeferred<DetectionFrame[]>();
+    const navigationLoad = createDeferred<DetectionFrame[]>();
+    const source = {
+      loadFrames: vi
+        .fn()
+        .mockResolvedValueOnce(frames)
+        .mockImplementationOnce(() => rollingRefresh.promise)
+        .mockImplementationOnce(() => navigationLoad.promise),
+    };
+    const timeline = createBufferedDetectionTimeline({
+      bufferAheadSeconds: 5,
+      bufferBehindSeconds: 0.5,
+      refreshIntervalSeconds: 0.5,
+      source,
+    });
+
+    await timeline.prepare(0);
+    timeline.prefetch(0.5);
+    await vi.waitFor(() => expect(source.loadFrames).toHaveBeenCalledTimes(2));
+    timeline.prefetch(1.2);
+
+    const navigation = timeline.prepare(10);
+
+    await vi.waitFor(() => expect(source.loadFrames).toHaveBeenCalledTimes(3));
+    expect(source.loadFrames).toHaveBeenLastCalledWith(9.5, 15);
+
+    navigationLoad.resolve(frames);
+    await navigation;
+    rollingRefresh.resolve(frames);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(timeline.getState().bufferStartTime).toBe(9.5);
+    expect(timeline.getState().bufferEndTime).toBe(15);
+    expect(source.loadFrames).toHaveBeenCalledTimes(3);
+  });
+
+  it("retains unchanged internal frames across an immutable rolling window", async () => {
+    const source = { loadFrames: vi.fn(async () => frames) };
+    const timeline = createBufferedDetectionTimeline({
+      bufferAheadSeconds: 5,
+      bufferBehindSeconds: 0.5,
+      refreshIntervalSeconds: 0.5,
+      source,
+    });
+
+    await timeline.prepare(0);
+    const initialSnapshot = getBufferedDetectionTimelineFrameSnapshot(timeline);
+    const initialPublicFrame = timeline.getBufferedFrames()[0];
+
+    timeline.prefetch(0.5);
+    await vi.waitFor(() => expect(source.loadFrames).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(timeline.getState().bufferEndTime).toBe(5.5));
+    const refreshedSnapshot =
+      getBufferedDetectionTimelineFrameSnapshot(timeline);
+
+    expect(refreshedSnapshot).not.toBe(initialSnapshot);
+    expect(refreshedSnapshot[0]).toBe(initialSnapshot[0]);
+    expect(timeline.getBufferedFrames()[0]).not.toBe(initialPublicFrame);
+    expect(timeline.getBufferedFrames()[0]).not.toBe(refreshedSnapshot[0]);
   });
 
   it("hydrates loop-crossing hot buffers from tail and head source ranges", async () => {

--- a/packages/core/src/detections/buffered-detection-timeline.ts
+++ b/packages/core/src/detections/buffered-detection-timeline.ts
@@ -81,6 +81,9 @@ export function createBufferedDetectionTimeline(
       }
     | undefined;
   let incrementalRefresh: Promise<void> | undefined;
+  let pendingPrefetch:
+    { readonly loadId: number; readonly mediaTime: number } | undefined;
+  let prefetchPump: Promise<void> | undefined;
 
   const getSourceVersion = (
     ranges?: readonly DetectionFrameSourceVersionRange[],
@@ -141,9 +144,16 @@ export function createBufferedDetectionTimeline(
           return;
         }
 
-        buffer = copySortedDetectionFrames(frameRanges.flat());
+        const committedSourceVersion = getSourceVersion(sourceRanges);
+        const loadedBuffer = copySortedDetectionFrames(frameRanges.flat());
+
+        buffer =
+          bufferedSourceVersion !== null &&
+          bufferedSourceVersion === committedSourceVersion
+            ? reuseBufferedFrameSnapshots(buffer, loadedBuffer)
+            : loadedBuffer;
         bufferedVersionRange = versionRange;
-        bufferedSourceVersion = getSourceVersion(sourceRanges);
+        bufferedSourceVersion = committedSourceVersion;
         state = {
           bufferEndTime: endTime,
           bufferStartTime: startTime,
@@ -276,22 +286,8 @@ export function createBufferedDetectionTimeline(
         return;
       }
 
-      if (shouldRefreshRollingWindow(mediaTime)) {
-        void loadWindow(mediaTime).catch(() => undefined);
-        return;
-      }
-
-      const comparableMediaTime = getComparableMediaTime(mediaTime);
-
-      if (
-        inFlight &&
-        comparableMediaTime >= inFlight.startTime &&
-        comparableMediaTime <= inFlight.endTime
-      ) {
-        return;
-      }
-
-      void refreshBuffer(mediaTime).catch(() => undefined);
+      pendingPrefetch = { loadId, mediaTime };
+      pumpPrefetchQueue();
     },
 
     selectFrame(mediaTime) {
@@ -326,6 +322,7 @@ export function createBufferedDetectionTimeline(
       }
 
       destroyed = true;
+      pendingPrefetch = undefined;
       buffer = [];
       bufferedSourceVersion = null;
       bufferedVersionRange = null;
@@ -344,6 +341,49 @@ export function createBufferedDetectionTimeline(
   bufferedFrameSnapshots.set(timeline, () => buffer);
 
   return timeline;
+
+  function pumpPrefetchQueue() {
+    if (destroyed || prefetchPump) {
+      return;
+    }
+
+    prefetchPump = drainPrefetchQueue().finally(() => {
+      prefetchPump = undefined;
+
+      if (!destroyed && pendingPrefetch) {
+        pumpPrefetchQueue();
+      }
+    });
+  }
+
+  async function drainPrefetchQueue() {
+    while (!destroyed && pendingPrefetch) {
+      if (inFlight) {
+        await inFlight.promise.catch(() => undefined);
+        continue;
+      }
+
+      const request = pendingPrefetch;
+
+      pendingPrefetch = undefined;
+
+      if (request.loadId !== loadId) {
+        continue;
+      }
+
+      const { mediaTime } = request;
+
+      if (!shouldPrefetch(mediaTime)) {
+        continue;
+      }
+
+      await (
+        shouldRefreshRollingWindow(mediaTime)
+          ? loadWindow(mediaTime)
+          : refreshBuffer(mediaTime)
+      ).catch(() => undefined);
+    }
+  }
 
   async function applyIncrementalChanges() {
     if (
@@ -725,6 +765,20 @@ function mergeIncrementalFrames(
   }
 
   return Array.from(framesByIdentity.values()).sort(compareDetectionFrames);
+}
+
+function reuseBufferedFrameSnapshots(
+  currentFrames: readonly DetectionFrame[],
+  loadedFrames: readonly DetectionFrame[],
+) {
+  const currentFramesByIdentity = new Map(
+    currentFrames.map((frame) => [getDetectionFrameIdentity(frame), frame]),
+  );
+
+  return loadedFrames.map(
+    (frame) =>
+      currentFramesByIdentity.get(getDetectionFrameIdentity(frame)) ?? frame,
+  );
 }
 
 function getDetectionFrameIdentity(frame: DetectionFrame) {

--- a/packages/core/src/types/detection-timeline.ts
+++ b/packages/core/src/types/detection-timeline.ts
@@ -172,7 +172,9 @@ export interface DetectionFrameSource {
   getAvailableRanges?(): readonly DetectionFrameSourceVersionRange[];
   /**
    * Optional monotonically increasing source version. Buffered timelines use
-   * this to refresh only when the current range changed.
+   * this to refresh only when the current range changed. Sources that can
+   * revise an existing frame must implement this hook; without it, overlapping
+   * frame identities are treated as immutable across rolling window loads.
    */
   getVersion?(range?: DetectionFrameSourceVersionRange): number;
   /**

--- a/packages/web/src/render-preparation/prepared-render-window.test.ts
+++ b/packages/web/src/render-preparation/prepared-render-window.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { BaseMaskStyle } from "supervision-js-core";
+import {
+  BaseMaskStyle,
+  createBufferedDetectionTimeline,
+} from "supervision-js-core";
 import {
   DetectionBufferStatus,
+  DetectionFrameSelectionMode,
   type BufferedDetectionTimeline,
 } from "supervision-js-core";
 import {
@@ -82,6 +86,63 @@ const manyFrames = Array.from({ length: 10 }, (_, frameIndex) => ({
 })) satisfies DetectionFrame[];
 
 describe("prepared render window", () => {
+  it("keeps prepared overlap across an immutable rolling buffer refresh", async () => {
+    vi.useFakeTimers();
+    resetMocks();
+
+    try {
+      const source = {
+        loadFrames: vi.fn(async (startTime: number, endTime: number) =>
+          denseFrames.filter(
+            (frame) =>
+              frame.mediaTime >= startTime && frame.mediaTime < endTime,
+          ),
+        ),
+      };
+      const timeline = createBufferedDetectionTimeline({
+        bufferAheadSeconds: 0.12,
+        bufferBehindSeconds: 0,
+        frameIndexOriginTime: 0,
+        frameRate: 25,
+        refreshIntervalSeconds: 0.04,
+        selectionMode: DetectionFrameSelectionMode.NearestFrameIndex,
+        source,
+      });
+
+      await timeline.prepare(0);
+
+      const renderWindow = createPreparedRenderWindow({
+        detectionTimeline: timeline,
+        maskStyle: new BaseMaskStyle(),
+        prefetchFrameCount: 3,
+        preparedWindowScanIntervalSeconds: 0,
+      });
+
+      renderWindow.getFrame(0);
+      await flushMaskPreparationTimers(6);
+      const preparedOverlap = renderWindow.getFrame(0.08)?.maskFrame;
+
+      expect(preparedOverlap).toBeDefined();
+
+      timeline.prefetch(0.04);
+      await vi.waitFor(() =>
+        expect(source.loadFrames).toHaveBeenCalledTimes(2),
+      );
+      await vi.waitFor(() =>
+        expect(timeline.getState().bufferEndTime).toBeCloseTo(0.16),
+      );
+
+      renderWindow.getFrame(0.04);
+
+      expect(renderWindow.getFrame(0.08)?.maskFrame).toBe(preparedOverlap);
+
+      renderWindow.destroy();
+      timeline.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("rebuilds the active mask artifact when semantic content changes at the same frame key", async () => {
     vi.useFakeTimers();
     resetMocks();


### PR DESCRIPTION
# Description

Fixes the demo playback stalls caused by high-frequency rolling detection-window prefetches superseding each other before they could commit. Background prefetch is now single-flight and coalesces to the latest media time. Immutable overlapping frames retain their internal identity so prepared mask artifacts are reused instead of being discarded at every rollover.

The Core App compatibility boundary is preserved: the public timeline API is unchanged, public frame reads remain defensive copies, explicit seeks supersede stale background work, and versioned/appendable sources continue through the existing incremental refresh path. Sources that revise an existing frame are now explicitly documented as requiring `getVersion()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added a 30 fps prefetch regression proving requests coalesce while the active load commits
- Added coverage proving a newer seek discards queued rolling work
- Added Core and Web coverage for stable immutable overlap, defensive public copies, and prepared mask reuse
- Preserved coverage proving real source revisions receive new identity and invalidate prepared artifacts
- Ran `npm run verify`: 75 Vitest files / 517 tests plus formatting, lint, typecheck, builds, docs, boundaries, fixtures, package smoke, demo, examples, and benchmark builds

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

- GitHub Pages demo deployment after merge
- No Core App deployment or consumer migration is required

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
