### PR TITLE
Refresh docs for current React Native APIs

### DIFF
--- a/docs/internal/react-native-architecture.md
+++ b/docs/internal/react-native-architecture.md
@@ -1,7 +1,7 @@
 # React Native Architecture
 
-This note defines the current direction for a future React Native package. It is
-not a public API promise.
+This note defines the current direction for the private experimental React
+Native package. It is not a public API promise.
 
 The package is being hardened toward release using the web API as the
 blueprint; see the current phased extraction and API plan in
@@ -18,10 +18,12 @@ browser package entrypoint.
 
 ## Rendering Direction
 
-React Native rendering should use native-friendly technology such as Skia or a
-native GPU surface. The first proof should accept externally supplied media
-frames or native frame handles and resolve core presentation styles into
-draw instructions.
+React Native rendering uses platform adapters around a renderer-neutral session
+core. The current `./react` and `./skia` entrypoints provide a package-owned
+static `MediaSessionView`, synchronized frame packets, and Skia drawing helpers.
+Live camera frames still enter through example-owned native frame handles; the
+next reusable live adapter should implement the same source/processor/renderer
+contracts rather than introduce a second session abstraction.
 
 The package should remain non-Expo-coupled. Expo may be a consumer environment,
 but the library boundary should not require Expo APIs.
@@ -35,10 +37,12 @@ directly through Skia or a future native GPU adapter.
 
 ## Media Direction
 
-Mediabunny is browser-focused and should stay in `packages/web`. React Native
-will need platform media providers for files, camera streams, and native video
-frames. Those providers should conform to core media-frame metadata contracts
-without making core know about native texture handles or camera APIs.
+Mediabunny is browser-focused and stays in `packages/web`. React Native models
+platform media through `MediaFrameSource`, `MediaFrameProcessor`, and
+`MediaRendererAdapter`. The current iOS saved-video adapter wraps the optional
+Nitro `VideoFrameSource`; live VisionCamera production remains example-owned.
+Native handles stay outside core, and Android saved-video decoding is not yet
+implemented.
 
 ## Storage Direction
 
@@ -50,22 +54,23 @@ storage engine belongs to the React Native package or the host app.
 ## Inference Boundary
 
 ExecuTorch and other on-device inference engines are detection producers, not
-rendering dependencies. A host app may run a model with ExecuTorch and append
+rendering dependencies. A host app may run a model with ExecuTorch and feed
 detections into the same core-shaped pipeline, but `supervision-js-react-native`
-should not depend on ExecuTorch to render detections.
+does not import the ExecuTorch runtime to render detections.
 
-The example app may use ExecuTorch to prove a realistic producer integration.
-That dependency must stay in `examples/react-native`, not in `packages/core` or
-`packages/react-native`.
+The package's optional `./adapters/executorch` subpath accepts structural runner
+and result shapes, owns worklet-safe serialization and coordinate repair, and
+keeps model ownership with the host. The example app owns the actual ExecuTorch
+models and hooks; neither core nor the React Native package takes a runtime
+dependency on that producer.
 
 ## Current Proof
 
-The current private package resolves one externally supplied media frame and one
-detection frame through core styles, then maps media-space geometry into a
-React Native canvas. It also maps React Native touch coordinates back into media
-space and delegates picking to core contracts. That proves the dependency
-direction, style contract, coordinate mapping, and interaction boundary without
-choosing a full mobile media pipeline.
+The current private package owns a generic `createMediaSession()` lifecycle,
+source/processor/renderer contracts, stable state snapshots, prepared-frame
+ownership, package defaults, and a React lifecycle adapter. Its static binding
+and `MediaSessionView` map media-space geometry into a React Native Skia scene,
+map touch coordinates back into media space, and delegate picking to core.
 
 The React Native gesture adapter also delegates box creation, movement, handle
 resizing, vertex deletion, and scaled-mask picking to the shared core editing
@@ -73,12 +78,12 @@ engine. The host retains selection, persistence, undo, and native drawing of
 `AnnotationOverlayStyle` affordances; a native overlay-renderer is intentionally
 not part of this proof.
 
-Static and live examples now use the same render-owned presentation shape:
-prepare one frame packet, then draw media, masks, boxes, and labels through the
-same synchronized frame stage. Static mode supplies a Skia image as the media
-source; live mode supplies VisionCamera's native frame renderer as the media
-source. The annotation rendering lane stays shared so future static work does
-not drift into a second renderer implementation.
+Static and live examples use the same render-owned presentation shape: prepare
+one frame packet, then draw media, masks, boxes, and labels through the same
+synchronized frame stage. Static mode uses the package-owned React/Skia view;
+live mode supplies VisionCamera's native frame renderer as the media source.
+The annotation rendering lane stays shared rather than drifting into a second
+renderer implementation.
 
 The package also exposes a static-frame ID-mask proof:
 
@@ -105,9 +110,10 @@ The example app also includes a live camera proof:
   receives throttled diagnostics only.
 
 The reusable package now owns the live ID-mask artifact contract, artifact
-sizing helper, Roboflow-style palette helper, and the worklet-callable JS
-fallback builder. The example still owns the hot VisionCamera and ExecuTorch
-worklet because those are producer choices.
+sizing helper, Roboflow-style palette helper, worklet-callable JS fallback
+builder, saved-video serializer, and pose conversion helpers. The example still
+owns the hot VisionCamera/live-inference worklet because those are producer
+choices.
 
 The example also proves an Instant CV interaction layer without promoting a
 product-specific rule schema into the package. Touch-authored rules remain
@@ -135,13 +141,18 @@ JS builder otherwise, surfacing builder/fallback diagnostics. The package keeps
 without any native module. Android intentionally has no native implementation
 yet and always uses the JS fallback.
 
-This is deliberately an example-level integration. The long-term package design
-should move hot-frame rendering, prepared-window management, and background or
-native-thread mask preparation into reusable RN adapters without making the
-renderer depend on a specific inference engine.
+The package also owns the iOS saved-video source, reusable ExecuTorch
+serialization/preparation worklets, shared file/live defaults, and the existing
+analysis-paced `createReactNativeVideoSession()` compatibility factory. The
+factory supports pause/resume/stop and intentionally reports seeking as
+unsupported. New code should use `REACT_NATIVE_FILE_SESSION_DEFAULTS`; the old
+video-defaults name is retained only as a deprecated alias.
 
-Native video file playback, hot prepared windows, and worker or native-thread
-mask preparation remain future proofs.
+The remaining package work is to migrate that saved-video compatibility path
+onto the generic session core, move the live example lane behind reusable
+adapters, add Android saved-video decoding, and introduce bounded prepared
+windows where measurement justifies them. Inference engines remain injected
+producers rather than renderer dependencies.
 
 See [`react-native-live-rendering.md`](react-native-live-rendering.md) for the
 live rendering target and current V0 demo shape.

--- a/docs/internal/react-native-live-rendering.md
+++ b/docs/internal/react-native-live-rendering.md
@@ -82,19 +82,22 @@ On iOS, the demo explicitly requests the RF-DETR Nano segmentation CoreML INT8
 profile through ExecuTorch. ExecuTorch remains example-owned; it is a detection
 producer, not a renderer dependency.
 
-This is intentionally still a proof. It does not yet have a reusable
-`createReactNativeLiveSession()` API, native-thread prepared windows, a reusable
-live interaction/rule layer, camera recording/export, or a fully custom
-Skia/native renderer that imports and draws the camera frame directly.
+This is intentionally still a proof. The package now has a generic
+`createMediaSession()` core, but live mode does not yet use package-owned
+source/processor/renderer adapters. It also lacks native-thread prepared
+windows, a reusable live interaction/rule layer, camera recording/export, and a
+fully custom Skia/native renderer that imports and draws the camera frame
+directly.
 
 ## Next Architecture Step
 
-Move the live lane from example code into `packages/react-native` behind a small
-renderer contract:
+Move the live lane from example code into `packages/react-native` behind the
+existing generic session contracts:
 
-- frame input: native frame handle plus metadata;
-- artifact input: prepared ID-mask image/uniforms or raw binary masks;
-- presentation output: one render scene with media and annotations;
+- `MediaFrameSource`: native frame handle plus metadata;
+- `MediaFrameProcessor`: inference-produced detections and prepared semantic
+  input;
+- `MediaRendererAdapter`: one render scene with media and annotations;
 - timing policy: strict packet presentation first; any future low-latency mode
   must be explicit about the weaker synchronization guarantee;
 - diagnostics output: throttled state snapshots for host UI.

--- a/docs/public/guides/public-api.md
+++ b/docs/public/guides/public-api.md
@@ -142,7 +142,8 @@ These are implementation details, even when they are important to performance:
 - shader palette formats;
 - prepared render-window cache internals;
 - demo-only Roboflow or SAM3 request code;
-- React components or hooks.
+- React components or hooks in the browser package. The private experimental
+  React Native package has a separate `./react` entrypoint.
 
 Prepared artifacts are runtime representations. Detections remain semantic data.
 Apps should feed detections and styles into a session, not construct renderer
@@ -165,19 +166,38 @@ or prepared artifact internals.
 
 ## React Native Boundary
 
-React Native support is experimental and private. The future mobile package
-should depend on the platform-neutral core concepts, not on the browser package.
+React Native support is experimental and private. The current mobile package
+depends on the platform-neutral core concepts, not on the browser package.
 Pixi, Mediabunny, DOM APIs, browser workers, and IndexedDB remain browser
 implementation details.
 
-Mobile apps may eventually feed detections from on-device inference engines, but
-inference is outside the rendering package boundary. The library should render
-and interact with detections regardless of how they were produced.
+The private package now has a generic `createMediaSession()` core, a
+package-owned `MediaSessionView` and `useMediaSession()` hook at
+`supervision-js-react-native/react`, and platform adapter subpaths. These are
+mobile experiments, not exports from `supervision-js` and not part of the
+stable browser-package promise.
+
+Mobile apps can feed detections from on-device inference engines, but inference
+is outside the rendering package boundary. The library renders and interacts
+with detections regardless of how they were produced.
+
+The experimental iOS saved-video path is analysis-paced: it processes each
+decoded frame as quickly as inference permits rather than trying to match wall
+clock playback. It reports explicit capabilities; pause, resume, and stop are
+available, while seeking is intentionally unsupported until native decoding can
+reposition accurately. New package code should use
+`REACT_NATIVE_FILE_SESSION_DEFAULTS`; `REACT_NATIVE_VIDEO_SESSION_DEFAULTS`
+remains only as a deprecated compatibility alias.
 
 React Native currently shares editing geometry, picking, and gesture semantics
 through `createReactNativeAnnotationGestureAdapter`. Native hosts own drawing
 editing affordances from `AnnotationOverlayStyle` until a native overlay
 renderer is introduced.
+
+The remaining mobile work is integration, not a second session abstraction:
+move the saved-video compatibility factory and the example-owned live lane onto
+the generic source/processor/renderer contracts, and add an Android saved-video
+source before claiming cross-platform file support.
 
 ## Compatibility Posture
 

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -3,15 +3,21 @@
 Experimental Expo app for validating the `supervision-js-react-native` package
 on a phone or emulator.
 
-It has two modes:
+It has four modes:
 
-- Static: renders a bundled basketball frame and detections through React Native
-  Skia using draw instructions resolved from `supervision-js-core` styles.
+- Static: renders a bundled basketball frame and detections through the
+  package-owned `MediaSessionView` and static session binding.
 - Live: uses VisionCamera plus ExecuTorch RF-DETR Nano instance segmentation as
   an example inference producer. The frame worklet prepares one bounded ID-mask
   artifact from model-resolution masks, updates Skia presentation state, and
   only presents the same camera frame after the matching annotation packet is
   ready.
+- Video: exercises the package-owned iOS saved-video source and compatibility
+  session. Playback is analysis-paced, supports pause/resume/stop, and does not
+  claim seek support.
+- Instant CV: reuses the live strict-sync lane for example-owned Golden Pose,
+  Safety Zone, and Privacy recipes without promoting those product rules into
+  the package API.
 
 The mask layer follows the same performance principle as the browser package:
 compressed RLE masks are prepared once into a single frame-level ID-mask
@@ -19,8 +25,9 @@ artifact, uploaded as an `Alpha_8` Skia image, and colored with one runtime
 shader pass. The live mode prepares ExecuTorch binary masks directly into the
 ID-mask artifact so the hot path does not round-trip through React state. The
 live proof is strict-sync only: it does not display a newer camera frame with an
-older mask artifact. Native video playback, hot prepared windows, and
-worker/native-thread preparation are future proofs.
+older mask artifact. Saved-video decoding and native mask preparation are
+package-owned on iOS; the remaining work is to migrate that compatibility
+session onto the generic session core and add an Android saved-video source.
 
 ## Run
 
@@ -70,10 +77,11 @@ npm run example:react-native:android
 The demo should show a basketball frame, class-colored masks/boxes, labels, a
 selection outline, and a compact prepared-ID-mask readout. Switch to `Live` to
 test strict-synced camera-frame rendering with RF-DETR Nano instance
-segmentation. The live debug HUD reports delivered frame size, prepared artifact
-size, segmentation time, mask fill/upload time, total tick time, and dropped
-frames. If the readout says `Shader unavailable`, the GPU mask proof is not
-active.
+segmentation, `Video` to exercise analysis-paced saved-video processing, or
+`Instant CV` to exercise the example recipes. The live debug HUD reports
+delivered frame size, prepared artifact size, segmentation time, mask
+fill/upload time, total tick time, and dropped frames. If the readout says
+`Shader unavailable`, the GPU mask proof is not active.
 
 The live camera proof uses native dependencies and camera permissions. After
 changing native dependencies, Babel plugins, or `app.json`, rebuild the
@@ -95,5 +103,6 @@ npm run example:react-native:dev-client:ios
 - The demo may use ExecuTorch and VisionCamera as inference/media producers.
 - `packages/react-native` must not depend on Expo, Pixi, Mediabunny, DOM APIs,
   browser workers, IndexedDB, ExecuTorch, VisionCamera, or `packages/web`.
-- Media frames are externally supplied. The package only resolves core semantic
-  detections/styles into mobile-friendly drawing data.
+- The package owns generic media-session contracts, the static React/Skia view,
+  the iOS saved-video source, and reusable preparation worklets. Hosts still own
+  inference, live camera producers, persistence, and product UI.

--- a/packages/react-native/src/sessions.ts
+++ b/packages/react-native/src/sessions.ts
@@ -161,7 +161,7 @@ export interface ReactNativeVideoSessionPresentationOptions {
   readonly maxPixels?: number;
   readonly maxSide?: number;
   readonly mosaicCellPx?: number;
-  /** Memory-guard overrides; default to `REACT_NATIVE_VIDEO_SESSION_DEFAULTS`. */
+  /** Memory-guard overrides; default to `REACT_NATIVE_FILE_SESSION_DEFAULTS`. */
   readonly fullResMaskMaxPixels?: number;
   readonly maxPresentationSide?: number;
 }

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -95,6 +95,14 @@ test("TypeDoc includes every public API facade", async () => {
   );
 });
 
+test("TypeDoc does not publish the private workspace version", async () => {
+  const config = JSON.parse(
+    await readFile(path.join(rootDir, "typedoc.json"), "utf8"),
+  );
+
+  assert.equal(config.includeVersion, false);
+});
+
 test("copyable integration examples typecheck", async () => {
   const applicationGuide = await readFile(
     path.join(publicDocsDir, "guides/application-integration.md"),

--- a/typedoc.json
+++ b/typedoc.json
@@ -16,7 +16,7 @@
   "excludeProtected": true,
   "githubPages": true,
   "hideGenerator": true,
-  "includeVersion": true,
+  "includeVersion": false,
   "lightHighlightTheme": "github-light",
   "darkHighlightTheme": "github-dark",
   "name": "supervision-js",


### PR DESCRIPTION
# Description

Audits the current documentation after the recent browser and React Native API changes and removes stale guidance.

- Documents the implemented React Native media-session, React/Skia, saved-video, and adapter boundaries instead of calling them future work.
- Updates the React Native example README to cover all four current demo modes.
- Keeps deprecated compatibility exports in generated reference while directing prose to preferred APIs.
- Stops TypeDoc from publishing the private root workspace version (`0.0.0`) as the public docs version and adds a regression test.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `npm run verify`
- 513 unit tests, documentation contracts, package boundaries, package smoke tests, and production builds passed on the exact PR commit.
- Verified browser copyable examples use current APIs and deprecated compatibility exports retain TypeDoc migration guidance.

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

- GitHub Pages documentation is regenerated after merge.
- No runtime deployment is required.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
