### PR TITLE
Allow Render branch preview hosts

### DIFF
--- a/docs/internal/render-deployment.md
+++ b/docs/internal/render-deployment.md
@@ -47,6 +47,11 @@ Auto-deploy: On commit
 the Render and GitHub Pages output identical and avoids maintaining a second
 production server or image delivery path.
 
+The start command passes Render's exact `RENDER_EXTERNAL_HOSTNAME` to Vite's
+additional-host allowlist. This supports branch preview services without
+trusting arbitrary hosts; local runs fall back to the canonical production
+hostname.
+
 ## Update With The Render CLI
 
 After authenticating with `render login`, the existing service can be

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "demo:dev": "npm run build && npm run dev:demo",
     "demo:build": "npm run build && npm run build -w demo && npm run example:vanilla:build:app && npm run docs:build:typedoc",
     "pages:build": "node tools/build-pages.mjs",
-    "pages:serve": "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=supervision-js-demo.onrender.com vite preview --outDir dist/pages --host 0.0.0.0 --port ${PORT:-4173}",
+    "pages:serve": "__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=${RENDER_EXTERNAL_HOSTNAME:-supervision-js-demo.onrender.com} vite preview --outDir dist/pages --host 0.0.0.0 --port ${PORT:-4173}",
     "docs:build": "npm run build && npm run docs:build:typedoc",
     "docs:build:typedoc": "typedoc && node tools/copy-doc-assets.mjs",
     "docs:check": "node --test tools/docs-contract.test.mjs",

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -103,6 +103,19 @@ test("TypeDoc does not publish the private workspace version", async () => {
   assert.equal(config.includeVersion, false);
 });
 
+test("Render preview trusts only its assigned hostname", async () => {
+  const packageJson = JSON.parse(
+    await readFile(path.join(rootDir, "package.json"), "utf8"),
+  );
+  const serveCommand = packageJson.scripts["pages:serve"];
+
+  assert.match(
+    serveCommand,
+    /__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=\$\{RENDER_EXTERNAL_HOSTNAME:-supervision-js-demo\.onrender\.com\}/,
+  );
+  assert.doesNotMatch(serveCommand, /allowedHosts=(?:true|\*)/);
+});
+
 test("copyable integration examples typecheck", async () => {
   const applicationGuide = await readFile(
     path.join(publicDocsDir, "guides/application-integration.md"),


### PR DESCRIPTION
# Description

Fixes branch-specific Render previews being rejected by Vite's Host allowlist.

The combined demo/docs preview server now uses Render's exact `RENDER_EXTERNAL_HOSTNAME`, with the canonical production hostname as a fallback outside Render. This keeps preview services working without enabling arbitrary hosts or all `onrender.com` subdomains.

Source: current conversation after reproducing the blocked `supervision-js-demo-pr-28.onrender.com` preview. Render documents the injected hostname at https://render.com/docs/environment-variables#render-external-hostname.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change adds functionality)
- [ ] Maintenance (non-breaking, non-user-facing change)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Built the combined artifact with `npm run pages:build`.
- Started the preview with `RENDER_EXTERNAL_HOSTNAME=supervision-js-demo-pr-28.onrender.com` and verified that Host returns HTTP 200 while an unrelated Host returns HTTP 403.
- Started without the Render variable and verified the canonical production Host still returns HTTP 200.
- `npm run verify` passed on commit `a6628637154dc77b58857711a1c4f52ab26428dd` (517 tests plus docs, boundary, smoke, and production builds).

## Will the change affect Universe? If so was this change tested in universe?

No.

## Any specific deployment considerations

- Render branch previews and the canonical Render service use the existing `npm run pages:serve` start command.
- No environment variable needs to be configured manually; Render injects `RENDER_EXTERNAL_HOSTNAME`.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
