### PR TITLE
Fix demo bounding box toggles

### DIFF
--- a/demo/fixtures/horse_trail/fixture.meta.json
+++ b/demo/fixtures/horse_trail/fixture.meta.json
@@ -9,6 +9,7 @@
     "readyStatusLabel": "70s horse trail source media | browser-normalized WebM 30fps"
   },
   "presentation": {
+    "boxesEnabled": false,
     "confidenceThreshold": 0.5,
     "keypointsEnabled": false,
     "polygonsEnabled": false

--- a/demo/src/fixtures/demo-fixtures.test.ts
+++ b/demo/src/fixtures/demo-fixtures.test.ts
@@ -68,6 +68,7 @@ describe("geometry showcase fixture", () => {
     );
 
     expect(fixture?.presentationDefaults).toEqual({
+      boxesEnabled: false,
       confidenceThreshold: 0.5,
       keypointsEnabled: false,
       polygonsEnabled: false,

--- a/demo/src/presentation/demo-presentation.test.ts
+++ b/demo/src/presentation/demo-presentation.test.ts
@@ -114,6 +114,34 @@ describe("demo presentation", () => {
     });
   });
 
+  it("renders enabled boxes for detections with other geometry", () => {
+    const presentation = createDemoPresentation({
+      ...defaultDemoPresentationSettings,
+      boxesEnabled: true,
+    });
+
+    for (const combinedDetection of [detection, vectorDetection]) {
+      const context = {
+        detectionIndex: 0,
+        frame: { detections: [combinedDetection], mediaTime: 0 },
+        mediaTime: 0,
+      };
+
+      expect(
+        presentation.boxStyle?.resolve(combinedDetection, context),
+      ).toMatchObject({ rect: combinedDetection.rect });
+    }
+  });
+
+  it("removes the box style when boxes are disabled", () => {
+    const presentation = createDemoPresentation({
+      ...defaultDemoPresentationSettings,
+      boxesEnabled: false,
+    });
+
+    expect(presentation.boxStyle).toBeNull();
+  });
+
   it("treats mask opacity as a cheap presentation knob", () => {
     const lowOpacityPresentation = createDemoPresentation({
       ...defaultDemoPresentationSettings,
@@ -224,10 +252,11 @@ describe("demo presentation", () => {
     });
   });
 
-  it("keeps default mask-only interaction picking free of box highlights", () => {
-    const presentation = createDemoPresentation(
-      defaultDemoPresentationSettings,
-    );
+  it("keeps mask-only interaction picking free of box highlights", () => {
+    const presentation = createDemoPresentation({
+      ...defaultDemoPresentationSettings,
+      boxesEnabled: false,
+    });
     const frame = { detections: [detection], mediaTime: 0 };
     const hoverPresentation = presentation.interactionStyle?.resolve(
       detection,
@@ -291,19 +320,16 @@ describe("demo presentation", () => {
       },
     );
 
-    const hoverBox = hoverPresentation?.boxStyle?.resolve(rectangleDetection, {
+    const hoverBox = hoverPresentation?.boxStyle?.resolve(detection, {
       detectionIndex: 0,
       frame,
       mediaTime: 0,
     });
-    const selectedBox = selectedPresentation?.boxStyle?.resolve(
-      rectangleDetection,
-      {
-        detectionIndex: 0,
-        frame,
-        mediaTime: 0,
-      },
-    );
+    const selectedBox = selectedPresentation?.boxStyle?.resolve(detection, {
+      detectionIndex: 0,
+      frame,
+      mediaTime: 0,
+    });
     const hoverMask = hoverPresentation?.maskStyle?.resolve(detection, {
       detectionIndex: 0,
       frame,

--- a/demo/src/presentation/demo-presentation.ts
+++ b/demo/src/presentation/demo-presentation.ts
@@ -256,14 +256,7 @@ function createDemoKeypointStyle(
 function createDemoBoxStyle(settings: DemoPresentationSettings): BoxStyle {
   return {
     resolve(detection: Detection): BoxDrawInstruction | undefined {
-      if (
-        !detection.rect ||
-        detection.mask ||
-        detection.polygon ||
-        detection.polyline ||
-        detection.keypoints ||
-        !passesConfidenceThreshold(detection, settings)
-      ) {
+      if (!detection.rect || !passesConfidenceThreshold(detection, settings)) {
         return undefined;
       }
 
@@ -571,14 +564,7 @@ function createDemoInteractionBoxStyle(
 ): BoxStyle {
   return {
     resolve(detection: Detection): BoxDrawInstruction | undefined {
-      if (
-        !detection.rect ||
-        detection.mask ||
-        detection.polygon ||
-        detection.polyline ||
-        detection.keypoints ||
-        !passesConfidenceThreshold(detection, settings)
-      ) {
+      if (!detection.rect || !passesConfidenceThreshold(detection, settings)) {
         return undefined;
       }
 


### PR DESCRIPTION
# Description

Restores the demo's Boxes control for detections that also contain masks, polygons, polylines, or keypoints. The horse trail now starts with boxes disabled while retaining masks and labels, and users can enable boxes in both horse and basketball fixtures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added regression coverage for masked and vector-geometry detections with Boxes enabled
- Added coverage for Boxes disabled and the horse fixture default
- Ran `npm run verify` successfully (524 tests plus lint, typecheck, package/demo/docs builds, boundary checks, and smoke tests)

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- hosting

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
