### PR TITLE
Add strict VisionCamera live source adapter

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -46,7 +46,6 @@ import {
   NativeFrameRendererView,
   useCameraDevice,
   useCameraPermission,
-  useFrameOutput,
   useFrameRenderer,
   type Frame,
 } from "react-native-vision-camera";
@@ -80,6 +79,7 @@ import {
   resolveReactNativeLabelLayout,
   createEmptyReactNativeLiveIdMaskUniforms,
 } from "supervision-js-react-native";
+import { useVisionCameraFrameOutput } from "supervision-js-react-native/adapters/vision-camera";
 import {
   createReactNativeStaticMediaSessionBinding,
   getReactNativeMediaSessionViewReadout,
@@ -2782,16 +2782,11 @@ function LiveCameraProof(props: {
     ],
   );
 
-  const inferenceFrameOutput = useFrameOutput({
-    allowDeferredStart: false,
-    dropFramesWhileBusy: true,
-    enablePhysicalBufferRotation: false,
-    enablePreviewSizedOutputBuffers: true,
+  const inferenceFrameOutput = useVisionCameraFrameOutput({
     onFrame: onLiveInferenceFrame,
     onFrameDropped() {
       reportDroppedFrame();
     },
-    pixelFormat: "rgb",
     targetResolution: LIVE_FRAME_TARGET_RESOLUTION,
   });
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -20,6 +20,11 @@
       "react-native": "./src/adapters/executorch.ts",
       "import": "./dist/adapters/executorch.js"
     },
+    "./adapters/vision-camera": {
+      "types": "./dist/adapters/vision-camera.d.ts",
+      "react-native": "./src/adapters/vision-camera.ts",
+      "import": "./dist/adapters/vision-camera.js"
+    },
     "./adapters/video-file": {
       "types": "./dist/adapters/video-file.d.ts",
       "react-native": "./src/adapters/video-file.ts",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -83,6 +83,7 @@
     "react-native": "*",
     "react-native-nitro-modules": "*",
     "react-native-reanimated": "*",
+    "react-native-vision-camera": "*",
     "react-native-worklets": "*",
     "react-native-vision-camera-worklets": "*"
   },
@@ -100,6 +101,9 @@
       "optional": true
     },
     "react-native-reanimated": {
+      "optional": true
+    },
+    "react-native-vision-camera": {
       "optional": true
     },
     "react-native-worklets": {

--- a/packages/react-native/rollup.config.js
+++ b/packages/react-native/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from "@rollup/plugin-typescript";
 export default {
   input: {
     "adapters/executorch": "src/adapters/executorch.ts",
+    "adapters/vision-camera": "src/adapters/vision-camera.ts",
     "adapters/video-file": "src/adapters/video-file.ts",
     index: "src/index.ts",
     "media-session": "src/media-session.ts",

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createVisionCameraLiveSource } from "./vision-camera";
+
+function createFrame(timestamp: number) {
+  return {
+    dispose: vi.fn(),
+    height: 720,
+    timestamp,
+    width: 1280,
+  };
+}
+
+describe("createVisionCameraLiveSource", () => {
+  it("strictly serializes frames and disposes dropped native buffers", async () => {
+    let finishFrame: (() => void) | undefined;
+    const source = createVisionCameraLiveSource();
+    const first = createFrame(1_000_000_000);
+    const dropped = createFrame(2_000_000_000);
+
+    source.start({
+      onEnd: vi.fn(),
+      onError: vi.fn(),
+      onFrame: (frame) =>
+        new Promise<void>((resolve) => {
+          expect(frame.metadata).toMatchObject({
+            frameIndex: 0,
+            height: 720,
+            mediaTime: 1,
+            width: 1280,
+          });
+          finishFrame = resolve;
+        }),
+    });
+
+    expect(source.offerFrame(first)).toBe(true);
+    expect(source.offerFrame(dropped)).toBe(false);
+    expect(dropped.dispose).toHaveBeenCalledOnce();
+
+    finishFrame?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(first.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("does not retain frames after stop or destroy", () => {
+    const source = createVisionCameraLiveSource();
+    const stopped = createFrame(0);
+    const destroyed = createFrame(1);
+
+    source.start({ onEnd: vi.fn(), onError: vi.fn(), onFrame: vi.fn() });
+    source.stop?.();
+    expect(source.offerFrame(stopped)).toBe(false);
+    source.destroy?.();
+    expect(source.offerFrame(destroyed)).toBe(false);
+    expect(stopped.dispose).toHaveBeenCalledOnce();
+    expect(destroyed.dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createVisionCameraLiveSource } from "./vision-camera";
+import {
+  createVisionCameraLiveSource,
+  useVisionCameraFrameOutput,
+} from "./vision-camera";
 
 function createFrame(timestamp: number) {
   return {
@@ -55,5 +58,16 @@ describe("createVisionCameraLiveSource", () => {
     expect(source.offerFrame(destroyed)).toBe(false);
     expect(stopped.dispose).toHaveBeenCalledOnce();
     expect(destroyed.dispose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("useVisionCameraFrameOutput", () => {
+  it("fails clearly outside a VisionCamera runtime", () => {
+    expect(() =>
+      useVisionCameraFrameOutput({
+        onFrame: vi.fn(),
+        targetResolution: { height: 720, width: 1280 },
+      }),
+    ).toThrow(/VisionCamera frame output is unavailable/);
   });
 });

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -1,0 +1,126 @@
+import {
+  MediaSessionMode,
+  type MediaTimelineMetadata,
+  type PlatformMediaFrame,
+} from "supervision-js-core";
+
+import type {
+  MediaFrameSource,
+  MediaFrameSourceConsumer,
+  MediaSessionCapabilities,
+} from "../types/frame-source";
+
+/**
+ * Structural subset of a VisionCamera frame used by the source adapter.
+ *
+ * Keeping this type structural makes the adapter independently testable and
+ * keeps VisionCamera out of the base package entrypoint.
+ */
+export interface VisionCameraFrame {
+  readonly height: number;
+  readonly timestamp: number;
+  readonly width: number;
+  dispose(): void;
+}
+
+export interface VisionCameraLiveSourceOptions<
+  TFrame extends VisionCameraFrame,
+> {
+  readonly onDroppedFrame?: (frame: TFrame) => void;
+  readonly timeline?: Partial<MediaTimelineMetadata>;
+}
+
+export interface VisionCameraLiveSource<
+  TFrame extends VisionCameraFrame,
+> extends MediaFrameSource<TFrame> {
+  /**
+   * Called from the VisionCamera frame-output callback. Returns `false` when
+   * a prior frame is still being processed; the caller must not render it.
+   */
+  offerFrame(frame: TFrame): boolean;
+}
+
+const LIVE_CAPABILITIES: MediaSessionCapabilities = {
+  live: true,
+  pausable: false,
+  seekable: false,
+  stoppable: true,
+};
+
+/**
+ * Creates the package-owned strict-sync bridge for VisionCamera frame output.
+ *
+ * A camera frame is presented only after its consumer settles. While that
+ * happens, later frames are dropped and disposed immediately instead of
+ * accumulating a native-buffer queue. The session owns processing and
+ * rendering; the host only injects its camera callback and inference producer.
+ */
+export function createVisionCameraLiveSource<TFrame extends VisionCameraFrame>(
+  options: VisionCameraLiveSourceOptions<TFrame> = {},
+): VisionCameraLiveSource<TFrame> {
+  let consumer: MediaFrameSourceConsumer<TFrame> | null = null;
+  let destroyed = false;
+  let processing = false;
+  let stopped = false;
+  let nextFrameIndex = 0;
+  const timeline: MediaTimelineMetadata = {
+    duration: null,
+    frameRate: options.timeline?.frameRate ?? null,
+    height: options.timeline?.height ?? 0,
+    width: options.timeline?.width ?? 0,
+  };
+
+  return {
+    capabilities: LIVE_CAPABILITIES,
+    mode: MediaSessionMode.Stream,
+    timeline,
+    start(nextConsumer) {
+      if (destroyed) {
+        throw new Error("VisionCamera live source has been destroyed.");
+      }
+
+      consumer = nextConsumer;
+      stopped = false;
+    },
+    stop() {
+      stopped = true;
+    },
+    destroy() {
+      destroyed = true;
+      stopped = true;
+      consumer = null;
+    },
+    offerFrame(frame) {
+      if (!consumer || destroyed || stopped || processing) {
+        options.onDroppedFrame?.(frame);
+        frame.dispose();
+        return false;
+      }
+
+      processing = true;
+      const activeConsumer = consumer;
+      const platformFrame: PlatformMediaFrame<TFrame> = {
+        metadata: {
+          duration: null,
+          frameIndex: nextFrameIndex,
+          height: frame.height,
+          mediaTime: frame.timestamp / 1_000_000_000,
+          width: frame.width,
+        },
+        payload: frame,
+      };
+      nextFrameIndex += 1;
+
+      void Promise.resolve(activeConsumer.onFrame(platformFrame))
+        .then(
+          () => undefined,
+          (error: unknown) => activeConsumer.onError(error),
+        )
+        .finally(() => {
+          processing = false;
+          frame.dispose();
+        });
+      return true;
+    },
+  };
+}

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -3,6 +3,7 @@ import {
   type MediaTimelineMetadata,
   type PlatformMediaFrame,
 } from "supervision-js-core";
+import type { CameraFrameOutput } from "react-native-vision-camera";
 
 import type {
   MediaFrameSource,
@@ -143,7 +144,7 @@ export function createVisionCameraLiveSource<TFrame extends VisionCameraFrame>(
  */
 export function useVisionCameraFrameOutput<TFrame extends VisionCameraFrame>(
   options: VisionCameraFrameOutputOptions<TFrame>,
-): unknown {
+): CameraFrameOutput {
   if (typeof require !== "function") {
     throw new Error(
       "VisionCamera frame output is unavailable in this runtime.",
@@ -160,7 +161,7 @@ export function useVisionCameraFrameOutput<TFrame extends VisionCameraFrame>(
       onFrameDropped?: () => void;
       pixelFormat: "rgb";
       targetResolution: VisionCameraFrameOutputOptions<TFrame>["targetResolution"];
-    }): unknown;
+    }): CameraFrameOutput;
   };
   let visionCamera: VisionCameraModule;
 

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -40,6 +40,17 @@ export interface VisionCameraLiveSource<
   offerFrame(frame: TFrame): boolean;
 }
 
+export interface VisionCameraFrameOutputOptions<
+  TFrame extends VisionCameraFrame,
+> {
+  readonly onFrame: (frame: TFrame) => void;
+  readonly onFrameDropped?: () => void;
+  readonly targetResolution: {
+    readonly height: number;
+    readonly width: number;
+  };
+}
+
 const LIVE_CAPABILITIES: MediaSessionCapabilities = {
   live: true,
   pausable: false,
@@ -123,4 +134,57 @@ export function createVisionCameraLiveSource<TFrame extends VisionCameraFrame>(
       return true;
     },
   };
+}
+
+/**
+ * Package-owned VisionCamera configuration for strict-sync live processing.
+ * The injected callback remains a host worklet producer; the package owns the
+ * vendor hook and the non-negotiable queue policy.
+ */
+export function useVisionCameraFrameOutput<TFrame extends VisionCameraFrame>(
+  options: VisionCameraFrameOutputOptions<TFrame>,
+): unknown {
+  if (typeof require !== "function") {
+    throw new Error(
+      "VisionCamera frame output is unavailable in this runtime.",
+    );
+  }
+
+  type VisionCameraModule = {
+    useFrameOutput(config: {
+      allowDeferredStart: boolean;
+      dropFramesWhileBusy: boolean;
+      enablePhysicalBufferRotation: boolean;
+      enablePreviewSizedOutputBuffers: boolean;
+      onFrame(frame: TFrame): void;
+      onFrameDropped?: () => void;
+      pixelFormat: "rgb";
+      targetResolution: VisionCameraFrameOutputOptions<TFrame>["targetResolution"];
+    }): unknown;
+  };
+  let visionCamera: VisionCameraModule;
+
+  try {
+    // Lazy require keeps this optional peer out of the base and Node test paths.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    visionCamera = require("react-native-vision-camera") as VisionCameraModule;
+  } catch (cause) {
+    throw new Error(
+      "VisionCamera frame output is unavailable in this runtime.",
+      {
+        cause,
+      },
+    );
+  }
+
+  return visionCamera.useFrameOutput({
+    allowDeferredStart: false,
+    dropFramesWhileBusy: true,
+    enablePhysicalBufferRotation: false,
+    enablePreviewSizedOutputBuffers: true,
+    onFrame: options.onFrame,
+    onFrameDropped: options.onFrameDropped,
+    pixelFormat: "rgb",
+    targetResolution: options.targetResolution,
+  });
 }


### PR DESCRIPTION
Adds a package-owned strict-sync VisionCamera source adapter with native-frame disposal and focused tests.\n\nValidation: npm run verify --silent.