### PR TITLE
Move VisionCamera frame renderer into React Native adapter

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -41,10 +41,8 @@ import {
 } from "react-native";
 import {
   Camera,
-  NativeFrameRendererView,
   useCameraDevice,
   useCameraPermission,
-  useFrameRenderer,
   type Frame,
 } from "react-native-vision-camera";
 import { useSharedValue } from "react-native-reanimated";
@@ -77,7 +75,11 @@ import {
   resolveReactNativeLabelLayout,
   createEmptyReactNativeLiveIdMaskUniforms,
 } from "supervision-js-react-native";
-import { useVisionCameraFrameOutput } from "supervision-js-react-native/adapters/vision-camera";
+import {
+  useVisionCameraFrameOutput,
+  useVisionCameraFrameRenderer,
+  VisionCameraFrameRendererView,
+} from "supervision-js-react-native/adapters/vision-camera";
 import {
   createReactNativeStaticMediaSessionBinding,
   getReactNativeMediaSessionViewReadout,
@@ -1215,7 +1217,7 @@ function LiveCameraProof(props: {
     readonly timestamp: number;
   } | null>(null);
   const instantRequestIdRef = useRef(0);
-  const frameRenderer = useFrameRenderer();
+  const frameRenderer = useVisionCameraFrameRenderer();
   const canvasWidth = window.width;
   const canvasHeight = window.height;
   const isInstantPrivacy = isInstantCv && instantRecipe === "privacy";
@@ -2800,7 +2802,7 @@ function LiveCameraProof(props: {
                 ]}
               />
             ) : null}
-            <NativeFrameRendererView
+            <VisionCameraFrameRendererView
               renderer={frameRenderer}
               style={[
                 styles.frameRendererSurface,

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createVisionCameraLiveSource,
+  useVisionCameraFrameRenderer,
   useVisionCameraFrameOutput,
 } from "./vision-camera";
 
@@ -69,5 +70,13 @@ describe("useVisionCameraFrameOutput", () => {
         targetResolution: { height: 720, width: 1280 },
       }),
     ).toThrow(/VisionCamera frame output is unavailable/);
+  });
+});
+
+describe("useVisionCameraFrameRenderer", () => {
+  it("fails clearly outside a VisionCamera runtime", () => {
+    expect(() => useVisionCameraFrameRenderer()).toThrow(
+      /VisionCamera is unavailable/,
+    );
   });
 });

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -3,7 +3,10 @@ import {
   type MediaTimelineMetadata,
   type PlatformMediaFrame,
 } from "supervision-js-core";
+import { createElement, type ComponentType, type ReactElement } from "react";
+import type { StyleProp, ViewStyle } from "react-native";
 import type { CameraFrameOutput } from "react-native-vision-camera";
+import type { FrameRenderer } from "react-native-vision-camera";
 
 import type {
   MediaFrameSource,
@@ -50,6 +53,11 @@ export interface VisionCameraFrameOutputOptions<
     readonly height: number;
     readonly width: number;
   };
+}
+
+export interface VisionCameraFrameRendererViewProps {
+  readonly renderer: FrameRenderer;
+  readonly style?: StyleProp<ViewStyle>;
 }
 
 const LIVE_CAPABILITIES: MediaSessionCapabilities = {
@@ -145,30 +153,10 @@ export function createVisionCameraLiveSource<TFrame extends VisionCameraFrame>(
 export function useVisionCameraFrameOutput<TFrame extends VisionCameraFrame>(
   options: VisionCameraFrameOutputOptions<TFrame>,
 ): CameraFrameOutput {
-  if (typeof require !== "function") {
-    throw new Error(
-      "VisionCamera frame output is unavailable in this runtime.",
-    );
-  }
-
-  type VisionCameraModule = {
-    useFrameOutput(config: {
-      allowDeferredStart: boolean;
-      dropFramesWhileBusy: boolean;
-      enablePhysicalBufferRotation: boolean;
-      enablePreviewSizedOutputBuffers: boolean;
-      onFrame(frame: TFrame): void;
-      onFrameDropped?: () => void;
-      pixelFormat: "rgb";
-      targetResolution: VisionCameraFrameOutputOptions<TFrame>["targetResolution"];
-    }): CameraFrameOutput;
-  };
   let visionCamera: VisionCameraModule;
 
   try {
-    // Lazy require keeps this optional peer out of the base and Node test paths.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    visionCamera = require("react-native-vision-camera") as VisionCameraModule;
+    visionCamera = loadVisionCamera();
   } catch (cause) {
     throw new Error(
       "VisionCamera frame output is unavailable in this runtime.",
@@ -188,4 +176,49 @@ export function useVisionCameraFrameOutput<TFrame extends VisionCameraFrame>(
     pixelFormat: "rgb",
     targetResolution: options.targetResolution,
   });
+}
+
+/** Returns the optional VisionCamera native frame renderer with a stable error. */
+export function useVisionCameraFrameRenderer(): FrameRenderer {
+  const visionCamera = loadVisionCamera();
+
+  return visionCamera.useFrameRenderer();
+}
+
+/** Package-owned view binding for a VisionCamera native frame renderer. */
+export function VisionCameraFrameRendererView(
+  props: VisionCameraFrameRendererViewProps,
+): ReactElement {
+  const visionCamera = loadVisionCamera();
+
+  return createElement(visionCamera.NativeFrameRendererView, props);
+}
+
+interface VisionCameraModule {
+  NativeFrameRendererView: ComponentType<VisionCameraFrameRendererViewProps>;
+  useFrameOutput<TFrame extends VisionCameraFrame>(config: {
+    allowDeferredStart: boolean;
+    dropFramesWhileBusy: boolean;
+    enablePhysicalBufferRotation: boolean;
+    enablePreviewSizedOutputBuffers: boolean;
+    onFrame(frame: TFrame): void;
+    onFrameDropped?: () => void;
+    pixelFormat: "rgb";
+    targetResolution: VisionCameraFrameOutputOptions<TFrame>["targetResolution"];
+  }): CameraFrameOutput;
+  useFrameRenderer(): FrameRenderer;
+}
+
+function loadVisionCamera(): VisionCameraModule {
+  if (typeof require !== "function") {
+    throw new Error("VisionCamera is unavailable in this runtime.");
+  }
+
+  try {
+    // Lazy require keeps this optional peer out of the base and Node test paths.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("react-native-vision-camera") as VisionCameraModule;
+  } catch (cause) {
+    throw new Error("VisionCamera is unavailable in this runtime.", { cause });
+  }
 }


### PR DESCRIPTION
# Description

Moves the optional VisionCamera native frame-renderer hook and view binding into the React Native package adapter. The demo consumes the adapter instead of importing those vendor APIs directly.

## Type of change

- [x] Maintenance (non-breaking change which improves an experimental package boundary)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added the unavailable-runtime contract test for the native frame renderer
- Ran the focused VisionCamera adapter tests
- Ran React Native package typecheck and build
- Ran React Native demo typecheck

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- No deployment changes; requires device validation of the existing live-camera path after merge.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)