### PR TITLE
Give the VisionCamera adapter frame presentation ownership

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -39,12 +39,6 @@ import {
   Vibration,
   View,
 } from "react-native";
-import {
-  Camera,
-  useCameraDevice,
-  useCameraPermission,
-  type Frame,
-} from "react-native-vision-camera";
 import { useSharedValue } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import { Asset } from "expo-asset";
@@ -77,7 +71,12 @@ import {
 } from "supervision-js-react-native";
 import {
   useVisionCameraFrameOutput,
-  VisionCameraFrameRendererView,
+  useVisionCameraDevice,
+  useVisionCameraPermission,
+  VisionCameraLiveView,
+  resolveVisionCameraFrameRendererStyle,
+  resolveVisionCameraFrameSize,
+  type VisionCameraOutputFrame,
 } from "supervision-js-react-native/adapters/vision-camera";
 import {
   createReactNativeStaticMediaSessionBinding,
@@ -1174,8 +1173,8 @@ function LiveCameraProof(props: {
 }) {
   const isInstantCv = props.mode === "instant";
   const window = useWindowDimensions();
-  const device = useCameraDevice("back");
-  const { hasPermission, requestPermission } = useCameraPermission();
+  const device = useVisionCameraDevice("back");
+  const { hasPermission, requestPermission } = useVisionCameraPermission();
   const [liveFrame, setLiveFrame] = useState<LiveFrameState | null>(null);
   const [liveError, setLiveError] = useState<LiveFrameError | null>(null);
   const [liveDetections, setLiveDetections] = useState<
@@ -1258,7 +1257,7 @@ function LiveCameraProof(props: {
   );
   const liveFrameRendererStyle = useMemo(
     () =>
-      resolveLiveFrameRendererStyle({
+      resolveVisionCameraFrameRendererStyle({
         canvasHeight,
         canvasWidth,
         orientation: liveFrame?.frameOrientation ?? "left",
@@ -2038,7 +2037,7 @@ function LiveCameraProof(props: {
   // must all be render-stable (shared values, useCallback reporters, memoized
   // handles). Per-render data flows in through shared values instead.
   const onLiveInferenceFrame = useCallback(
-    (frame: Frame) => {
+    (frame: VisionCameraOutputFrame) => {
       "worklet";
 
       let stage = "start";
@@ -2071,7 +2070,7 @@ function LiveCameraProof(props: {
               }),
           );
           const poseMs = Date.now() - poseStartedAt;
-          const detectionFrameSize = resolveLiveDetectionFrameSize(frame);
+          const detectionFrameSize = resolveVisionCameraFrameSize(frame);
           const mediaRect = liveMediaRect.value;
           stage = "pose-adapt";
           const serializationStartedAt = Date.now();
@@ -2279,7 +2278,7 @@ function LiveCameraProof(props: {
           const segmentationMs = Date.now() - segmentationStartedAt;
           stage = "mask-read-layout";
           const mediaRect = liveMediaRect.value;
-          const detectionFrameSize = resolveLiveDetectionFrameSize(frame);
+          const detectionFrameSize = resolveVisionCameraFrameSize(frame);
           stage = "mask-serialize-detections";
           const serializationStartedAt = Date.now();
           const detections = runWithWorkletDebugLogging(
@@ -2641,7 +2640,7 @@ function LiveCameraProof(props: {
             frameOrientation: frame.orientation,
             frameIsMirrored: frame.isMirrored,
             hasPresentedFrame: lastPresentedFrame.value,
-            height: resolveLiveDetectionFrameSize(frame).height,
+            height: resolveVisionCameraFrameSize(frame).height,
             inferenceTickMs: lastInferenceTickDurationMs.value,
             maskBuilder: lastMaskBuilderName.value,
             maskFallbackReason: lastMaskFallbackReason.value,
@@ -2659,7 +2658,7 @@ function LiveCameraProof(props: {
             shaderActive: lastShaderActive.value,
             syncMode,
             timestamp: frame.timestamp,
-            width: resolveLiveDetectionFrameSize(frame).width,
+            width: resolveVisionCameraFrameSize(frame).width,
             visibleKeypointCount: lastVisibleKeypointCount.value,
           });
         }
@@ -2791,25 +2790,25 @@ function LiveCameraProof(props: {
         mediaLayer={
           <>
             {device ? (
-              <Camera
-                device={device}
-                isActive={Boolean(canRunCamera)}
-                orientationSource="interface"
-                outputs={cameraOutputs}
-                style={[
+              <VisionCameraLiveView
+                cameraStyle={[
                   styles.captureCamera,
                   awaitingSyncedFrame ? styles.captureCameraVisible : null,
                 ]}
+                device={device}
+                frameRenderer={frameRenderer}
+                frameRendererStyle={[
+                  styles.frameRendererSurface,
+                  liveFrameRendererStyle,
+                  awaitingSyncedFrame
+                    ? styles.frameRendererSurfaceHidden
+                    : null,
+                ]}
+                isActive={Boolean(canRunCamera)}
+                orientationSource="interface"
+                outputs={cameraOutputs}
               />
             ) : null}
-            <VisionCameraFrameRendererView
-              renderer={frameRenderer}
-              style={[
-                styles.frameRendererSurface,
-                liveFrameRendererStyle,
-                awaitingSyncedFrame ? styles.frameRendererSurfaceHidden : null,
-              ]}
-            />
           </>
         }
         showBoxes={showBoxLayer}
@@ -3956,54 +3955,6 @@ function formatLiveFallbackReason(reason: string | undefined) {
   }
 
   return reason.length > 28 ? `${reason.slice(0, 28)}…` : reason;
-}
-
-function resolveLiveDetectionFrameSize(frame: {
-  readonly height: number;
-  readonly orientation: string;
-  readonly width: number;
-}) {
-  "worklet";
-
-  if (frame.orientation === "left" || frame.orientation === "right") {
-    return {
-      height: frame.width,
-      width: frame.height,
-    };
-  }
-
-  return {
-    height: frame.height,
-    width: frame.width,
-  };
-}
-
-function resolveLiveFrameRendererStyle(options: {
-  readonly canvasHeight: number;
-  readonly canvasWidth: number;
-  readonly orientation: string;
-}): ViewStyle {
-  if (options.orientation === "left" || options.orientation === "right") {
-    return {
-      height: options.canvasWidth,
-      left: (options.canvasWidth - options.canvasHeight) / 2,
-      position: "absolute",
-      top: (options.canvasHeight - options.canvasWidth) / 2,
-      transform: [
-        { rotate: options.orientation === "left" ? "90deg" : "-90deg" },
-      ],
-      width: options.canvasHeight,
-    };
-  }
-
-  return {
-    bottom: 0,
-    left: 0,
-    position: "absolute",
-    right: 0,
-    top: 0,
-    transform: options.orientation === "down" ? [{ rotate: "180deg" }] : [],
-  };
 }
 
 function createLiveFrameError(

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -77,7 +77,6 @@ import {
 } from "supervision-js-react-native";
 import {
   useVisionCameraFrameOutput,
-  useVisionCameraFrameRenderer,
   VisionCameraFrameRendererView,
 } from "supervision-js-react-native/adapters/vision-camera";
 import {
@@ -1217,7 +1216,6 @@ function LiveCameraProof(props: {
     readonly timestamp: number;
   } | null>(null);
   const instantRequestIdRef = useRef(0);
-  const frameRenderer = useVisionCameraFrameRenderer();
   const canvasWidth = window.width;
   const canvasHeight = window.height;
   const isInstantPrivacy = isInstantCv && instantRecipe === "privacy";
@@ -2044,6 +2042,7 @@ function LiveCameraProof(props: {
       "worklet";
 
       let stage = "start";
+      let shouldPresent = false;
 
       try {
         const syncMode = "synced";
@@ -2256,8 +2255,8 @@ function LiveCameraProof(props: {
           lastShaderActive.value = false;
 
           stage = "render-synced-frame";
-          frameRenderer.renderFrame(frame);
           lastPresentedFrame.value = true;
+          shouldPresent = true;
         } else if (shouldRunInference) {
           const inferenceStartedAt = Date.now();
 
@@ -2624,8 +2623,8 @@ function LiveCameraProof(props: {
               namespace: "rn-live",
             },
             () => {
-              frameRenderer.renderFrame(frame);
               lastPresentedFrame.value = true;
+              shouldPresent = true;
             },
           );
         }
@@ -2664,6 +2663,8 @@ function LiveCameraProof(props: {
             visibleKeypointCount: lastVisibleKeypointCount.value,
           });
         }
+
+        return shouldPresent;
       } catch (error) {
         if (Date.now() - lastErrorReportAt.value > 250) {
           lastErrorReportAt.value = Date.now();
@@ -2672,8 +2673,7 @@ function LiveCameraProof(props: {
             createLiveFrameError(stage, error, frame),
           );
         }
-      } finally {
-        frame.dispose();
+        return false;
       }
     },
     [
@@ -2681,7 +2681,6 @@ function LiveCameraProof(props: {
       emptyLiveMaskImage,
       emptyLiveMaskUniforms,
       emptyLiveVectorPicture,
-      frameRenderer,
       lastArtifactBytes,
       lastArtifactHeight,
       lastArtifactWidth,
@@ -2731,13 +2730,14 @@ function LiveCameraProof(props: {
     ],
   );
 
-  const inferenceFrameOutput = useVisionCameraFrameOutput({
-    onFrame: onLiveInferenceFrame,
-    onFrameDropped() {
-      reportDroppedFrame();
-    },
-    targetResolution: LIVE_FRAME_TARGET_RESOLUTION,
-  });
+  const { frameOutput: inferenceFrameOutput, frameRenderer } =
+    useVisionCameraFrameOutput({
+      onFrame: onLiveInferenceFrame,
+      onFrameDropped() {
+        reportDroppedFrame();
+      },
+      targetResolution: LIVE_FRAME_TARGET_RESOLUTION,
+    });
 
   const cameraOutputs = useMemo(
     () => [inferenceFrameOutput],

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createVisionCameraLiveSource,
   presentVisionCameraFrame,
+  resolveVisionCameraFrameRendererStyle,
+  resolveVisionCameraFrameSize,
+  useVisionCameraDevice,
   useVisionCameraFrameRenderer,
   useVisionCameraFrameOutput,
+  useVisionCameraPermission,
 } from "./vision-camera";
 
 function createFrame(timestamp: number) {
@@ -82,6 +86,17 @@ describe("useVisionCameraFrameRenderer", () => {
   });
 });
 
+describe("VisionCamera hook adapters", () => {
+  it("fails clearly outside a VisionCamera runtime", () => {
+    expect(() => useVisionCameraDevice("back")).toThrow(
+      /VisionCamera is unavailable/,
+    );
+    expect(() => useVisionCameraPermission()).toThrow(
+      /VisionCamera is unavailable/,
+    );
+  });
+});
+
 describe("presentVisionCameraFrame", () => {
   it("renders only completed packets and always disposes the native frame", () => {
     const rendered = createFrame(0);
@@ -106,5 +121,43 @@ describe("presentVisionCameraFrame", () => {
       }),
     ).toThrow(/inference failed/);
     expect(frame.dispose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("VisionCamera orientation", () => {
+  it.each([
+    ["up", { height: 720, width: 1280 }],
+    ["down", { height: 720, width: 1280 }],
+    ["left", { height: 1280, width: 720 }],
+    ["right", { height: 1280, width: 720 }],
+  ])("normalizes %s detection dimensions", (orientation, expected) => {
+    expect(
+      resolveVisionCameraFrameSize({
+        height: 720,
+        orientation,
+        width: 1280,
+      }),
+    ).toEqual(expected);
+  });
+
+  it("uses the matching native renderer transform", () => {
+    expect(
+      resolveVisionCameraFrameRendererStyle({
+        canvasHeight: 800,
+        canvasWidth: 400,
+        orientation: "left",
+      }),
+    ).toMatchObject({
+      height: 400,
+      transform: [{ rotate: "90deg" }],
+      width: 800,
+    });
+    expect(
+      resolveVisionCameraFrameRendererStyle({
+        canvasHeight: 800,
+        canvasWidth: 400,
+        orientation: "down",
+      }),
+    ).toMatchObject({ transform: [{ rotate: "180deg" }] });
   });
 });

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createVisionCameraLiveSource,
+  presentVisionCameraFrame,
   useVisionCameraFrameRenderer,
   useVisionCameraFrameOutput,
 } from "./vision-camera";
@@ -66,7 +67,7 @@ describe("useVisionCameraFrameOutput", () => {
   it("fails clearly outside a VisionCamera runtime", () => {
     expect(() =>
       useVisionCameraFrameOutput({
-        onFrame: vi.fn(),
+        onFrame: vi.fn(() => false),
         targetResolution: { height: 720, width: 1280 },
       }),
     ).toThrow(/VisionCamera frame output is unavailable/);
@@ -78,5 +79,32 @@ describe("useVisionCameraFrameRenderer", () => {
     expect(() => useVisionCameraFrameRenderer()).toThrow(
       /VisionCamera is unavailable/,
     );
+  });
+});
+
+describe("presentVisionCameraFrame", () => {
+  it("renders only completed packets and always disposes the native frame", () => {
+    const rendered = createFrame(0);
+    const dropped = createFrame(1);
+    const frameRenderer = { renderFrame: vi.fn() };
+
+    presentVisionCameraFrame(rendered, frameRenderer, () => true);
+    presentVisionCameraFrame(dropped, frameRenderer, () => false);
+
+    expect(frameRenderer.renderFrame).toHaveBeenCalledOnce();
+    expect(frameRenderer.renderFrame).toHaveBeenCalledWith(rendered);
+    expect(rendered.dispose).toHaveBeenCalledOnce();
+    expect(dropped.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("releases the frame when host processing throws", () => {
+    const frame = createFrame(0);
+
+    expect(() =>
+      presentVisionCameraFrame(frame, { renderFrame: vi.fn() }, () => {
+        throw new Error("inference failed");
+      }),
+    ).toThrow(/inference failed/);
+    expect(frame.dispose).toHaveBeenCalledOnce();
   });
 });

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -5,6 +5,7 @@ import {
 } from "supervision-js-core";
 import {
   createElement,
+  Fragment,
   useCallback,
   type ComponentType,
   type ReactElement,
@@ -12,6 +13,7 @@ import {
 import type { StyleProp, ViewStyle } from "react-native";
 import type {
   CameraFrameOutput,
+  CameraDevice,
   Frame,
   FrameRenderer,
 } from "react-native-vision-camera";
@@ -73,9 +75,32 @@ export interface VisionCameraFrameRendererViewProps {
   readonly style?: StyleProp<ViewStyle>;
 }
 
+export interface VisionCameraLiveViewProps {
+  readonly cameraStyle?: StyleProp<ViewStyle>;
+  readonly device: CameraDevice;
+  readonly frameRenderer: FrameRenderer;
+  readonly frameRendererStyle?: StyleProp<ViewStyle>;
+  readonly isActive: boolean;
+  readonly outputs: CameraFrameOutput[];
+  readonly orientationSource?: "interface";
+}
+
 export interface VisionCameraFrameOutputBinding {
   readonly frameOutput: CameraFrameOutput;
   readonly frameRenderer: FrameRenderer;
+}
+
+/** Optional-peer alias for a native frame passed to a host inference producer. */
+export type VisionCameraOutputFrame = Frame;
+
+export interface VisionCameraPermissionState {
+  readonly hasPermission: boolean;
+  requestPermission(): Promise<boolean>;
+}
+
+export interface VisionCameraFrameSize {
+  readonly height: number;
+  readonly width: number;
 }
 
 /**
@@ -98,6 +123,60 @@ export function presentVisionCameraFrame<TFrame extends VisionCameraFrame>(
   } finally {
     frame.dispose();
   }
+}
+
+/**
+ * Resolves the upright detection coordinate space for VisionCamera's reported
+ * frame orientation. The camera buffer remains native-oriented; only semantic
+ * detection coordinates are normalized here.
+ */
+export function resolveVisionCameraFrameSize(frame: {
+  readonly height: number;
+  readonly orientation: string;
+  readonly width: number;
+}): VisionCameraFrameSize {
+  "worklet";
+
+  if (frame.orientation === "left" || frame.orientation === "right") {
+    return {
+      height: frame.width,
+      width: frame.height,
+    };
+  }
+
+  return {
+    height: frame.height,
+    width: frame.width,
+  };
+}
+
+/** Builds the native presentation transform that matches the camera orientation. */
+export function resolveVisionCameraFrameRendererStyle(options: {
+  readonly canvasHeight: number;
+  readonly canvasWidth: number;
+  readonly orientation: string;
+}): ViewStyle {
+  if (options.orientation === "left" || options.orientation === "right") {
+    return {
+      height: options.canvasWidth,
+      left: (options.canvasWidth - options.canvasHeight) / 2,
+      position: "absolute",
+      top: (options.canvasHeight - options.canvasWidth) / 2,
+      transform: [
+        { rotate: options.orientation === "left" ? "90deg" : "-90deg" },
+      ],
+      width: options.canvasHeight,
+    };
+  }
+
+  return {
+    bottom: 0,
+    left: 0,
+    position: "absolute",
+    right: 0,
+    top: 0,
+    transform: options.orientation === "down" ? [{ rotate: "180deg" }] : [],
+  };
 }
 
 const LIVE_CAPABILITIES: MediaSessionCapabilities = {
@@ -240,6 +319,22 @@ export function useVisionCameraFrameRenderer(): FrameRenderer {
   return visionCamera.useFrameRenderer();
 }
 
+/** Returns the optional VisionCamera device hook through the package boundary. */
+export function useVisionCameraDevice(
+  position: "back" | "front" | "external" | "unspecified",
+): CameraDevice | undefined {
+  const visionCamera = loadVisionCamera();
+
+  return visionCamera.useCameraDevice(position);
+}
+
+/** Returns the optional VisionCamera permission hook through the package boundary. */
+export function useVisionCameraPermission(): VisionCameraPermissionState {
+  const visionCamera = loadVisionCamera();
+
+  return visionCamera.useCameraPermission();
+}
+
 /** Package-owned view binding for a VisionCamera native frame renderer. */
 export function VisionCameraFrameRendererView(
   props: VisionCameraFrameRendererViewProps,
@@ -249,7 +344,35 @@ export function VisionCameraFrameRendererView(
   return createElement(visionCamera.NativeFrameRendererView, props);
 }
 
+/**
+ * Package-owned VisionCamera scene binding for the live preview and its
+ * strict-sync rendered surface. Hosts supply session/producer state only;
+ * the optional adapter owns the vendor component composition.
+ */
+export function VisionCameraLiveView(
+  props: VisionCameraLiveViewProps,
+): ReactElement {
+  const visionCamera = loadVisionCamera();
+
+  return createElement(
+    Fragment,
+    null,
+    createElement(visionCamera.Camera, {
+      device: props.device,
+      isActive: props.isActive,
+      orientationSource: props.orientationSource,
+      outputs: props.outputs,
+      style: props.cameraStyle,
+    }),
+    createElement(visionCamera.NativeFrameRendererView, {
+      renderer: props.frameRenderer,
+      style: props.frameRendererStyle,
+    }),
+  );
+}
+
 interface VisionCameraModule {
+  Camera: ComponentType<VisionCameraCameraProps>;
   NativeFrameRendererView: ComponentType<VisionCameraFrameRendererViewProps>;
   useFrameOutput(config: {
     allowDeferredStart: boolean;
@@ -261,7 +384,19 @@ interface VisionCameraModule {
     pixelFormat: "rgb";
     targetResolution: VisionCameraFrameOutputOptions<Frame>["targetResolution"];
   }): CameraFrameOutput;
+  useCameraDevice(
+    position: "back" | "front" | "external" | "unspecified",
+  ): CameraDevice | undefined;
+  useCameraPermission(): VisionCameraPermissionState;
   useFrameRenderer(): FrameRenderer;
+}
+
+interface VisionCameraCameraProps {
+  readonly device: CameraDevice;
+  readonly isActive: boolean;
+  readonly orientationSource?: "interface";
+  readonly outputs?: CameraFrameOutput[];
+  readonly style?: StyleProp<ViewStyle>;
 }
 
 function loadVisionCamera(): VisionCameraModule {

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -3,10 +3,18 @@ import {
   type MediaTimelineMetadata,
   type PlatformMediaFrame,
 } from "supervision-js-core";
-import { createElement, type ComponentType, type ReactElement } from "react";
+import {
+  createElement,
+  useCallback,
+  type ComponentType,
+  type ReactElement,
+} from "react";
 import type { StyleProp, ViewStyle } from "react-native";
-import type { CameraFrameOutput } from "react-native-vision-camera";
-import type { FrameRenderer } from "react-native-vision-camera";
+import type {
+  CameraFrameOutput,
+  Frame,
+  FrameRenderer,
+} from "react-native-vision-camera";
 
 import type {
   MediaFrameSource,
@@ -47,7 +55,12 @@ export interface VisionCameraLiveSource<
 export interface VisionCameraFrameOutputOptions<
   TFrame extends VisionCameraFrame,
 > {
-  readonly onFrame: (frame: TFrame) => void;
+  /**
+   * Processes one frame and returns whether its completed packet should be
+   * presented. The adapter owns rendering and disposal after this callback
+   * settles, so host worklets cannot dispose a frame before native rendering.
+   */
+  readonly onFrame: (frame: TFrame) => boolean;
   readonly onFrameDropped?: () => void;
   readonly targetResolution: {
     readonly height: number;
@@ -58,6 +71,33 @@ export interface VisionCameraFrameOutputOptions<
 export interface VisionCameraFrameRendererViewProps {
   readonly renderer: FrameRenderer;
   readonly style?: StyleProp<ViewStyle>;
+}
+
+export interface VisionCameraFrameOutputBinding {
+  readonly frameOutput: CameraFrameOutput;
+  readonly frameRenderer: FrameRenderer;
+}
+
+/**
+ * Presents a completed frame and always releases its native buffer afterwards.
+ *
+ * This is exported for advanced custom VisionCamera bindings; normal React
+ * consumers get the same lifecycle through `useVisionCameraFrameOutput()`.
+ */
+export function presentVisionCameraFrame<TFrame extends VisionCameraFrame>(
+  frame: TFrame,
+  frameRenderer: Pick<FrameRenderer, "renderFrame">,
+  processFrame: (frame: TFrame) => boolean,
+): void {
+  "worklet";
+
+  try {
+    if (processFrame(frame)) {
+      frameRenderer.renderFrame(frame as unknown as Frame);
+    }
+  } finally {
+    frame.dispose();
+  }
 }
 
 const LIVE_CAPABILITIES: MediaSessionCapabilities = {
@@ -152,7 +192,7 @@ export function createVisionCameraLiveSource<TFrame extends VisionCameraFrame>(
  */
 export function useVisionCameraFrameOutput<TFrame extends VisionCameraFrame>(
   options: VisionCameraFrameOutputOptions<TFrame>,
-): CameraFrameOutput {
+): VisionCameraFrameOutputBinding {
   let visionCamera: VisionCameraModule;
 
   try {
@@ -166,16 +206,31 @@ export function useVisionCameraFrameOutput<TFrame extends VisionCameraFrame>(
     );
   }
 
-  return visionCamera.useFrameOutput({
-    allowDeferredStart: false,
-    dropFramesWhileBusy: true,
-    enablePhysicalBufferRotation: false,
-    enablePreviewSizedOutputBuffers: true,
-    onFrame: options.onFrame,
-    onFrameDropped: options.onFrameDropped,
-    pixelFormat: "rgb",
-    targetResolution: options.targetResolution,
-  });
+  const frameRenderer = useVisionCameraFrameRenderer();
+  const onFrame = useCallback(
+    (frame: Frame) => {
+      "worklet";
+
+      presentVisionCameraFrame(frame, frameRenderer, (nextFrame) =>
+        options.onFrame(nextFrame as unknown as TFrame),
+      );
+    },
+    [frameRenderer, options.onFrame],
+  );
+
+  return {
+    frameOutput: visionCamera.useFrameOutput({
+      allowDeferredStart: false,
+      dropFramesWhileBusy: true,
+      enablePhysicalBufferRotation: false,
+      enablePreviewSizedOutputBuffers: true,
+      onFrame,
+      onFrameDropped: options.onFrameDropped,
+      pixelFormat: "rgb",
+      targetResolution: options.targetResolution,
+    }),
+    frameRenderer,
+  };
 }
 
 /** Returns the optional VisionCamera native frame renderer with a stable error. */
@@ -196,15 +251,15 @@ export function VisionCameraFrameRendererView(
 
 interface VisionCameraModule {
   NativeFrameRendererView: ComponentType<VisionCameraFrameRendererViewProps>;
-  useFrameOutput<TFrame extends VisionCameraFrame>(config: {
+  useFrameOutput(config: {
     allowDeferredStart: boolean;
     dropFramesWhileBusy: boolean;
     enablePhysicalBufferRotation: boolean;
     enablePreviewSizedOutputBuffers: boolean;
-    onFrame(frame: TFrame): void;
+    onFrame(frame: Frame): void;
     onFrameDropped?: () => void;
     pixelFormat: "rgb";
-    targetResolution: VisionCameraFrameOutputOptions<TFrame>["targetResolution"];
+    targetResolution: VisionCameraFrameOutputOptions<Frame>["targetResolution"];
   }): CameraFrameOutput;
   useFrameRenderer(): FrameRenderer;
 }


### PR DESCRIPTION
# Description

Makes the VisionCamera adapter own the strict presentation lifecycle: it renders only a completed packet and disposes every native frame afterwards. The demo now reports whether a packet is ready instead of directly rendering or disposing the frame.

## Type of change

- [x] Maintenance (non-breaking change which improves an experimental package boundary)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added adapter tests for render, skip, and error disposal paths
- Ran focused VisionCamera adapter tests
- Ran React Native package typecheck and build
- Ran React Native demo typecheck

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Validate the live camera on iPhone after merging: camera frames must keep presenting and no native-buffer stalls should occur.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)