### PR TITLE
Move the live VisionCamera view into the optional adapter

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -39,12 +39,6 @@ import {
   Vibration,
   View,
 } from "react-native";
-import {
-  Camera,
-  useCameraDevice,
-  useCameraPermission,
-  type Frame,
-} from "react-native-vision-camera";
 import { useSharedValue } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import { Asset } from "expo-asset";
@@ -77,7 +71,10 @@ import {
 } from "supervision-js-react-native";
 import {
   useVisionCameraFrameOutput,
-  VisionCameraFrameRendererView,
+  useVisionCameraDevice,
+  useVisionCameraPermission,
+  VisionCameraLiveView,
+  type VisionCameraOutputFrame,
 } from "supervision-js-react-native/adapters/vision-camera";
 import {
   createReactNativeStaticMediaSessionBinding,
@@ -1174,8 +1171,8 @@ function LiveCameraProof(props: {
 }) {
   const isInstantCv = props.mode === "instant";
   const window = useWindowDimensions();
-  const device = useCameraDevice("back");
-  const { hasPermission, requestPermission } = useCameraPermission();
+  const device = useVisionCameraDevice("back");
+  const { hasPermission, requestPermission } = useVisionCameraPermission();
   const [liveFrame, setLiveFrame] = useState<LiveFrameState | null>(null);
   const [liveError, setLiveError] = useState<LiveFrameError | null>(null);
   const [liveDetections, setLiveDetections] = useState<
@@ -2038,7 +2035,7 @@ function LiveCameraProof(props: {
   // must all be render-stable (shared values, useCallback reporters, memoized
   // handles). Per-render data flows in through shared values instead.
   const onLiveInferenceFrame = useCallback(
-    (frame: Frame) => {
+    (frame: VisionCameraOutputFrame) => {
       "worklet";
 
       let stage = "start";
@@ -2791,25 +2788,25 @@ function LiveCameraProof(props: {
         mediaLayer={
           <>
             {device ? (
-              <Camera
-                device={device}
-                isActive={Boolean(canRunCamera)}
-                orientationSource="interface"
-                outputs={cameraOutputs}
-                style={[
+              <VisionCameraLiveView
+                cameraStyle={[
                   styles.captureCamera,
                   awaitingSyncedFrame ? styles.captureCameraVisible : null,
                 ]}
+                device={device}
+                frameRenderer={frameRenderer}
+                frameRendererStyle={[
+                  styles.frameRendererSurface,
+                  liveFrameRendererStyle,
+                  awaitingSyncedFrame
+                    ? styles.frameRendererSurfaceHidden
+                    : null,
+                ]}
+                isActive={Boolean(canRunCamera)}
+                orientationSource="interface"
+                outputs={cameraOutputs}
               />
             ) : null}
-            <VisionCameraFrameRendererView
-              renderer={frameRenderer}
-              style={[
-                styles.frameRendererSurface,
-                liveFrameRendererStyle,
-                awaitingSyncedFrame ? styles.frameRendererSurfaceHidden : null,
-              ]}
-            />
           </>
         }
         showBoxes={showBoxLayer}

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -74,6 +74,8 @@ import {
   useVisionCameraDevice,
   useVisionCameraPermission,
   VisionCameraLiveView,
+  resolveVisionCameraFrameRendererStyle,
+  resolveVisionCameraFrameSize,
   type VisionCameraOutputFrame,
 } from "supervision-js-react-native/adapters/vision-camera";
 import {
@@ -1255,7 +1257,7 @@ function LiveCameraProof(props: {
   );
   const liveFrameRendererStyle = useMemo(
     () =>
-      resolveLiveFrameRendererStyle({
+      resolveVisionCameraFrameRendererStyle({
         canvasHeight,
         canvasWidth,
         orientation: liveFrame?.frameOrientation ?? "left",
@@ -2068,7 +2070,7 @@ function LiveCameraProof(props: {
               }),
           );
           const poseMs = Date.now() - poseStartedAt;
-          const detectionFrameSize = resolveLiveDetectionFrameSize(frame);
+          const detectionFrameSize = resolveVisionCameraFrameSize(frame);
           const mediaRect = liveMediaRect.value;
           stage = "pose-adapt";
           const serializationStartedAt = Date.now();
@@ -2276,7 +2278,7 @@ function LiveCameraProof(props: {
           const segmentationMs = Date.now() - segmentationStartedAt;
           stage = "mask-read-layout";
           const mediaRect = liveMediaRect.value;
-          const detectionFrameSize = resolveLiveDetectionFrameSize(frame);
+          const detectionFrameSize = resolveVisionCameraFrameSize(frame);
           stage = "mask-serialize-detections";
           const serializationStartedAt = Date.now();
           const detections = runWithWorkletDebugLogging(
@@ -2638,7 +2640,7 @@ function LiveCameraProof(props: {
             frameOrientation: frame.orientation,
             frameIsMirrored: frame.isMirrored,
             hasPresentedFrame: lastPresentedFrame.value,
-            height: resolveLiveDetectionFrameSize(frame).height,
+            height: resolveVisionCameraFrameSize(frame).height,
             inferenceTickMs: lastInferenceTickDurationMs.value,
             maskBuilder: lastMaskBuilderName.value,
             maskFallbackReason: lastMaskFallbackReason.value,
@@ -2656,7 +2658,7 @@ function LiveCameraProof(props: {
             shaderActive: lastShaderActive.value,
             syncMode,
             timestamp: frame.timestamp,
-            width: resolveLiveDetectionFrameSize(frame).width,
+            width: resolveVisionCameraFrameSize(frame).width,
             visibleKeypointCount: lastVisibleKeypointCount.value,
           });
         }
@@ -3953,54 +3955,6 @@ function formatLiveFallbackReason(reason: string | undefined) {
   }
 
   return reason.length > 28 ? `${reason.slice(0, 28)}…` : reason;
-}
-
-function resolveLiveDetectionFrameSize(frame: {
-  readonly height: number;
-  readonly orientation: string;
-  readonly width: number;
-}) {
-  "worklet";
-
-  if (frame.orientation === "left" || frame.orientation === "right") {
-    return {
-      height: frame.width,
-      width: frame.height,
-    };
-  }
-
-  return {
-    height: frame.height,
-    width: frame.width,
-  };
-}
-
-function resolveLiveFrameRendererStyle(options: {
-  readonly canvasHeight: number;
-  readonly canvasWidth: number;
-  readonly orientation: string;
-}): ViewStyle {
-  if (options.orientation === "left" || options.orientation === "right") {
-    return {
-      height: options.canvasWidth,
-      left: (options.canvasWidth - options.canvasHeight) / 2,
-      position: "absolute",
-      top: (options.canvasHeight - options.canvasWidth) / 2,
-      transform: [
-        { rotate: options.orientation === "left" ? "90deg" : "-90deg" },
-      ],
-      width: options.canvasHeight,
-    };
-  }
-
-  return {
-    bottom: 0,
-    left: 0,
-    position: "absolute",
-    right: 0,
-    top: 0,
-    transform: options.orientation === "down" ? [{ rotate: "180deg" }] : [],
-  };
 }
 
 function createLiveFrameError(

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createVisionCameraLiveSource,
   presentVisionCameraFrame,
+  useVisionCameraDevice,
   useVisionCameraFrameRenderer,
   useVisionCameraFrameOutput,
+  useVisionCameraPermission,
 } from "./vision-camera";
 
 function createFrame(timestamp: number) {
@@ -77,6 +79,17 @@ describe("useVisionCameraFrameOutput", () => {
 describe("useVisionCameraFrameRenderer", () => {
   it("fails clearly outside a VisionCamera runtime", () => {
     expect(() => useVisionCameraFrameRenderer()).toThrow(
+      /VisionCamera is unavailable/,
+    );
+  });
+});
+
+describe("VisionCamera hook adapters", () => {
+  it("fails clearly outside a VisionCamera runtime", () => {
+    expect(() => useVisionCameraDevice("back")).toThrow(
+      /VisionCamera is unavailable/,
+    );
+    expect(() => useVisionCameraPermission()).toThrow(
       /VisionCamera is unavailable/,
     );
   });

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createVisionCameraLiveSource,
   presentVisionCameraFrame,
+  resolveVisionCameraFrameRendererStyle,
+  resolveVisionCameraFrameSize,
   useVisionCameraDevice,
   useVisionCameraFrameRenderer,
   useVisionCameraFrameOutput,
@@ -119,5 +121,43 @@ describe("presentVisionCameraFrame", () => {
       }),
     ).toThrow(/inference failed/);
     expect(frame.dispose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("VisionCamera orientation", () => {
+  it.each([
+    ["up", { height: 720, width: 1280 }],
+    ["down", { height: 720, width: 1280 }],
+    ["left", { height: 1280, width: 720 }],
+    ["right", { height: 1280, width: 720 }],
+  ])("normalizes %s detection dimensions", (orientation, expected) => {
+    expect(
+      resolveVisionCameraFrameSize({
+        height: 720,
+        orientation,
+        width: 1280,
+      }),
+    ).toEqual(expected);
+  });
+
+  it("uses the matching native renderer transform", () => {
+    expect(
+      resolveVisionCameraFrameRendererStyle({
+        canvasHeight: 800,
+        canvasWidth: 400,
+        orientation: "left",
+      }),
+    ).toMatchObject({
+      height: 400,
+      transform: [{ rotate: "90deg" }],
+      width: 800,
+    });
+    expect(
+      resolveVisionCameraFrameRendererStyle({
+        canvasHeight: 800,
+        canvasWidth: 400,
+        orientation: "down",
+      }),
+    ).toMatchObject({ transform: [{ rotate: "180deg" }] });
   });
 });

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -5,6 +5,7 @@ import {
 } from "supervision-js-core";
 import {
   createElement,
+  Fragment,
   useCallback,
   type ComponentType,
   type ReactElement,
@@ -12,6 +13,7 @@ import {
 import type { StyleProp, ViewStyle } from "react-native";
 import type {
   CameraFrameOutput,
+  CameraDevice,
   Frame,
   FrameRenderer,
 } from "react-native-vision-camera";
@@ -73,9 +75,27 @@ export interface VisionCameraFrameRendererViewProps {
   readonly style?: StyleProp<ViewStyle>;
 }
 
+export interface VisionCameraLiveViewProps {
+  readonly cameraStyle?: StyleProp<ViewStyle>;
+  readonly device: CameraDevice;
+  readonly frameRenderer: FrameRenderer;
+  readonly frameRendererStyle?: StyleProp<ViewStyle>;
+  readonly isActive: boolean;
+  readonly outputs: CameraFrameOutput[];
+  readonly orientationSource?: "interface";
+}
+
 export interface VisionCameraFrameOutputBinding {
   readonly frameOutput: CameraFrameOutput;
   readonly frameRenderer: FrameRenderer;
+}
+
+/** Optional-peer alias for a native frame passed to a host inference producer. */
+export type VisionCameraOutputFrame = Frame;
+
+export interface VisionCameraPermissionState {
+  readonly hasPermission: boolean;
+  requestPermission(): Promise<boolean>;
 }
 
 /**
@@ -240,6 +260,22 @@ export function useVisionCameraFrameRenderer(): FrameRenderer {
   return visionCamera.useFrameRenderer();
 }
 
+/** Returns the optional VisionCamera device hook through the package boundary. */
+export function useVisionCameraDevice(
+  position: "back" | "front" | "external" | "unspecified",
+): CameraDevice | undefined {
+  const visionCamera = loadVisionCamera();
+
+  return visionCamera.useCameraDevice(position);
+}
+
+/** Returns the optional VisionCamera permission hook through the package boundary. */
+export function useVisionCameraPermission(): VisionCameraPermissionState {
+  const visionCamera = loadVisionCamera();
+
+  return visionCamera.useCameraPermission();
+}
+
 /** Package-owned view binding for a VisionCamera native frame renderer. */
 export function VisionCameraFrameRendererView(
   props: VisionCameraFrameRendererViewProps,
@@ -249,7 +285,35 @@ export function VisionCameraFrameRendererView(
   return createElement(visionCamera.NativeFrameRendererView, props);
 }
 
+/**
+ * Package-owned VisionCamera scene binding for the live preview and its
+ * strict-sync rendered surface. Hosts supply session/producer state only;
+ * the optional adapter owns the vendor component composition.
+ */
+export function VisionCameraLiveView(
+  props: VisionCameraLiveViewProps,
+): ReactElement {
+  const visionCamera = loadVisionCamera();
+
+  return createElement(
+    Fragment,
+    null,
+    createElement(visionCamera.Camera, {
+      device: props.device,
+      isActive: props.isActive,
+      orientationSource: props.orientationSource,
+      outputs: props.outputs,
+      style: props.cameraStyle,
+    }),
+    createElement(visionCamera.NativeFrameRendererView, {
+      renderer: props.frameRenderer,
+      style: props.frameRendererStyle,
+    }),
+  );
+}
+
 interface VisionCameraModule {
+  Camera: ComponentType<VisionCameraCameraProps>;
   NativeFrameRendererView: ComponentType<VisionCameraFrameRendererViewProps>;
   useFrameOutput(config: {
     allowDeferredStart: boolean;
@@ -261,7 +325,19 @@ interface VisionCameraModule {
     pixelFormat: "rgb";
     targetResolution: VisionCameraFrameOutputOptions<Frame>["targetResolution"];
   }): CameraFrameOutput;
+  useCameraDevice(
+    position: "back" | "front" | "external" | "unspecified",
+  ): CameraDevice | undefined;
+  useCameraPermission(): VisionCameraPermissionState;
   useFrameRenderer(): FrameRenderer;
+}
+
+interface VisionCameraCameraProps {
+  readonly device: CameraDevice;
+  readonly isActive: boolean;
+  readonly orientationSource?: "interface";
+  readonly outputs?: CameraFrameOutput[];
+  readonly style?: StyleProp<ViewStyle>;
 }
 
 function loadVisionCamera(): VisionCameraModule {

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -98,6 +98,11 @@ export interface VisionCameraPermissionState {
   requestPermission(): Promise<boolean>;
 }
 
+export interface VisionCameraFrameSize {
+  readonly height: number;
+  readonly width: number;
+}
+
 /**
  * Presents a completed frame and always releases its native buffer afterwards.
  *
@@ -118,6 +123,60 @@ export function presentVisionCameraFrame<TFrame extends VisionCameraFrame>(
   } finally {
     frame.dispose();
   }
+}
+
+/**
+ * Resolves the upright detection coordinate space for VisionCamera's reported
+ * frame orientation. The camera buffer remains native-oriented; only semantic
+ * detection coordinates are normalized here.
+ */
+export function resolveVisionCameraFrameSize(frame: {
+  readonly height: number;
+  readonly orientation: string;
+  readonly width: number;
+}): VisionCameraFrameSize {
+  "worklet";
+
+  if (frame.orientation === "left" || frame.orientation === "right") {
+    return {
+      height: frame.width,
+      width: frame.height,
+    };
+  }
+
+  return {
+    height: frame.height,
+    width: frame.width,
+  };
+}
+
+/** Builds the native presentation transform that matches the camera orientation. */
+export function resolveVisionCameraFrameRendererStyle(options: {
+  readonly canvasHeight: number;
+  readonly canvasWidth: number;
+  readonly orientation: string;
+}): ViewStyle {
+  if (options.orientation === "left" || options.orientation === "right") {
+    return {
+      height: options.canvasWidth,
+      left: (options.canvasWidth - options.canvasHeight) / 2,
+      position: "absolute",
+      top: (options.canvasHeight - options.canvasWidth) / 2,
+      transform: [
+        { rotate: options.orientation === "left" ? "90deg" : "-90deg" },
+      ],
+      width: options.canvasHeight,
+    };
+  }
+
+  return {
+    bottom: 0,
+    left: 0,
+    position: "absolute",
+    right: 0,
+    top: 0,
+    transform: options.orientation === "down" ? [{ rotate: "180deg" }] : [],
+  };
 }
 
 const LIVE_CAPABILITIES: MediaSessionCapabilities = {


### PR DESCRIPTION
# Description

Moves the live Camera plus native-frame-renderer surface into the optional VisionCamera adapter. The demo now receives device/permission and live-view bindings through the package boundary rather than importing VisionCamera components or frame types directly.

## Type of change

- [x] Maintenance (non-breaking change which improves an experimental package boundary)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added off-device errors for the package camera device and permission hooks
- Ran focused VisionCamera adapter tests
- Ran React Native package typecheck and build
- Ran React Native demo typecheck

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Validate the live camera preview and strict-sync rendered surface on iPhone after merging the stack.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)