### PR TITLE
Normalize live camera orientation in the adapter

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -74,6 +74,8 @@ import {
   useVisionCameraDevice,
   useVisionCameraPermission,
   VisionCameraLiveView,
+  resolveVisionCameraFrameRendererStyle,
+  resolveVisionCameraFrameSize,
   type VisionCameraOutputFrame,
 } from "supervision-js-react-native/adapters/vision-camera";
 import {
@@ -1255,7 +1257,7 @@ function LiveCameraProof(props: {
   );
   const liveFrameRendererStyle = useMemo(
     () =>
-      resolveLiveFrameRendererStyle({
+      resolveVisionCameraFrameRendererStyle({
         canvasHeight,
         canvasWidth,
         orientation: liveFrame?.frameOrientation ?? "left",
@@ -2068,7 +2070,7 @@ function LiveCameraProof(props: {
               }),
           );
           const poseMs = Date.now() - poseStartedAt;
-          const detectionFrameSize = resolveLiveDetectionFrameSize(frame);
+          const detectionFrameSize = resolveVisionCameraFrameSize(frame);
           const mediaRect = liveMediaRect.value;
           stage = "pose-adapt";
           const serializationStartedAt = Date.now();
@@ -2276,7 +2278,7 @@ function LiveCameraProof(props: {
           const segmentationMs = Date.now() - segmentationStartedAt;
           stage = "mask-read-layout";
           const mediaRect = liveMediaRect.value;
-          const detectionFrameSize = resolveLiveDetectionFrameSize(frame);
+          const detectionFrameSize = resolveVisionCameraFrameSize(frame);
           stage = "mask-serialize-detections";
           const serializationStartedAt = Date.now();
           const detections = runWithWorkletDebugLogging(
@@ -2638,7 +2640,7 @@ function LiveCameraProof(props: {
             frameOrientation: frame.orientation,
             frameIsMirrored: frame.isMirrored,
             hasPresentedFrame: lastPresentedFrame.value,
-            height: resolveLiveDetectionFrameSize(frame).height,
+            height: resolveVisionCameraFrameSize(frame).height,
             inferenceTickMs: lastInferenceTickDurationMs.value,
             maskBuilder: lastMaskBuilderName.value,
             maskFallbackReason: lastMaskFallbackReason.value,
@@ -2656,7 +2658,7 @@ function LiveCameraProof(props: {
             shaderActive: lastShaderActive.value,
             syncMode,
             timestamp: frame.timestamp,
-            width: resolveLiveDetectionFrameSize(frame).width,
+            width: resolveVisionCameraFrameSize(frame).width,
             visibleKeypointCount: lastVisibleKeypointCount.value,
           });
         }
@@ -3953,54 +3955,6 @@ function formatLiveFallbackReason(reason: string | undefined) {
   }
 
   return reason.length > 28 ? `${reason.slice(0, 28)}…` : reason;
-}
-
-function resolveLiveDetectionFrameSize(frame: {
-  readonly height: number;
-  readonly orientation: string;
-  readonly width: number;
-}) {
-  "worklet";
-
-  if (frame.orientation === "left" || frame.orientation === "right") {
-    return {
-      height: frame.width,
-      width: frame.height,
-    };
-  }
-
-  return {
-    height: frame.height,
-    width: frame.width,
-  };
-}
-
-function resolveLiveFrameRendererStyle(options: {
-  readonly canvasHeight: number;
-  readonly canvasWidth: number;
-  readonly orientation: string;
-}): ViewStyle {
-  if (options.orientation === "left" || options.orientation === "right") {
-    return {
-      height: options.canvasWidth,
-      left: (options.canvasWidth - options.canvasHeight) / 2,
-      position: "absolute",
-      top: (options.canvasHeight - options.canvasWidth) / 2,
-      transform: [
-        { rotate: options.orientation === "left" ? "90deg" : "-90deg" },
-      ],
-      width: options.canvasHeight,
-    };
-  }
-
-  return {
-    bottom: 0,
-    left: 0,
-    position: "absolute",
-    right: 0,
-    top: 0,
-    transform: options.orientation === "down" ? [{ rotate: "180deg" }] : [],
-  };
 }
 
 function createLiveFrameError(

--- a/packages/react-native/src/adapters/vision-camera.test.ts
+++ b/packages/react-native/src/adapters/vision-camera.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createVisionCameraLiveSource,
   presentVisionCameraFrame,
+  resolveVisionCameraFrameRendererStyle,
+  resolveVisionCameraFrameSize,
   useVisionCameraDevice,
   useVisionCameraFrameRenderer,
   useVisionCameraFrameOutput,
@@ -119,5 +121,43 @@ describe("presentVisionCameraFrame", () => {
       }),
     ).toThrow(/inference failed/);
     expect(frame.dispose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("VisionCamera orientation", () => {
+  it.each([
+    ["up", { height: 720, width: 1280 }],
+    ["down", { height: 720, width: 1280 }],
+    ["left", { height: 1280, width: 720 }],
+    ["right", { height: 1280, width: 720 }],
+  ])("normalizes %s detection dimensions", (orientation, expected) => {
+    expect(
+      resolveVisionCameraFrameSize({
+        height: 720,
+        orientation,
+        width: 1280,
+      }),
+    ).toEqual(expected);
+  });
+
+  it("uses the matching native renderer transform", () => {
+    expect(
+      resolveVisionCameraFrameRendererStyle({
+        canvasHeight: 800,
+        canvasWidth: 400,
+        orientation: "left",
+      }),
+    ).toMatchObject({
+      height: 400,
+      transform: [{ rotate: "90deg" }],
+      width: 800,
+    });
+    expect(
+      resolveVisionCameraFrameRendererStyle({
+        canvasHeight: 800,
+        canvasWidth: 400,
+        orientation: "down",
+      }),
+    ).toMatchObject({ transform: [{ rotate: "180deg" }] });
   });
 });

--- a/packages/react-native/src/adapters/vision-camera.ts
+++ b/packages/react-native/src/adapters/vision-camera.ts
@@ -98,6 +98,11 @@ export interface VisionCameraPermissionState {
   requestPermission(): Promise<boolean>;
 }
 
+export interface VisionCameraFrameSize {
+  readonly height: number;
+  readonly width: number;
+}
+
 /**
  * Presents a completed frame and always releases its native buffer afterwards.
  *
@@ -118,6 +123,60 @@ export function presentVisionCameraFrame<TFrame extends VisionCameraFrame>(
   } finally {
     frame.dispose();
   }
+}
+
+/**
+ * Resolves the upright detection coordinate space for VisionCamera's reported
+ * frame orientation. The camera buffer remains native-oriented; only semantic
+ * detection coordinates are normalized here.
+ */
+export function resolveVisionCameraFrameSize(frame: {
+  readonly height: number;
+  readonly orientation: string;
+  readonly width: number;
+}): VisionCameraFrameSize {
+  "worklet";
+
+  if (frame.orientation === "left" || frame.orientation === "right") {
+    return {
+      height: frame.width,
+      width: frame.height,
+    };
+  }
+
+  return {
+    height: frame.height,
+    width: frame.width,
+  };
+}
+
+/** Builds the native presentation transform that matches the camera orientation. */
+export function resolveVisionCameraFrameRendererStyle(options: {
+  readonly canvasHeight: number;
+  readonly canvasWidth: number;
+  readonly orientation: string;
+}): ViewStyle {
+  if (options.orientation === "left" || options.orientation === "right") {
+    return {
+      height: options.canvasWidth,
+      left: (options.canvasWidth - options.canvasHeight) / 2,
+      position: "absolute",
+      top: (options.canvasHeight - options.canvasWidth) / 2,
+      transform: [
+        { rotate: options.orientation === "left" ? "90deg" : "-90deg" },
+      ],
+      width: options.canvasHeight,
+    };
+  }
+
+  return {
+    bottom: 0,
+    left: 0,
+    position: "absolute",
+    right: 0,
+    top: 0,
+    transform: options.orientation === "down" ? [{ rotate: "180deg" }] : [],
+  };
 }
 
 const LIVE_CAPABILITIES: MediaSessionCapabilities = {


### PR DESCRIPTION
# Description

Moves VisionCamera orientation-to-detection-size normalization and native renderer transforms into the optional adapter. The adapter now has pure coverage for all supported orientations, while the demo stops owning camera presentation geometry.

## Type of change

- [x] Maintenance (non-breaking change which improves an experimental package boundary)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added orientation and renderer-transform adapter tests
- Ran focused VisionCamera adapter tests
- Ran React Native package typecheck and build
- Ran React Native demo typecheck
- Ran npm run verify on the stack head before this extraction

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Validate portrait and landscape camera presentation on iPhone after merging the stack.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)