### PR TITLE
Add an architecture-first docs homepage

### DIFF
--- a/docs/internal/agent-guidance.md
+++ b/docs/internal/agent-guidance.md
@@ -23,6 +23,19 @@ Before making project-direction or architecture changes, read:
 Those docs define the current product intent: maintain a focused, session-first
 browser API without promising a broad Python-parity annotation framework.
 
+## Public Docs Home
+
+[`../public/index.md`](../public/index.md) is the source of the public docs
+homepage. Update it in the same change when the public package name or install
+path, the session-first API, supported browser capabilities, public/private
+package boundary, or documentation entrypoints materially change.
+
+Keep it consumer-facing and current: explain the architecture enough to orient
+an integrator, but do not promote Pixi, Mediabunny, workers, prepared artifacts,
+or the private React Native experiment into public contracts. Do not edit
+generated `docs/site/` output; rebuild the docs with `npm run demo:build` and
+run `npm run docs:check` after changing the homepage.
+
 ## Project Direction
 
 - Keep the core library vanilla browser TypeScript/JavaScript.

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -7,7 +7,7 @@
         <code>supervision</code> is a browser-native TypeScript library for interactive computer vision media. A media session keeps the visible frame, detections, styles, interaction, and playback on one timing reference.
       </p>
       <div class="supervision-home__actions">
-        <a class="supervision-home__button supervision-home__button--primary" data-supervision-docs-link="documents/Application_Integration.html">Get started</a>
+        <a class="supervision-home__button supervision-home__button--primary" href="documents/Application_Integration.html">Get started</a>
         <a class="supervision-home__button supervision-home__button--secondary" href="https://supervision-js-demo.onrender.com/">Open the demo</a>
       </div>
     </div>
@@ -33,18 +33,24 @@
         <p>
           Give a session a container and media. It prepares the renderer, exposes state for your UI, and provides playback and detection controls without asking React or your app to run another frame loop.
         </p>
-        <a data-supervision-docs-link="documents/Media_Sessions.html">Learn how media sessions work <span aria-hidden="true">→</span></a>
+        <a href="documents/Media_Sessions.html">Learn how media sessions work <span aria-hidden="true">→</span></a>
       </div>
       <pre><code class="language-ts">import { createMediaSession } from "supervision";
+const container = document.querySelector&lt;HTMLElement&gt;("#viewer");
+
+if (!container) {
+throw new Error("Missing #viewer container.");
+}
+
 const session = await createMediaSession({
-  container: document.querySelector("#viewer"),
-  media: fileOrUrl,
-  renderer: { autoPlay: true, loop: true },
+container,
+media: "/media/example.mp4",
+renderer: { autoPlay: true, loop: true },
 });
 session.subscribe((state) =&gt; {
-  console.log(state.status, state.activities);
+console.log(state.status, state.activities);
 });</code></pre>
-    </div>
+</div>
   </section>
   <section class="supervision-home__section" aria-labelledby="capabilities-title">
     <div class="supervision-home__section-heading">
@@ -59,19 +65,19 @@ session.subscribe((state) =&gt; {
         <span class="supervision-home__capability-number">01</span>
         <h3>Media and playback</h3>
         <p>Images, video, and browser media streams with preparation, normalization, seeking, stepping, rate control, and current-frame refresh.</p>
-        <a data-supervision-docs-link="documents/Media_Preparation.html">Media preparation</a>
+        <a href="documents/Media_Preparation.html">Media preparation</a>
       </article>
       <article class="supervision-home__capability-card">
         <span class="supervision-home__capability-number">02</span>
         <h3>Detection rendering</h3>
         <p>Boxes, masks, polygons, polylines, keypoints, labels, class colors, and presentation styles selected from canonical media timing.</p>
-        <a data-supervision-docs-link="documents/Detections_And_Rendering.html">Detections and rendering</a>
+        <a href="documents/Detections_And_Rendering.html">Detections and rendering</a>
       </article>
       <article class="supervision-home__capability-card">
         <span class="supervision-home__capability-number">03</span>
         <h3>Interaction and editing</h3>
         <p>Renderer-synchronized picking plus host-owned editing engines, persistence, undo/redo policy, and annotation commits.</p>
-        <a data-supervision-docs-link="documents/Interactive_Picking.html">Interactive picking</a>
+        <a href="documents/Interactive_Picking.html">Interactive picking</a>
       </article>
     </div>
   </section>
@@ -125,7 +131,7 @@ session.subscribe((state) =&gt; {
       <p>
         The public API is deliberately smaller than the implementation. It gives applications the media, detections, styles, interaction, state, and lifecycle primitives they need without coupling them to a scene graph, decoder, worker protocol, or prepared-artifact format.
       </p>
-      <a class="supervision-home__text-link" data-supervision-docs-link="documents/Public_API.html">Explore the public API <span aria-hidden="true">→</span></a>
+      <a class="supervision-home__text-link" href="documents/Public_API.html">Explore the public API <span aria-hidden="true">→</span></a>
     </div>
     <div class="supervision-home__boundary-card">
       <div>
@@ -142,10 +148,10 @@ session.subscribe((state) =&gt; {
     <p class="supervision-home__eyebrow">Keep learning</p>
     <h2 id="next-title">Choose the path that matches your integration.</h2>
     <nav class="supervision-home__next-grid" aria-label="Documentation paths">
-      <a data-supervision-docs-link="documents/Application_Integration.html"><strong>Application integration</strong><span>Install, mount, own the lifecycle.</span></a>
-      <a data-supervision-docs-link="documents/Static_Detections.html"><strong>Static detections</strong><span>Render a known sequence of prediction frames.</span></a>
-      <a data-supervision-docs-link="documents/Streaming_Detections.html"><strong>Streaming detections</strong><span>Ingest model output while media plays.</span></a>
-      <a data-supervision-docs-link="documents/React_Integration.html"><strong>React integration</strong><span>Wrap a vanilla session without moving its hot path into React.</span></a>
+      <a href="documents/Application_Integration.html"><strong>Application integration</strong><span>Install, mount, own the lifecycle.</span></a>
+      <a href="documents/Static_Detections.html"><strong>Static detections</strong><span>Render a known sequence of prediction frames.</span></a>
+      <a href="documents/Streaming_Detections.html"><strong>Streaming detections</strong><span>Ingest model output while media plays.</span></a>
+      <a href="documents/React_Integration.html"><strong>React integration</strong><span>Wrap a vanilla session without moving its hot path into React.</span></a>
     </nav>
   </section>
 </div>

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -1,94 +1,151 @@
-# supervision-js
-
-The `supervision` npm package is a browser-native TypeScript library for interactive
-computer vision media applications. It is the browser-focused subset of
-[Roboflow Supervision](https://github.com/roboflow/supervision): focused on
-media sessions, detection rendering, styles, interaction, and editing rather
-than Python API parity.
-
-The main API is `createMediaSession()`. It renders media and annotations in one
-renderer-owned scene, so the visible media frame and its detections share the
-same timing reference.
-
-## Installation
-
-Until the first browser release is available on npm's `next` tag, build the
-portable archive from this repository and install it in a browser application:
-
-```sh
-# In this repository
-npm install
-npm run package:tarball
-
-# In the consuming application
-npm install ./vendor/supervision-0.1.0.tgz
-```
-
-Once the first browser release is available on npm's `next` tag:
-
-```sh
-npm install supervision@next
-```
-
-After that release is promoted to npm's `latest` tag, install it without the
-tag:
-
-```sh
-npm install supervision
-```
-
-The archive includes the internal core dependency. Consumers should import the
-public browser package only:
-
-```ts
-import { createMediaSession } from "supervision";
-import { createMaskBrushEditor } from "supervision/editing";
-```
-
-Read [Application Integration](guides/application-integration.md) for the
-complete browser, lifecycle, and verification contract.
-
-## Quick Start
-
-```ts
-import { createMediaSession } from "supervision";
-
-const container = document.querySelector("#viewer");
-
-if (!container) {
-  throw new Error("Missing #viewer container.");
-}
-
+<div class="supervision-home">
+  <section class="supervision-home__hero" aria-labelledby="supervision-home-title">
+    <div class="supervision-home__hero-copy">
+      <p class="supervision-home__eyebrow">Roboflow Supervision for the browser</p>
+      <h1 id="supervision-home-title">Render computer vision media as one synchronized scene.</h1>
+      <p class="supervision-home__lede">
+        <code>supervision</code> is a browser-native TypeScript library for interactive computer vision media. A media session keeps the visible frame, detections, styles, interaction, and playback on one timing reference.
+      </p>
+      <div class="supervision-home__actions">
+        <a class="supervision-home__button supervision-home__button--primary" data-supervision-docs-link="documents/Application_Integration.html">Get started</a>
+        <a class="supervision-home__button supervision-home__button--secondary" href="https://supervision-js-demo.onrender.com/">Open the demo</a>
+      </div>
+    </div>
+    <aside class="supervision-home__scene-card" aria-label="Media session composition">
+      <p class="supervision-home__card-label">One renderer-owned scene</p>
+      <div class="supervision-home__scene-stack" aria-hidden="true">
+        <span class="supervision-home__scene-layer supervision-home__scene-layer--media">Media frame</span>
+        <span class="supervision-home__scene-layer supervision-home__scene-layer--masks">Masks &amp; geometry</span>
+        <span class="supervision-home__scene-layer supervision-home__scene-layer--labels">Labels &amp; interaction</span>
+      </div>
+      <p>
+        The session owns composition and timing. Your application owns the surrounding UI, model calls, product workflow, and data persistence.
+      </p>
+    </aside>
+  </section>
+  <section class="supervision-home__section" aria-labelledby="quick-start-title">
+    <div class="supervision-home__section-heading">
+      <p class="supervision-home__eyebrow">Quick start</p>
+      <h2 id="quick-start-title">Create one session for one media item.</h2>
+    </div>
+    <div class="supervision-home__quick-start">
+      <div>
+        <p>
+          Give a session a container and media. It prepares the renderer, exposes state for your UI, and provides playback and detection controls without asking React or your app to run another frame loop.
+        </p>
+        <a data-supervision-docs-link="documents/Media_Sessions.html">Learn how media sessions work <span aria-hidden="true">→</span></a>
+      </div>
+      <pre><code class="language-ts">import { createMediaSession } from "supervision";
 const session = await createMediaSession({
-  container,
+  container: document.querySelector("#viewer"),
   media: fileOrUrl,
   renderer: { autoPlay: true, loop: true },
 });
-
-session.subscribe((state) => {
+session.subscribe((state) =&gt; {
   console.log(state.status, state.activities);
-});
-```
-
-## Capabilities
-
-The supported browser surface covers images, video, and browser media streams;
-static and streaming detections; boxes, masks, polygons, polylines, keypoints,
-and labels; presentation styles; picking; and advanced annotation editing.
-
-React Native is experimental and separately versioned. It is not a dependency
-of the browser package or a compatibility promise.
-
-## Learn More
-
-- [Application Integration](guides/application-integration.md)
-- [Media Sessions](guides/media-sessions.md)
-- [Public API](guides/public-api.md)
-- [Media Preparation](guides/media-preparation.md)
-- [Detections And Rendering](guides/detections-and-rendering.md)
-- [Presentation Styles](guides/presentation-styles.md)
-- [React Integration](recipes/react-integration.md)
-- [Static Detections](recipes/static-detections.md)
-- [Streaming Detections](recipes/streaming-detections.md)
-- [Interactive Picking](recipes/interactive-picking.md)
-- [Session Lifecycle](recipes/session-lifecycle.md)
+});</code></pre>
+    </div>
+  </section>
+  <section class="supervision-home__section" aria-labelledby="capabilities-title">
+    <div class="supervision-home__section-heading">
+      <p class="supervision-home__eyebrow">Browser capabilities</p>
+      <h2 id="capabilities-title">The parts of a serious CV viewer, kept in one system.</h2>
+      <p>
+        Use the common session API first; use the deeper data, media, and editing APIs when the integration needs them.
+      </p>
+    </div>
+    <div class="supervision-home__capability-grid">
+      <article class="supervision-home__capability-card">
+        <span class="supervision-home__capability-number">01</span>
+        <h3>Media and playback</h3>
+        <p>Images, video, and browser media streams with preparation, normalization, seeking, stepping, rate control, and current-frame refresh.</p>
+        <a data-supervision-docs-link="documents/Media_Preparation.html">Media preparation</a>
+      </article>
+      <article class="supervision-home__capability-card">
+        <span class="supervision-home__capability-number">02</span>
+        <h3>Detection rendering</h3>
+        <p>Boxes, masks, polygons, polylines, keypoints, labels, class colors, and presentation styles selected from canonical media timing.</p>
+        <a data-supervision-docs-link="documents/Detections_And_Rendering.html">Detections and rendering</a>
+      </article>
+      <article class="supervision-home__capability-card">
+        <span class="supervision-home__capability-number">03</span>
+        <h3>Interaction and editing</h3>
+        <p>Renderer-synchronized picking plus host-owned editing engines, persistence, undo/redo policy, and annotation commits.</p>
+        <a data-supervision-docs-link="documents/Interactive_Picking.html">Interactive picking</a>
+      </article>
+    </div>
+  </section>
+  <section class="supervision-home__section" aria-labelledby="architecture-title">
+    <div class="supervision-home__section-heading">
+      <p class="supervision-home__eyebrow">Architecture</p>
+      <h2 id="architecture-title">Portable semantics, platform-specific rendering.</h2>
+      <p>
+        The public browser package is built around a small platform-neutral core. Rendering and media engines stay behind that boundary so applications depend on session, detection, and style contracts—not renderer objects.
+      </p>
+    </div>
+    <div class="supervision-home__package-grid">
+      <article class="supervision-home__package-card supervision-home__package-card--core">
+        <p class="supervision-home__package-kind">Private semantic core</p>
+        <h3><code>supervision-js-core</code></h3>
+        <p>Detections, geometry, masks, timelines, styles, sources, picking, editing vocabulary, lifecycle contracts, and pure utilities.</p>
+      </article>
+      <article class="supervision-home__package-card supervision-home__package-card--web">
+        <p class="supervision-home__package-kind">Published browser package</p>
+        <h3><code>supervision</code></h3>
+        <p><code>createMediaSession()</code>, browser media preparation, playback, render preparation, storage adapters, and the first 2D renderer.</p>
+      </article>
+      <article class="supervision-home__package-card supervision-home__package-card--experiment">
+        <p class="supervision-home__package-kind">Private experiment</p>
+        <h3><code>supervision-js-react-native</code></h3>
+        <p>Native session and rendering experiments that share core semantics but are not part of the browser package or its compatibility promise.</p>
+      </article>
+    </div>
+    <div class="supervision-home__pipeline" aria-label="Detection rendering pipeline">
+      <article>
+        <span>01</span>
+        <h3>Semantic data</h3>
+        <p>Detection frames and compact masks come from memory, chunks, IndexedDB, or your own source.</p>
+      </article>
+      <article>
+        <span>02</span>
+        <h3>Prepared window</h3>
+        <p>A bounded set of nearby frames is parsed and prepared for rendering without retaining an entire video in memory.</p>
+      </article>
+      <article>
+        <span>03</span>
+        <h3>Active scene</h3>
+        <p>Media and annotations are selected by the same media timing reference and presented together.</p>
+      </article>
+    </div>
+  </section>
+  <section class="supervision-home__section supervision-home__section--split" aria-labelledby="boundaries-title">
+    <div>
+      <p class="supervision-home__eyebrow">Public boundary</p>
+      <h2 id="boundaries-title">Start with the session. Keep implementation details private.</h2>
+      <p>
+        The public API is deliberately smaller than the implementation. It gives applications the media, detections, styles, interaction, state, and lifecycle primitives they need without coupling them to a scene graph, decoder, worker protocol, or prepared-artifact format.
+      </p>
+      <a class="supervision-home__text-link" data-supervision-docs-link="documents/Public_API.html">Explore the public API <span aria-hidden="true">→</span></a>
+    </div>
+    <div class="supervision-home__boundary-card">
+      <div>
+        <p>Applications work with</p>
+        <strong>sessions · detections · styles · sources · state</strong>
+      </div>
+      <div>
+        <p>Applications do not need to know</p>
+        <strong>Pixi scenes · media adapters · workers · prepared artifacts</strong>
+      </div>
+    </div>
+  </section>
+  <section class="supervision-home__section supervision-home__next" aria-labelledby="next-title">
+    <p class="supervision-home__eyebrow">Keep learning</p>
+    <h2 id="next-title">Choose the path that matches your integration.</h2>
+    <nav class="supervision-home__next-grid" aria-label="Documentation paths">
+      <a data-supervision-docs-link="documents/Application_Integration.html"><strong>Application integration</strong><span>Install, mount, own the lifecycle.</span></a>
+      <a data-supervision-docs-link="documents/Static_Detections.html"><strong>Static detections</strong><span>Render a known sequence of prediction frames.</span></a>
+      <a data-supervision-docs-link="documents/Streaming_Detections.html"><strong>Streaming detections</strong><span>Ingest model output while media plays.</span></a>
+      <a data-supervision-docs-link="documents/React_Integration.html"><strong>React integration</strong><span>Wrap a vanilla session without moving its hot path into React.</span></a>
+    </nav>
+  </section>
+</div>

--- a/docs/public/typedoc-custom.css
+++ b/docs/public/typedoc-custom.css
@@ -516,6 +516,402 @@ pre > button {
   color: var(--rf-violet-700);
 }
 
+.tsd-typography.supervision-docs--home {
+  max-width: 72rem;
+}
+
+/* The generated reference pages use TypeDoc's three-column, scrollable pane.
+ * The home page is an editorial landing page, so it intentionally gets one
+ * document-flow column without altering reference-page navigation. */
+.container-main.supervision-docs--home-layout {
+  display: block !important;
+  height: auto !important;
+  max-width: 1580px !important;
+  overflow: visible !important;
+}
+
+.container-main.supervision-docs--home-layout > :not(.col-content) {
+  display: none !important;
+}
+
+.container-main.supervision-docs--home-layout > .col-content {
+  height: auto !important;
+  margin: 0 auto !important;
+  max-width: 72rem !important;
+  overflow: visible !important;
+  width: 100% !important;
+}
+
+.supervision-home {
+  color: var(--rf-gray-600);
+}
+
+.supervision-home__hero {
+  align-items: center;
+  display: grid;
+  gap: clamp(2rem, 6vw, 5rem);
+  grid-template-columns: minmax(0, 1.16fr) minmax(18rem, 0.84fr);
+  padding: clamp(1rem, 3vw, 2rem) 0 clamp(3.5rem, 9vw, 6rem);
+}
+
+.supervision-home__eyebrow,
+.supervision-home__package-kind,
+.supervision-home__card-label {
+  color: var(--rf-violet-700) !important;
+  font-size: 0.72rem;
+  font-weight: 780;
+  letter-spacing: 0.11em;
+  margin: 0 0 0.78rem !important;
+  text-transform: uppercase;
+}
+
+.supervision-home h1,
+.supervision-home h2,
+.supervision-home h3,
+.supervision-home p {
+  margin-top: 0 !important;
+}
+
+.supervision-home h1 {
+  font-size: clamp(2.7rem, 5.6vw, 5rem) !important;
+  line-height: 0.99 !important;
+  margin-bottom: 1.3rem !important;
+  max-width: 52rem;
+}
+
+.supervision-home h2 {
+  font-size: clamp(2rem, 3.6vw, 3.05rem) !important;
+  line-height: 1.05 !important;
+  margin-bottom: 1rem !important;
+  max-width: 48rem;
+}
+
+.supervision-home h3 {
+  font-size: 1.14rem !important;
+  margin-bottom: 0.62rem !important;
+}
+
+.supervision-home__lede {
+  font-size: clamp(1.05rem, 1.8vw, 1.22rem);
+  line-height: 1.65;
+  margin-bottom: 1.6rem !important;
+  max-width: 45rem;
+}
+
+.supervision-home__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.72rem;
+}
+
+.supervision-home__button {
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  display: inline-flex;
+  font-size: 0.9rem;
+  font-weight: 720;
+  justify-content: center;
+  min-height: 2.7rem;
+  padding: 0.55rem 0.95rem;
+  text-decoration: none !important;
+}
+
+.supervision-home__button--primary {
+  background: var(--rf-violet-600);
+  box-shadow: 0 9px 20px rgba(109, 40, 217, 0.22);
+  color: #ffffff !important;
+}
+
+.supervision-home__button--primary:hover {
+  background: var(--rf-violet-700);
+  color: #ffffff !important;
+}
+
+.supervision-home__button--secondary {
+  background: #ffffff;
+  border-color: var(--rf-gray-300);
+  color: var(--rf-gray-900) !important;
+}
+
+.supervision-home__button--secondary:hover {
+  background: var(--rf-violet-50);
+  border-color: var(--rf-violet-300);
+  color: var(--rf-violet-700) !important;
+}
+
+.supervision-home__scene-card {
+  background:
+    radial-gradient(
+      circle at 85% 0,
+      rgba(196, 181, 253, 0.62),
+      transparent 42%
+    ),
+    linear-gradient(145deg, #ffffff, #f3edff);
+  border: 1px solid #dccdff;
+  border-radius: 22px;
+  box-shadow: 0 18px 45px rgba(75, 34, 142, 0.11);
+  padding: clamp(1.25rem, 3vw, 1.8rem);
+}
+
+.supervision-home__scene-card > p:last-child {
+  font-size: 0.91rem;
+  line-height: 1.58;
+  margin-bottom: 0 !important;
+}
+
+.supervision-home__scene-stack {
+  display: grid;
+  gap: 0.58rem;
+  margin: 1.1rem 0 1.35rem;
+}
+
+.supervision-home__scene-layer {
+  border: 1px solid transparent;
+  border-radius: 9px;
+  box-shadow: 0 7px 16px rgba(53, 31, 99, 0.08);
+  color: var(--rf-gray-900);
+  display: block;
+  font-size: 0.83rem;
+  font-weight: 720;
+  padding: 0.82rem 0.9rem;
+}
+
+.supervision-home__scene-layer--media {
+  background: #25213a;
+  color: #ffffff;
+  transform: translateX(0.45rem);
+}
+
+.supervision-home__scene-layer--masks {
+  background: #e9dfff;
+  border-color: #c9adff;
+  transform: translateX(-0.2rem);
+}
+
+.supervision-home__scene-layer--labels {
+  background: #ffffff;
+  border-color: var(--rf-gray-300);
+  transform: translateX(0.2rem);
+}
+
+.supervision-home__section {
+  border-top: 1px solid var(--rf-gray-100);
+  padding: clamp(3.5rem, 8vw, 6rem) 0;
+}
+
+.supervision-home__section-heading > p:last-child,
+.supervision-home__section--split
+  > div:first-child
+  > p:not(.supervision-home__eyebrow) {
+  font-size: 1.02rem;
+  line-height: 1.67;
+  margin-bottom: 0 !important;
+  max-width: 46rem;
+}
+
+.supervision-home__quick-start {
+  align-items: center;
+  background: linear-gradient(135deg, #fcfbff, var(--rf-violet-50));
+  border: 1px solid var(--rf-violet-100);
+  border-radius: 18px;
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: minmax(13rem, 0.74fr) minmax(20rem, 1.26fr);
+  margin-top: 1.8rem;
+  padding: clamp(1.15rem, 3vw, 1.75rem);
+}
+
+.supervision-home__quick-start > div > p {
+  line-height: 1.62;
+}
+
+.supervision-home__quick-start pre {
+  margin: 0 !important;
+}
+
+.supervision-home__quick-start a,
+.supervision-home__capability-card a,
+.supervision-home__text-link {
+  font-size: 0.88rem;
+  font-weight: 720;
+  text-decoration: none !important;
+}
+
+.supervision-home__capability-grid,
+.supervision-home__package-grid,
+.supervision-home__next-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 1.75rem;
+}
+
+.supervision-home__capability-card,
+.supervision-home__package-card {
+  background: #ffffff;
+  border: 1px solid var(--rf-gray-100);
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(17, 24, 39, 0.04);
+  min-height: 100%;
+  padding: 1.3rem;
+}
+
+.supervision-home__capability-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.supervision-home__capability-card p,
+.supervision-home__package-card p:not(.supervision-home__package-kind) {
+  font-size: 0.91rem;
+  line-height: 1.58;
+  margin-bottom: 1rem !important;
+}
+
+.supervision-home__capability-card a {
+  margin-top: auto;
+}
+
+.supervision-home__capability-number {
+  align-items: center;
+  background: var(--rf-violet-50);
+  border-radius: 999px;
+  color: var(--rf-violet-700);
+  display: inline-flex;
+  font-family: var(--font-family-code);
+  font-size: 0.71rem;
+  font-weight: 760;
+  height: 1.7rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+  width: 1.7rem;
+}
+
+.supervision-home__package-card {
+  border-left: 4px solid var(--rf-violet-600);
+}
+
+.supervision-home__package-card--core {
+  border-left-color: #047857;
+}
+
+.supervision-home__package-card--experiment {
+  border-left-color: #b45309;
+}
+
+.supervision-home__package-card--core .supervision-home__package-kind {
+  color: #047857 !important;
+}
+
+.supervision-home__package-card--experiment .supervision-home__package-kind {
+  color: #b45309 !important;
+}
+
+.supervision-home__pipeline {
+  display: grid;
+  gap: 0.72rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 1rem;
+}
+
+.supervision-home__pipeline article {
+  background: #fdfcff;
+  border: 1px solid #e3d9f8;
+  border-radius: 14px;
+  padding: 1.15rem;
+  position: relative;
+}
+
+.supervision-home__pipeline span {
+  color: var(--rf-violet-700);
+  display: block;
+  font-family: var(--font-family-code);
+  font-size: 0.72rem;
+  font-weight: 760;
+  margin-bottom: 0.62rem;
+}
+
+.supervision-home__pipeline p {
+  font-size: 0.87rem;
+  line-height: 1.56;
+  margin-bottom: 0 !important;
+}
+
+.supervision-home__section--split {
+  align-items: start;
+  display: grid;
+  gap: clamp(1.5rem, 5vw, 4rem);
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 0.78fr);
+}
+
+.supervision-home__boundary-card {
+  background: #211839;
+  border-radius: 18px;
+  color: #f8f7ff;
+  overflow: hidden;
+}
+
+.supervision-home__boundary-card div {
+  padding: 1.3rem;
+}
+
+.supervision-home__boundary-card div + div {
+  background: #2e214d;
+}
+
+.supervision-home__boundary-card p {
+  color: #d7c9ff !important;
+  font-size: 0.72rem;
+  font-weight: 730 !important;
+  letter-spacing: 0.09em;
+  margin-bottom: 0.48rem !important;
+  text-transform: uppercase;
+}
+
+.supervision-home__boundary-card strong {
+  color: #ffffff;
+  font-size: 0.96rem;
+  line-height: 1.45;
+}
+
+.supervision-home__next {
+  padding-bottom: clamp(0.5rem, 2vw, 1.5rem);
+}
+
+.supervision-home__next-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.supervision-home__next-grid a {
+  align-items: start;
+  background: var(--rf-violet-50);
+  border: 1px solid var(--rf-violet-100);
+  border-radius: 13px;
+  color: var(--rf-gray-900) !important;
+  display: grid;
+  gap: 0.25rem;
+  min-height: 100%;
+  padding: 1rem 1.1rem;
+  text-decoration: none !important;
+}
+
+.supervision-home__next-grid a:hover {
+  background: #ffffff;
+  border-color: var(--rf-violet-300);
+  box-shadow: 0 8px 20px rgba(109, 40, 217, 0.08);
+}
+
+.supervision-home__next-grid strong {
+  font-size: 0.94rem;
+}
+
+.supervision-home__next-grid span {
+  color: var(--rf-gray-600);
+  font-size: 0.84rem;
+  line-height: 1.48;
+}
+
 @media (max-width: 1199px) {
   .container-main {
     border-radius: 0;
@@ -565,5 +961,27 @@ pre > button {
 
   .col-sidebar {
     background: #ffffff !important;
+  }
+
+  .supervision-home__hero,
+  .supervision-home__quick-start,
+  .supervision-home__section--split {
+    grid-template-columns: 1fr;
+  }
+
+  .supervision-home__capability-grid,
+  .supervision-home__package-grid,
+  .supervision-home__pipeline {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .supervision-home h1 {
+    font-size: 2.55rem !important;
+  }
+
+  .supervision-home__next-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/docs/public/typedoc-custom.css
+++ b/docs/public/typedoc-custom.css
@@ -542,6 +542,10 @@ pre > button {
   width: 100% !important;
 }
 
+html.supervision-docs--home #tsd-toolbar-menu-trigger {
+  display: none;
+}
+
 .supervision-home {
   color: var(--rf-gray-600);
 }

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -94,15 +94,10 @@
     }
 
     home.closest(".tsd-typography")?.classList.add("supervision-docs--home");
+    document.documentElement.classList.add("supervision-docs--home");
     home
       .closest(".container-main")
       ?.classList.add("supervision-docs--home-layout");
-    for (const link of home.querySelectorAll("[data-supervision-docs-link]")) {
-      link.href = new URL(
-        link.dataset.supervisionDocsLink,
-        window.location.href,
-      ).href;
-    }
   }
 
   function brandToolbar() {

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -67,6 +67,7 @@
     document.documentElement.dataset.theme = "light";
     localStorage.setItem("tsd-theme", "light");
     brandToolbar();
+    decorateHomePage();
     upgradeIcons(document);
 
     const observer = new MutationObserver((mutations) => {
@@ -83,6 +84,25 @@
       childList: true,
       subtree: true,
     });
+  }
+
+  function decorateHomePage() {
+    const home = document.querySelector(".supervision-home");
+
+    if (!home) {
+      return;
+    }
+
+    home.closest(".tsd-typography")?.classList.add("supervision-docs--home");
+    home
+      .closest(".container-main")
+      ?.classList.add("supervision-docs--home-layout");
+    for (const link of home.querySelectorAll("[data-supervision-docs-link]")) {
+      link.href = new URL(
+        link.dataset.supervisionDocsLink,
+        window.location.href,
+      ).href;
+    }
   }
 
   function brandToolbar() {

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -117,6 +117,7 @@ test("Render preview trusts only its assigned hostname", async () => {
 });
 
 test("copyable integration examples typecheck", async () => {
+  const homepage = await readFile(path.join(publicDocsDir, "index.md"), "utf8");
   const applicationGuide = await readFile(
     path.join(publicDocsDir, "guides/application-integration.md"),
     "utf8",
@@ -129,9 +130,12 @@ test("copyable integration examples typecheck", async () => {
     source.includes("let session: MediaSession"),
   );
   const reactExample = findCodeBlocks(reactRecipe, "tsx")[0];
+  const homepageExample = findHtmlCodeBlock(homepage, "language-ts");
 
   assert.ok(browserExample, "Missing minimal browser integration example.");
   assert.ok(reactExample, "Missing React integration example.");
+  assert.ok(homepageExample, "Missing homepage quick-start example.");
+  assertTypechecks(homepageExample, ".docs-homepage-integration.ts");
   assertTypechecks(browserExample, ".docs-browser-integration.ts");
   assertTypechecks(
     reactExample,
@@ -144,6 +148,17 @@ function findMarkdownLinks(source) {
   return [...source.matchAll(/!?\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g)]
     .filter((match) => !match[0].startsWith("!"))
     .map((match) => match[1]);
+}
+
+function findHtmlCodeBlock(source, className) {
+  const match = source.match(
+    new RegExp(`<pre><code class="${className}">([\\s\\S]*?)<\\/code><\\/pre>`),
+  );
+
+  return match?.[1]
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&amp;", "&");
 }
 
 function findCodeBlocks(source, language) {


### PR DESCRIPTION
# Description

Replaces the generic documentation landing page with a consumer-facing architecture guide for the published `supervision` browser package. It introduces a responsive Roboflow-styled home, explains the session-first boundary without promoting internal implementation details, and documents when agents must keep the page current.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `npm run format:check`
- Ran `npm run docs:check`
- Ran `npm run demo:build` (browser, demo, vanilla example, and generated docs builds)
- Inspected the generated homepage at desktop and mobile breakpoints, and confirmed reference-page navigation remains scoped to normal TypeDoc layout

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- hosting: publish the generated documentation with the existing docs deployment

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
