### PR TITLE
Prepare supervision 0.1.1 stable release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,12 +11,13 @@ on:
         options:
           - next
           - latest
-      release_sha:
-        description: "Recovery only: full SHA that produced an already-published immutable version."
+      recovery_run_id:
+        description: "Recovery only: failed Publish npm package run ID after npm upload succeeded."
         required: false
         type: string
 
 permissions:
+  actions: read
   contents: write
   id-token: write
 
@@ -36,28 +37,50 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
-          # A recovery must rebuild the exact commit that produced the immutable
-          # npm artifact, rather than whatever main happens to contain later.
-          ref: ${{ inputs.release_sha || github.sha }}
           fetch-depth: 0
 
-      - name: Verify selected release commit
+      - name: Resolve release source
+        id: release_source
         shell: bash
         env:
-          RELEASE_SHA_INPUT: ${{ inputs.release_sha }}
+          GH_TOKEN: ${{ github.token }}
+          RECOVERY_RUN_ID: ${{ inputs.recovery_run_id }}
         run: |
           set -euo pipefail
+          release_sha="${GITHUB_SHA}"
 
-          if [[ -z "${RELEASE_SHA_INPUT}" ]]; then
-            exit 0
+          if [[ -n "${RECOVERY_RUN_ID}" ]]; then
+            if ! [[ "${RECOVERY_RUN_ID}" =~ ^[0-9]+$ ]]; then
+              echo "recovery_run_id must be a GitHub Actions run ID." >&2
+              exit 1
+            fi
+
+            run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RECOVERY_RUN_ID}")"
+            workflow_name="$(jq --raw-output '.name' <<<"${run}")"
+            event="$(jq --raw-output '.event' <<<"${run}")"
+            head_branch="$(jq --raw-output '.head_branch' <<<"${run}")"
+            conclusion="$(jq --raw-output '.conclusion' <<<"${run}")"
+            release_sha="$(jq --raw-output '.head_sha' <<<"${run}")"
+
+            if [[ "${workflow_name}" != "Publish npm package" \
+              || "${event}" != "workflow_dispatch" \
+              || "${head_branch}" != "main" \
+              || "${conclusion}" != "failure" \
+              || ! "${release_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "recovery_run_id must identify a failed Publish npm package dispatch from main." >&2
+              exit 1
+            fi
+
+            if ! git merge-base --is-ancestor "${release_sha}" origin/main; then
+              echo "Recovery run head ${release_sha} is not reachable from main." >&2
+              exit 1
+            fi
+
+            git checkout --detach "${release_sha}"
           fi
 
-          if ! [[ "${RELEASE_SHA_INPUT}" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "release_sha must be a full 40-character Git commit SHA." >&2
-            exit 1
-          fi
-
-          test "$(git rev-parse HEAD)" = "${RELEASE_SHA_INPUT}"
+          echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+          echo "recovery=$([[ -n "${RECOVERY_RUN_ID}" ]] && echo true || echo false)" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -82,7 +105,7 @@ jobs:
         shell: bash
         env:
           DIST_TAG: ${{ inputs.dist_tag }}
-          RELEASE_SHA_INPUT: ${{ inputs.release_sha }}
+          RECOVERY: ${{ steps.release_source.outputs.recovery }}
         run: |
           set -euo pipefail
           version="$(node -p "require('./packages/web/package.json').version")"
@@ -103,13 +126,18 @@ jobs:
               exit 1
             fi
 
-            if [[ -z "${RELEASE_SHA_INPUT}" ]]; then
-              echo "supervision@${version} is already published. To recover its GitHub Release, dispatch this workflow from main with release_sha set to the full commit SHA that produced the published artifact." >&2
+            if [[ "${RECOVERY}" != "true" ]]; then
+              echo "supervision@${version} is already published. To recover its GitHub Release, dispatch this workflow from main with recovery_run_id set to the failed Publish npm package run ID." >&2
               exit 1
             fi
 
-            echo "supervision@${version} is already published; continuing the explicit SHA recovery."
+            echo "supervision@${version} is already published; continuing the verified run recovery."
             exit 0
+          fi
+
+          if [[ "${RECOVERY}" == "true" ]]; then
+            echo "Recovery run's supervision@${version} is not published; refusing to publish a recovery source." >&2
+            exit 1
           fi
 
           shopt -s nullglob

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -11,6 +11,10 @@ on:
         options:
           - next
           - latest
+      release_sha:
+        description: "Recovery only: full SHA that produced an already-published immutable version."
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -31,6 +35,29 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          # A recovery must rebuild the exact commit that produced the immutable
+          # npm artifact, rather than whatever main happens to contain later.
+          ref: ${{ inputs.release_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Verify selected release commit
+        shell: bash
+        env:
+          RELEASE_SHA_INPUT: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RELEASE_SHA_INPUT}" ]]; then
+            exit 0
+          fi
+
+          if ! [[ "${RELEASE_SHA_INPUT}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "release_sha must be a full 40-character Git commit SHA." >&2
+            exit 1
+          fi
+
+          test "$(git rev-parse HEAD)" = "${RELEASE_SHA_INPUT}"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -55,6 +82,7 @@ jobs:
         shell: bash
         env:
           DIST_TAG: ${{ inputs.dist_tag }}
+          RELEASE_SHA_INPUT: ${{ inputs.release_sha }}
         run: |
           set -euo pipefail
           version="$(node -p "require('./packages/web/package.json').version")"
@@ -75,7 +103,12 @@ jobs:
               exit 1
             fi
 
-            echo "supervision@${version} is already published; continuing release verification."
+            if [[ -z "${RELEASE_SHA_INPUT}" ]]; then
+              echo "supervision@${version} is already published. To recover its GitHub Release, dispatch this workflow from main with release_sha set to the full commit SHA that produced the published artifact." >&2
+              exit 1
+            fi
+
+            echo "supervision@${version} is already published; continuing the explicit SHA recovery."
             exit 0
           fi
 
@@ -97,6 +130,31 @@ jobs:
           published_version="$(npm view "supervision@${DIST_TAG}" version)"
           test "${published_version}" = "${version}"
 
+      - name: Create or verify release tag
+        if: inputs.dist_tag == 'latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/web/package.json').version")"
+          tag="v${version}"
+          release_sha="$(git rev-parse HEAD)"
+
+          git fetch --tags --force
+
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "${tag}")"
+            if [[ "${tag_sha}" != "${release_sha}" ]]; then
+              echo "Existing ${tag} points to ${tag_sha}, not ${release_sha}." >&2
+              exit 1
+            fi
+
+            echo "Git tag ${tag} already points to the release commit."
+            exit 0
+          fi
+
+          git tag --annotate "${tag}" "${release_sha}" --message "supervision ${tag}"
+          git push origin "refs/tags/${tag}"
+
       - name: Create GitHub Release
         if: inputs.dist_tag == 'latest'
         shell: bash
@@ -113,6 +171,5 @@ jobs:
           fi
 
           gh release create "${tag}" \
-            --target "${GITHUB_SHA}" \
             --title "supervision ${tag}" \
             --generate-notes

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,16 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       dist_tag:
-        description: npm dist-tag for this release
+        description: Select latest for a stable release; use next only for an explicit prerelease or canary.
         required: true
-        default: next
+        default: latest
         type: choice
         options:
           - next
           - latest
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 concurrency:
@@ -53,12 +53,66 @@ jobs:
 
       - name: Publish generated tarball
         shell: bash
+        env:
+          DIST_TAG: ${{ inputs.dist_tag }}
         run: |
           set -euo pipefail
+          version="$(node -p "require('./packages/web/package.json').version")"
+
+          if [[ "${DIST_TAG}" == "latest" && "${version}" == *-* ]]; then
+            echo "Prerelease version ${version} must use the next tag." >&2
+            exit 1
+          fi
+
+          if [[ "${DIST_TAG}" == "next" && "${version}" != *-* ]]; then
+            echo "Stable version ${version} must use the latest tag." >&2
+            exit 1
+          fi
+
+          if published_version="$(npm view "supervision@${version}" version 2>/dev/null)"; then
+            if [[ "${published_version}" != "${version}" ]]; then
+              echo "Unexpected published version for supervision@${version}: ${published_version}" >&2
+              exit 1
+            fi
+
+            echo "supervision@${version} is already published; continuing release verification."
+            exit 0
+          fi
+
           shopt -s nullglob
           archives=(artifacts/supervision-*.tgz)
           if [ "${#archives[@]}" -ne 1 ]; then
             echo "Expected exactly one generated supervision tarball." >&2
             exit 1
           fi
-          npm publish "./${archives[0]}" --access public --tag "${{ inputs.dist_tag }}"
+          npm publish "./${archives[0]}" --access public --tag "${DIST_TAG}"
+
+      - name: Verify published npm dist-tag
+        shell: bash
+        env:
+          DIST_TAG: ${{ inputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/web/package.json').version")"
+          published_version="$(npm view "supervision@${DIST_TAG}" version)"
+          test "${published_version}" = "${version}"
+
+      - name: Create GitHub Release
+        if: inputs.dist_tag == 'latest'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./packages/web/package.json').version")"
+          tag="v${version}"
+
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            echo "GitHub Release ${tag} already exists."
+            exit 0
+          fi
+
+          gh release create "${tag}" \
+            --target "${GITHUB_SHA}" \
+            --title "supervision ${tag}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ session.setPresentation({ boxStyle, maskStyle, labelStyle });
 ## Installation
 
 ```sh
-npm install supervision
+npm install supervision@next
 ```
 
-The published package includes its private core dependency. Consumers import
-only the public browser entrypoints:
+The current browser release is published on npm's `next` tag. Its published
+package includes the private core dependency. Consumers import only the public
+browser entrypoints:
 
 ```ts
 import { createMediaSession } from "supervision";

--- a/README.md
+++ b/README.md
@@ -50,34 +50,12 @@ session.setPresentation({ boxStyle, maskStyle, labelStyle });
 
 ## Installation
 
-Until the first browser release is available on npm's `next` tag, build a
-portable release archive from a checkout and install it in a browser
-application:
-
-```sh
-# In this repository
-npm install
-npm run package:tarball
-
-# In the consuming application
-npm install ./vendor/supervision-0.1.0.tgz
-```
-
-Once the first browser release is available on npm's `next` tag:
-
-```sh
-npm install supervision@next
-```
-
-After that release is promoted to npm's `latest` tag, install it without the
-tag:
-
 ```sh
 npm install supervision
 ```
 
-The archive includes the internal core dependency. Consumers import only the
-public browser entrypoints:
+The published package includes its private core dependency. Consumers import
+only the public browser entrypoints:
 
 ```ts
 import { createMediaSession } from "supervision";

--- a/docs/internal/agent-guidance.md
+++ b/docs/internal/agent-guidance.md
@@ -36,6 +36,12 @@ or the private React Native experiment into public contracts. Do not edit
 generated `docs/site/` output; rebuild the docs with `npm run demo:build` and
 run `npm run docs:check` after changing the homepage.
 
+The documentation toolbar displays the published browser package version from
+`docs/public/typedoc-icons.js`. Update that value with
+`packages/web/package.json` in every browser package release; `npm run
+docs:check` rejects a mismatch. The package manifest is canonical, while the
+toolbar value is a checked presentation mirror.
+
 ## Project Direction
 
 - Keep the core library vanilla browser TypeScript/JavaScript.

--- a/docs/internal/agent-guidance.md
+++ b/docs/internal/agent-guidance.md
@@ -36,11 +36,13 @@ or the private React Native experiment into public contracts. Do not edit
 generated `docs/site/` output; rebuild the docs with `npm run demo:build` and
 run `npm run docs:check` after changing the homepage.
 
-The documentation toolbar displays the published browser package version from
+The documentation toolbar displays the browser package version from
 `docs/public/typedoc-icons.js`. Update that value with
 `packages/web/package.json` in every browser package release; `npm run
-docs:check` rejects a mismatch. The package manifest is canonical, while the
-toolbar value is a checked presentation mirror.
+docs:check` rejects a mismatch. Before publishing the version to npm, keep its
+toolbar label as pending; remove that label in the verified docs-only follow-up
+after the stable release. The package manifest is canonical, while the toolbar
+value is a checked presentation mirror.
 
 ## Project Direction
 

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -2,13 +2,13 @@
 
 This repository publishes one public package: `supervision`. The root
 workspace, `supervision-js-core`, and `supervision-js-react-native` remain
-private. The npm registry artifact is the portable tarball assembled by
+private. The registry artifact is the portable tarball assembled by
 `tools/pack-web-tarball.mjs`; it embeds the private core package without
 exposing the workspace-relative `file:../core` dependency.
 
 ## Release Boundary
 
-Never publish from `packages/web` directly. A release must publish exactly one
+Never publish from `packages/web` directly. A release publishes exactly one
 generated file matching:
 
 ```text
@@ -17,47 +17,59 @@ artifacts/supervision-<version>.tgz
 
 The manual GitHub Actions workflow at
 `.github/workflows/publish-npm.yml` recreates and independently validates that
-artifact before publishing it. It accepts only the `next` and `latest` tags,
-runs only from `main`, and is gated by the `npm-publish` GitHub environment.
+artifact before publishing it. It runs only from `main` and is gated by the
+`npm-publish` GitHub environment.
 
-`next` is the safe default for the first release. Promote a version to `latest`
-only after the release owner explicitly makes that decision.
+`latest` is the default tag for a reviewed, general-availability release.
+`next` is reserved for an explicit prerelease or canary. Do not use `next` as a
+holding area for a stable release: a stable publish with `latest` updates the
+default version that `npm install supervision` resolves.
 
-## One-Time Bootstrap
+The `packages/web/package.json` version is the source of truth. The stable
+release workflow creates the matching GitHub Release and `v<version>` tag from
+the `main` commit that npm published. That release page is the canonical GitHub
+record; npm is the canonical installation source.
+
+## Publication Access
 
 The package name is `supervision`; the repository remains `supervision-js`.
-The existing `supervision@0.0.9000` placeholder is an earlier Roboflow
-publication, and the first browser release must publish a newer immutable
-version.
+Keep this ownership and security posture in place:
 
-Before the first browser release, an npm administrator must:
+1. At least two active Roboflow maintainers have npm package access and two-factor
+   authentication.
+2. npm **Trusted publisher** points exactly to GitHub Actions organization
+   `roboflow`, repository `supervision-js`, workflow `publish-npm.yml`, and
+   environment `npm-publish` for the **npm publish** action.
+3. GitHub's `npm-publish` environment requires release-owner approval.
+4. No long-lived npm write token is stored in GitHub. Publishing uses OIDC.
 
-1. Confirm that the Roboflow owner can publish the existing `supervision`
-   package.
-2. Create or use the Roboflow npm owner that will own the first public release,
-   with two-factor authentication enabled.
-3. Add at least two active Roboflow maintainers to the npm package.
-4. Open the package's npm **Settings → Trusted publisher** and configure:
-   - provider: **GitHub Actions**;
-   - organization: `roboflow`;
-   - repository: `supervision-js`;
-   - workflow filename: `publish-npm.yml`;
-   - environment name: `npm-publish`;
-   - allowed action: **npm publish**.
-5. In GitHub, create the `npm-publish` environment and require approval from
-   the release owners. Do not store an npm write token in GitHub secrets.
-6. After one successful OIDC publish, set npm **Publishing access** to require
-   two-factor authentication and disallow tokens, then remove any obsolete
-   automation tokens.
+If publishing access breaks, compare the trusted-publisher fields with the
+workflow before changing credentials. Each npm package supports one trusted
+publisher.
 
-The trusted publisher must match the organization, repository, workflow file,
-and environment name exactly. Each npm package supports one trusted publisher.
+## Choose The Version And Tag
+
+Use SemVer against the published browser surface only:
+
+| Change                                                                      | Example next version from `0.1.0` | Tag      |
+| --------------------------------------------------------------------------- | --------------------------------- | -------- |
+| Backward-compatible fix, docs, dependency maintenance, or internal refactor | `0.1.1`                           | `latest` |
+| Backward-compatible public browser API addition                             | `0.2.0`                           | `latest` |
+| Breaking browser API or behavior change before 1.0                          | `0.2.0`                           | `latest` |
+| Preview of a future release                                                 | `0.1.2-rc.0`                      | `next`   |
+
+For pre-1.0 versions, a new minor version communicates a breaking public
+change. Changes limited to private React Native experiments do not by themselves
+change the published browser package version.
 
 ## Release Procedure
 
-1. Update the public package version in `packages/web/package.json` and refresh
-   `package-lock.json`.
-2. Run the normal validation plus the clean-consumer artifact smoke test:
+1. Update `packages/web/package.json`, `package-lock.json`, and the checked docs
+   toolbar version together. `npm run docs:check` verifies the toolbar mirror.
+2. Update public docs and README installation guidance to use
+   `npm install supervision`. Do not document path installs of release tarballs
+   for consumers.
+3. Run the normal validation plus the clean-consumer artifact smoke test:
 
    ```sh
    npm run verify
@@ -66,31 +78,46 @@ and environment name exactly. Each npm package supports one trusted publisher.
    npm run package:publish:dry-run
    ```
 
-3. Merge the reviewed release-preparation pull request to `main`.
-4. In GitHub Actions, run **Publish npm package** from `main`. Select `next`
-   unless the release owner has explicitly approved `latest`.
-5. Approve the `npm-publish` environment deployment. The workflow verifies,
-   packs, smoke-tests, and then publishes the generated archive through npm
-   trusted publishing (OIDC). It has no long-lived npm credential.
-6. Verify the published package metadata, provenance, tarball contents, and a
-   clean installation in a separate consumer. While the browser package remains
-   on `next`, public installation instructions must use
-   `npm install supervision@next`.
-7. Promote the verified release only when the release owner approves it:
+4. Merge the reviewed release-preparation pull request to `main`.
+5. In GitHub Actions, run **Publish npm package** from `main` and select
+   `latest` for a stable release. Approve the `npm-publish` environment
+   deployment. The workflow verifies, packs, smoke-tests, publishes the
+   generated archive through npm trusted publishing, verifies the selected npm
+   tag, and creates the matching GitHub Release.
+6. Verify npm metadata, provenance, tarball contents, and a clean installation
+   in a separate consumer:
 
    ```sh
-   npm dist-tag add supervision@<version> latest
+   npm view supervision dist-tags --json
+   npm view supervision@<version> version
+   npm pack supervision@<version>
    ```
 
-   Confirm that `latest` resolves to that version, then update public
-   installation instructions to `npm install supervision`.
+7. Confirm that the GitHub Release `v<version>` points at the same `main`
+   commit the workflow published.
+
+## Clear A Previous `next` Tag
+
+Publishing `0.1.1` with `latest` does not remove `next`; npm dist-tags are
+independent. After the stable publish is verified, remove a stale preview tag
+only when no release process still relies on it:
+
+```sh
+npm dist-tag ls supervision
+npm dist-tag rm supervision next
+npm dist-tag ls supervision
+```
+
+This does not unpublish `0.1.0`; it only removes the `next` alias. For the next
+preview cycle, publish a new prerelease version such as `0.1.2-rc.0` with the
+`next` tag.
 
 ## Recovery
 
-If a publish fails before uploading the package, fix the failure in a pull
+If publishing fails before uploading the package, fix the failure in a pull
 request and rerun the workflow from `main`. npm versions are immutable once
 published: never try to overwrite one. Publish a new patch version instead.
 
-If OIDC authentication fails, compare the npm trusted-publisher configuration
-with the workflow's organization, repository, filename, and environment. Do
-not work around the issue by adding a long-lived npm write token to GitHub.
+If package publishing succeeds but GitHub Release creation fails, rerun the
+workflow for the same `main` commit. The release step is idempotent and will
+leave an existing matching GitHub Release intact.

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -129,7 +129,9 @@ published: never try to overwrite one. Publish a new patch version instead.
 If package publishing succeeds but GitHub Release creation fails, do not start
 a new default dispatch from a later `main` commit: that would build a different
 source tree for an immutable version. Start **Publish npm package** from `main`
-with `release_sha` set to the full SHA of the failed run's `head_sha`. The
-workflow checks out that SHA, verifies or creates the matching `v<version>`
-tag, and then creates the GitHub Release. It rejects an already-published
-version without that explicit recovery SHA.
+with `recovery_run_id` set to the failed run's numeric GitHub Actions ID. The
+workflow reads that run's `head_sha`, confirms it was a failed main dispatch of
+this workflow, checks out that commit, and then verifies or creates the matching
+`v<version>` tag before creating the GitHub Release. It rejects an
+already-published version without that verified recovery run, and it refuses to
+publish a missing version during recovery.

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -66,6 +66,8 @@ change the published browser package version.
 
 1. Update `packages/web/package.json`, `package-lock.json`, and the checked docs
    toolbar version together. `npm run docs:check` verifies the toolbar mirror.
+   Before the npm publication, the toolbar must label that version as pending;
+   the post-publication docs-only follow-up removes that label.
 2. Keep the public repository README and hosted docs on the currently live npm
    channel until the stable publish has completed. Before the first browser
    package owns `latest`, that is `npm install supervision@next`; do not
@@ -99,8 +101,8 @@ change the published browser package version.
 7. Confirm that the GitHub Release `v<version>` points at the same `main`
    commit the workflow published. Then merge a docs-only follow-up that changes
    the public repository README and hosted docs from
-   `npm install supervision@next` to `npm install supervision` and verify the
-   documentation deployment.
+   `npm install supervision@next` to `npm install supervision`, removes the
+   toolbar's pending-release label, and verifies the documentation deployment.
 
 ## Clear A Previous `next` Tag
 
@@ -124,6 +126,10 @@ If publishing fails before uploading the package, fix the failure in a pull
 request and rerun the workflow from `main`. npm versions are immutable once
 published: never try to overwrite one. Publish a new patch version instead.
 
-If package publishing succeeds but GitHub Release creation fails, rerun the
-workflow for the same `main` commit. The release step is idempotent and will
-leave an existing matching GitHub Release intact.
+If package publishing succeeds but GitHub Release creation fails, do not start
+a new default dispatch from a later `main` commit: that would build a different
+source tree for an immutable version. Start **Publish npm package** from `main`
+with `release_sha` set to the full SHA of the failed run's `head_sha`. The
+workflow checks out that SHA, verifies or creates the matching `v<version>`
+tag, and then creates the GitHub Release. It rejects an already-published
+version without that explicit recovery SHA.

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -66,9 +66,12 @@ change the published browser package version.
 
 1. Update `packages/web/package.json`, `package-lock.json`, and the checked docs
    toolbar version together. `npm run docs:check` verifies the toolbar mirror.
-2. Update public docs and README installation guidance to use
-   `npm install supervision`. Do not document path installs of release tarballs
-   for consumers.
+2. Keep the public repository README and hosted docs on the currently live npm
+   channel until the stable publish has completed. Before the first browser
+   package owns `latest`, that is `npm install supervision@next`; do not
+   document path installs of release tarballs for consumers. The package README
+   published in this release may use `npm install supervision`, because it only
+   becomes visible after that stable publication.
 3. Run the normal validation plus the clean-consumer artifact smoke test:
 
    ```sh
@@ -94,13 +97,16 @@ change the published browser package version.
    ```
 
 7. Confirm that the GitHub Release `v<version>` points at the same `main`
-   commit the workflow published.
+   commit the workflow published. Then merge a docs-only follow-up that changes
+   the public repository README and hosted docs from
+   `npm install supervision@next` to `npm install supervision` and verify the
+   documentation deployment.
 
 ## Clear A Previous `next` Tag
 
 Publishing `0.1.1` with `latest` does not remove `next`; npm dist-tags are
-independent. After the stable publish is verified, remove a stale preview tag
-only when no release process still relies on it:
+independent. After the stable publish and docs-only follow-up are verified,
+remove a stale preview tag only when no release process still relies on it:
 
 ```sh
 npm dist-tag ls supervision

--- a/docs/internal/render-deployment.md
+++ b/docs/internal/render-deployment.md
@@ -90,8 +90,8 @@ curl --fail --location \
   https://supervision-js-demo.onrender.com/examples/vanilla/
 ```
 
-The Application Integration page must describe tarball installation, and the
-Editing module must appear in the generated API reference. Also verify that the
-live Render deploy's commit matches both canonical `main` and mirror `main`.
+The Application Integration page must describe `npm install supervision`, and
+the Editing module must appear in the generated API reference. Also verify that
+the live Render deploy's commit matches both canonical `main` and mirror `main`.
 Those checks distinguish the current documentation from the stale deployment
 that preceded this configuration.

--- a/docs/internal/render-deployment.md
+++ b/docs/internal/render-deployment.md
@@ -90,8 +90,10 @@ curl --fail --location \
   https://supervision-js-demo.onrender.com/examples/vanilla/
 ```
 
-The Application Integration page must describe `npm install supervision`, and
-the Editing module must appear in the generated API reference. Also verify that
-the live Render deploy's commit matches both canonical `main` and mirror `main`.
-Those checks distinguish the current documentation from the stale deployment
-that preceded this configuration.
+The Application Integration page must describe the browser package's current
+npm channel: `npm install supervision@next` before a stable release owns
+`latest`, then `npm install supervision` after the verified post-release docs
+follow-up. The Editing module must appear in the generated API reference. Also
+verify that the live Render deploy's commit matches both canonical `main` and
+mirror `main`. Those checks distinguish the current documentation from the
+stale deployment that preceded this configuration.

--- a/docs/internal/tarball-packaging.md
+++ b/docs/internal/tarball-packaging.md
@@ -1,7 +1,9 @@
 # Tarball Packaging
 
-The first npm release has not been published yet. The supported distribution
-until then is one portable npm tarball built from this repository.
+The portable tarball is the artifact published to npm. It is not a public
+consumer installation channel: consumers install the stable package with
+`npm install supervision`. This document exists for maintainers who validate
+or change the packaging path.
 
 ## Build The Tarball
 
@@ -9,40 +11,24 @@ until then is one portable npm tarball built from this repository.
 npm run package:tarball
 ```
 
-That command builds `supervision-js-core` and the published `supervision` package, then writes a
-single archive to the ignored `artifacts/` directory:
+That command builds `supervision-js-core` and the published `supervision`
+package, then writes a single archive to the ignored `artifacts/` directory:
 
-```
-artifacts/supervision-0.1.0.tgz
+```text
+artifacts/supervision-<version>.tgz
 ```
 
-`artifacts/` is cleared of previous `supervision-*.tgz` archives on every
-run, so exactly one artifact exists at a time. Pass `--skip-build` to repack
-existing `dist/` output, or `--out-dir=<path>` to write elsewhere:
+`artifacts/` is cleared of previous `supervision-*.tgz` archives on every run,
+so exactly one artifact exists at a time. Pass `--skip-build` to repack existing
+`dist/` output, or `--out-dir=<path>` to write elsewhere:
 
 ```sh
 node tools/pack-web-tarball.mjs --skip-build --out-dir=/tmp/supervision
 ```
 
-## Install In A Website
-
-Copy the archive next to the consuming project and install it by path:
-
-```sh
-npm install ./supervision-0.1.0.tgz
-```
-
-Both supported entrypoints then resolve normally:
-
-```ts
-import { createMediaSession } from "supervision";
-import { createMaskBrushEditor } from "supervision/editing";
-```
-
-The consumer needs an npm-compatible bundler such as Vite, webpack, Parcel, or
-esbuild. The default render-preparation worker is embedded in the browser entry
-and created from a Blob URL, so the bundler does not need worker-specific asset
-handling. There is no CDN, UMD, or `<script>` distribution.
+The archive is deliberately installed by path only inside the smoke test. That
+test proves the archive is portable before npm receives it; it is not consumer
+documentation.
 
 ## How The Private Core Is Made Portable
 
@@ -58,13 +44,13 @@ resolves it at pack time:
 2. Extract the web archive into a staging directory.
 3. Extract the core archive into `node_modules/supervision-js-core` inside that
    staging directory.
-4. Rewrite the staged manifest: pin `supervision-js-core` to its version instead
-   of `file:../core`, and list it in `bundleDependencies`.
+4. Rewrite the staged manifest: pin `supervision-js-core` to its version
+   instead of `file:../core`, and list it in `bundleDependencies`.
 5. `npm pack` the staging directory into the output archive.
 
-The source tree, the package boundary checks, and the Rollup externals are all
-unchanged. `pixi.js` and `mediabunny` stay ordinary dependencies and are
-installed from the registry by the consumer.
+The source tree, package boundary checks, and Rollup externals are unchanged.
+`pixi.js` and `mediabunny` stay ordinary dependencies and are installed from the
+registry by the consumer.
 
 ## Verify The Artifact
 
@@ -82,7 +68,7 @@ the OS temp directory — outside this repository — to check that:
 - the main browser entry embeds the worker source instead of referencing a
   runtime-relative worker URL;
 - `supervision-js-core` is bundled while `pixi.js` and `mediabunny` are not;
-- a clean `npm install <tarball>` produces a lockfile with no `file:` path;
+- a clean archive installation produces a lockfile with no `file:` path;
 - `supervision` and `supervision/editing` import under Node;
 - a minimal Vite production build that imports `createMediaSession` succeeds.
 
@@ -97,7 +83,7 @@ The portable archive is the only artifact that may be published. Do not run
 `npm publish` from `packages/web`: its workspace manifest intentionally points
 at the private core package through `file:../core`.
 
-See [npm-release.md](npm-release.md) for the one-time npm ownership bootstrap,
-trusted-publisher configuration, and the protected manual release workflow.
-Use `npm run package:publish:dry-run` to recreate the artifact and validate the
+See [npm-release.md](npm-release.md) for release ownership, trusted-publisher
+configuration, stable and preview tags, and the protected manual workflow. Use
+`npm run package:publish:dry-run` to recreate the artifact and validate the
 exact local archive argument that npm will receive, without publishing it.

--- a/docs/public/guides/application-integration.md
+++ b/docs/public/guides/application-integration.md
@@ -13,57 +13,14 @@ another web application.
 ## Installation
 
 The browser package is published as `supervision`. There is no CDN, UMD, or
-`<script>` build. Until the first browser release is available on npm's `next`
-tag, build and install a portable archive from this public repository:
-
-Build the portable archive from the `supervision-js` repository:
-
-```sh
-npm install
-npm run package:tarball
-```
-
-The archive is written to:
-
-```text
-artifacts/supervision-0.1.0.tgz
-```
-
-Copy that archive into a stable path in the consuming application, then install
-it from there:
-
-```text
-my-app/
-├── package.json
-└── vendor/
-    └── supervision-0.1.0.tgz
-```
-
-```sh
-npm install ./vendor/supervision-0.1.0.tgz
-```
-
-Keeping the archive at a stable project-relative path is important:
-`package-lock.json` records the local package location, and later `npm ci` runs
-must be able to read it. Commit the archive when the consuming repository allows
-vendored dependencies; otherwise store it in the team's artifact system and
-make retrieval part of the build.
-
-The archive contains the internal `supervision-js-core` package. Consumers must
-not install `supervision-js-core` separately.
-
-Once the first browser release is available on npm's `next` tag:
-
-```sh
-npm install supervision@next
-```
-
-After that release is promoted to npm's `latest` tag, install it without the
-tag:
+`<script>` build. Install the current stable release with npm:
 
 ```sh
 npm install supervision
 ```
+
+The published package includes the internal `supervision-js-core` dependency.
+Consumers must not install `supervision-js-core` separately.
 
 ## Supported Consumer
 
@@ -320,7 +277,6 @@ Before considering an integration complete:
 
 - Installing `supervision-web` instead of `supervision`.
 - Installing `supervision-js-core` separately.
-- Deleting or moving the tarball after committing a local `file:` dependency.
 - Running `createMediaSession()` during SSR.
 - Mounting into a zero-height container.
 - Treating rectangle `x` and `y` as top-left coordinates.

--- a/docs/public/guides/application-integration.md
+++ b/docs/public/guides/application-integration.md
@@ -13,10 +13,10 @@ another web application.
 ## Installation
 
 The browser package is published as `supervision`. There is no CDN, UMD, or
-`<script>` build. Install the current stable release with npm:
+`<script>` build. Install the current browser release with npm:
 
 ```sh
-npm install supervision
+npm install supervision@next
 ```
 
 The published package includes the internal `supervision-js-core` dependency.

--- a/docs/public/guides/public-api.md
+++ b/docs/public/guides/public-api.md
@@ -20,8 +20,9 @@ import from `supervision`:
 import { createMediaSession } from "supervision";
 ```
 
-Install the stable package with `npm install supervision`. See [Application
-Integration](application-integration.md) for the supported consumer workflow.
+Install the current browser release with `npm install supervision@next`. See
+[Application Integration](application-integration.md) for the supported
+consumer workflow.
 
 The split keeps detections, timelines, styles, retention policies, source
 composition, and picking contracts reusable without making Pixi, Mediabunny,

--- a/docs/public/guides/public-api.md
+++ b/docs/public/guides/public-api.md
@@ -20,10 +20,7 @@ import from `supervision`:
 import { createMediaSession } from "supervision";
 ```
 
-Until the first browser release is available on npm's `next` tag, install the
-portable `supervision-0.1.0.tgz` archive built from this repository. Once it is
-available, use `npm install supervision@next`; after it is promoted to npm's
-`latest` tag, use `npm install supervision`. See [Application
+Install the stable package with `npm install supervision`. See [Application
 Integration](application-integration.md) for the supported consumer workflow.
 
 The split keeps detections, timelines, styles, retention policies, source

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -6,6 +6,7 @@
       <p class="supervision-home__lede">
         <code>supervision</code> is a browser-native TypeScript library for interactive computer vision media. A media session keeps the visible frame, detections, styles, interaction, and playback on one timing reference.
       </p>
+      <p class="supervision-home__install"><code>npm install supervision</code></p>
       <div class="supervision-home__actions">
         <a class="supervision-home__button supervision-home__button--primary" href="documents/Application_Integration.html">Get started</a>
         <a class="supervision-home__button supervision-home__button--secondary" href="https://supervision-js-demo.onrender.com/">Open the demo</a>

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -6,7 +6,7 @@
       <p class="supervision-home__lede">
         <code>supervision</code> is a browser-native TypeScript library for interactive computer vision media. A media session keeps the visible frame, detections, styles, interaction, and playback on one timing reference.
       </p>
-      <p class="supervision-home__install"><code>npm install supervision</code></p>
+      <p class="supervision-home__install"><code>npm install supervision@next</code></p>
       <div class="supervision-home__actions">
         <a class="supervision-home__button supervision-home__button--primary" href="documents/Application_Integration.html">Get started</a>
         <a class="supervision-home__button supervision-home__button--secondary" href="https://supervision-js-demo.onrender.com/">Open the demo</a>

--- a/docs/public/typedoc-custom.css
+++ b/docs/public/typedoc-custom.css
@@ -602,6 +602,22 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
   max-width: 45rem;
 }
 
+.supervision-home__install {
+  color: var(--rf-gray-700);
+  font-size: 0.95rem;
+  margin-bottom: 1.6rem !important;
+}
+
+.supervision-home__install code {
+  background: var(--rf-violet-50);
+  border: 1px solid var(--rf-violet-100);
+  border-radius: 8px;
+  color: var(--rf-violet-700);
+  display: inline-block;
+  font-weight: 720;
+  padding: 0.45rem 0.62rem;
+}
+
 .supervision-home__actions {
   display: flex;
   flex-wrap: wrap;

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -3,6 +3,7 @@
 (function () {
   const packageName = "supervision";
   const packageVersion = "0.1.1";
+  const packageReleaseStatus = "pending release";
   const kindIconMap = {
     Accessor: "A",
     Class: "C",
@@ -117,7 +118,9 @@
       `${base}assets/brand/roboflow-logomark.svg`,
       window.location.href,
     ).href;
-    const version = `v${packageVersion}`;
+    const version = packageReleaseStatus
+      ? `v${packageVersion} (${packageReleaseStatus})`
+      : `v${packageVersion}`;
 
     title.innerHTML = `
       <img class="supervision-docs__mark" src="${logo}" alt="Roboflow" />

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -1,6 +1,8 @@
 /* global Element, MutationObserver, URL, localStorage */
 
 (function () {
+  const packageName = "supervision";
+  const packageVersion = "0.1.1";
   const kindIconMap = {
     Accessor: "A",
     Class: "C",
@@ -115,12 +117,12 @@
       `${base}assets/brand/roboflow-logomark.svg`,
       window.location.href,
     ).href;
-    const version = document.title.match(/v[^-]+$/)?.[0] ?? "pre-1.0";
+    const version = `v${packageVersion}`;
 
     title.innerHTML = `
       <img class="supervision-docs__mark" src="${logo}" alt="Roboflow" />
       <span class="supervision-docs__brand-copy">
-        <span>Supervision</span>
+        <span>${packageName}</span>
         <span class="supervision-docs__product">JS</span>
         <span class="supervision-docs__version">${version}</span>
       </span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10388,7 +10388,7 @@
     },
     "packages/web": {
       "name": "supervision",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.52.3",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "package:smoke": "node --test tools/package-smoke.test.mjs",
     "package:tarball": "node tools/pack-web-tarball.mjs",
     "package:tarball:smoke": "node --test tools/tarball-smoke.test.mjs",
-    "package:publish:dry-run": "npm run package:tarball && npm publish ./artifacts/supervision-*.tgz --access public --tag next --dry-run",
+    "package:publish:dry-run": "npm run package:tarball && npm publish ./artifacts/supervision-*.tgz --access public --tag latest --dry-run",
     "test:watch": "vitest",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -8,12 +8,11 @@ styling, interaction, and editing for images, video, and browser media streams.
 ## Installation
 
 ```sh
-npm install supervision@next
+npm install supervision
 ```
 
-The first public browser release is staged on npm's `next` tag. Use
-`npm install supervision` after it is promoted to `latest`. The package includes
-its internal core dependency. Consumers import the public browser entrypoints:
+The package includes its internal core dependency. Consumers import the public
+browser entrypoints:
 
 ```ts
 import { createMediaSession } from "supervision";

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supervision",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Browser-native computer vision media rendering and annotation engine.",
   "repository": {
     "type": "git",

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -103,7 +103,7 @@ test("TypeDoc does not publish the private workspace version", async () => {
   assert.equal(config.includeVersion, false);
 });
 
-test("documentation toolbar mirrors the published browser package version", async () => {
+test("documentation toolbar mirrors the browser package manifest version", async () => {
   const packageJson = JSON.parse(
     await readFile(path.join(rootDir, "packages/web/package.json"), "utf8"),
   );

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -103,6 +103,25 @@ test("TypeDoc does not publish the private workspace version", async () => {
   assert.equal(config.includeVersion, false);
 });
 
+test("documentation toolbar mirrors the published browser package version", async () => {
+  const packageJson = JSON.parse(
+    await readFile(path.join(rootDir, "packages/web/package.json"), "utf8"),
+  );
+  const toolbarScript = await readFile(
+    path.join(publicDocsDir, "typedoc-icons.js"),
+    "utf8",
+  );
+  const packageName = toolbarScript.match(
+    /const packageName = "([^"]+)";/,
+  )?.[1];
+  const packageVersion = toolbarScript.match(
+    /const packageVersion = "([^"]+)";/,
+  )?.[1];
+
+  assert.equal(packageName, packageJson.name);
+  assert.equal(packageVersion, packageJson.version);
+});
+
 test("Render preview trusts only its assigned hostname", async () => {
   const packageJson = JSON.parse(
     await readFile(path.join(rootDir, "package.json"), "utf8"),

--- a/tools/pack-web-tarball.mjs
+++ b/tools/pack-web-tarball.mjs
@@ -1,6 +1,5 @@
 /**
- * Builds one portable `supervision-<version>.tgz` for consumers that cannot
- * access this private repository.
+ * Builds the portable `supervision-<version>.tgz` artifact published to npm.
  *
  * The browser package depends on the private `supervision-js-core` workspace
  * through `file:../core`, which does not exist for an external consumer. Rather


### PR DESCRIPTION
# Description

Prepares the published browser package for the stable 0.1.1 release. Public docs remove tarball installation and stay on the live `@next` channel until stable publication completes; the toolbar marks 0.1.1 as pending during that interval. The package README shipped with 0.1.1 then uses `npm install supervision`. Release automation defaults to `latest`, reserves `next` for prereleases, verifies the npm dist-tag, and creates a verified `v<version>` tag before the matching GitHub Release. Recovery reads the original failed workflow run's immutable `head_sha`, preventing a later `main` commit from being tagged as an already-published artifact.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `npm run verify`
- `npm run docs:check`
- `npm run pages:build`, including generated docs checks for the pending 0.1.1 toolbar and live npm installation channel
- `npm run package:tarball:smoke`
- `npm run package:publish:dry-run`
- Parsed `.github/workflows/publish-npm.yml` as YAML

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- After merge, run **Publish npm package** from `main` with the `latest` tag and approve the `npm-publish` environment.
- Verify `supervision@0.1.1` and GitHub Release `v0.1.1`.
- If npm upload succeeds but GitHub Release creation fails, dispatch from `main` with the failed **Publish npm package** workflow run ID in `recovery_run_id`; never use a later `main` commit as recovery source.
- Merge the documented docs-only follow-up from `supervision@next` to unqualified `supervision`, remove the toolbar pending label, then remove the stale `next` dist-tag only after that deploy is live.
- hosting

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
