### PR TITLE
Add basketball playground to docs home

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Useful commands:
 
 - `npm run demo:dev` runs the browser demo.
 - `npm run example:vanilla:dev` runs the minimal vanilla integration.
-- `npm run docs:dev` builds and serves the generated docs.
+- `npm run docs:dev` runs the generated docs and the embedded demo playground.
 - `npm run pages:build` assembles the deployable site.
 - `npm run verify` runs the full repository validation suite.
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { BenchmarksPanel } from "./components/BenchmarksPanel";
 import { ControlBar } from "./components/ControlBar";
 import { DemoShell } from "./components/DemoShell";
+import { DocsBasketballPlayground } from "./components/DocsBasketballPlayground";
 import { PerformanceStrip } from "./components/PerformanceStrip";
 import { QualityControls } from "./components/QualityControls";
 import { RenderControls } from "./components/RenderControls";
@@ -23,6 +24,17 @@ const docsUrl =
 const allowUpload = import.meta.env.VITE_DEMO_ALLOW_UPLOAD !== "false";
 
 export function App() {
+  if (
+    new URLSearchParams(globalThis.location.search).get("embed") ===
+    "docs-playground"
+  ) {
+    return <DocsBasketballPlayground />;
+  }
+
+  return <DemoApp />;
+}
+
+function DemoApp() {
   const demo = useDemoRenderer();
   const [viewMode, setViewMode] = useState(DemoViewMode.Demo);
   const processedRanges = useMemo(

--- a/demo/src/components/DocsBasketballPlayground.tsx
+++ b/demo/src/components/DocsBasketballPlayground.tsx
@@ -1,0 +1,205 @@
+import { useCallback, useMemo } from "react";
+import { MediaRendererPlaybackState } from "supervision";
+import {
+  type DemoPresentationSettings,
+  type DemoPresentationLayerSetting,
+} from "../presentation/demo-presentation";
+import { useDemoRenderer } from "../hooks/useDemoRenderer";
+import { RendererViewport } from "./RendererViewport";
+
+const docsUrl =
+  import.meta.env.VITE_SUPERVISION_DOCS_URL ??
+  (globalThis.location.hostname === "localhost" ||
+  globalThis.location.hostname === "127.0.0.1"
+    ? "http://127.0.0.1:5175"
+    : `${import.meta.env.BASE_URL}docs/`);
+
+const annotationLayers: readonly {
+  readonly key: DemoPresentationLayerSetting;
+  readonly label: string;
+  readonly description: string;
+}[] = [
+  { key: "masksEnabled", label: "Masks", description: "Segmentation" },
+  { key: "boxesEnabled", label: "Boxes", description: "Detection bounds" },
+  {
+    key: "keypointsEnabled",
+    label: "Skeletons",
+    description: "Pose keypoints",
+  },
+  { key: "labelsEnabled", label: "Labels", description: "Class names" },
+];
+
+/** A compact, embeddable consumer of the browser demo for the docs homepage. */
+export function DocsBasketballPlayground() {
+  const demo = useDemoRenderer({
+    initialFixtureId: "basketball_geometry",
+    initialPresentationSettings: {
+      boxesEnabled: true,
+      focusEnabled: false,
+      keypointsEnabled: true,
+      labelsEnabled: true,
+      masksEnabled: true,
+      maskOpacity: 0.78,
+      polygonsEnabled: false,
+    },
+  });
+  const isPlaying =
+    demo.playbackState === MediaRendererPlaybackState.Playing ||
+    demo.playbackState === MediaRendererPlaybackState.Buffering;
+  const currentTime = demo.rendererState?.currentTime ?? 0;
+  const progress = useMemo(
+    () =>
+      demo.duration && demo.duration > 0
+        ? Math.min(100, Math.max(0, (currentTime / demo.duration) * 100))
+        : 0,
+    [currentTime, demo.duration],
+  );
+  const updatePresentation = useCallback(
+    (patch: Partial<DemoPresentationSettings>) => {
+      demo.setPresentationSettings({ ...demo.presentationSettings, ...patch });
+    },
+    [demo.presentationSettings, demo.setPresentationSettings],
+  );
+
+  return (
+    <main
+      className="docs-playground"
+      aria-label="Basketball annotation playground"
+    >
+      <div className="docs-playground__stage">
+        <RendererViewport
+          containerRef={demo.containerRef}
+          mediaState={demo.mediaState}
+          sessionState={demo.sessionState}
+          uploadInferenceState={null}
+        />
+        <div className="docs-playground__stage-copy">
+          <span>Live fixture</span>
+          <strong>Segmentation + pose</strong>
+        </div>
+      </div>
+
+      <section
+        className="docs-playground__controls"
+        aria-labelledby="playground-controls-title"
+      >
+        <div className="docs-playground__controls-heading">
+          <div>
+            <p>Try the renderer</p>
+            <h1 id="playground-controls-title">Style the scene</h1>
+          </div>
+          <a href={docsUrl} target="_parent">
+            Explore the API <span aria-hidden="true">→</span>
+          </a>
+        </div>
+
+        <fieldset className="docs-playground__layer-list">
+          <legend>Visible annotations</legend>
+          {annotationLayers.map(({ key, label, description }) => (
+            <label className="docs-playground__layer" key={key}>
+              <input
+                checked={demo.presentationSettings[key]}
+                onChange={() =>
+                  updatePresentation({ [key]: !demo.presentationSettings[key] })
+                }
+                type="checkbox"
+              />
+              <span>
+                <strong>{label}</strong>
+                <small>{description}</small>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+
+        <fieldset className="docs-playground__style-list">
+          <legend>Presentation</legend>
+          <RangeControl
+            label="Mask opacity"
+            max={1}
+            min={0.15}
+            onChange={(maskOpacity) => updatePresentation({ maskOpacity })}
+            step={0.05}
+            value={demo.presentationSettings.maskOpacity}
+            valueLabel={`${Math.round(demo.presentationSettings.maskOpacity * 100)}%`}
+          />
+          <RangeControl
+            label="Box stroke"
+            max={6}
+            min={1}
+            onChange={(boxStrokeWidth) =>
+              updatePresentation({ boxStrokeWidth })
+            }
+            step={0.5}
+            value={demo.presentationSettings.boxStrokeWidth}
+            valueLabel={`${demo.presentationSettings.boxStrokeWidth}px`}
+          />
+          <RangeControl
+            label="Keypoint size"
+            max={8}
+            min={2}
+            onChange={(keypointRadius) =>
+              updatePresentation({ keypointRadius })
+            }
+            step={0.5}
+            value={demo.presentationSettings.keypointRadius}
+            valueLabel={`${demo.presentationSettings.keypointRadius}px`}
+          />
+        </fieldset>
+
+        <div className="docs-playground__playback">
+          <button
+            aria-label={
+              isPlaying ? "Pause basketball fixture" : "Play basketball fixture"
+            }
+            disabled={!demo.canUseRenderer}
+            onClick={demo.onTogglePlayback}
+            type="button"
+          >
+            <span aria-hidden="true">{isPlaying ? "Ⅱ" : "▶"}</span>
+            {isPlaying ? "Pause" : "Play"}
+          </button>
+          <div aria-hidden="true" className="docs-playground__progress">
+            <span style={{ width: `${progress}%` }} />
+          </div>
+          <span className="docs-playground__loop">Loops continuously</span>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function RangeControl({
+  label,
+  max,
+  min,
+  onChange,
+  step,
+  value,
+  valueLabel,
+}: {
+  readonly label: string;
+  readonly max: number;
+  readonly min: number;
+  readonly onChange: (value: number) => void;
+  readonly step: number;
+  readonly value: number;
+  readonly valueLabel: string;
+}) {
+  return (
+    <label className="docs-playground__range">
+      <span>
+        <strong>{label}</strong>
+        <output>{valueLabel}</output>
+      </span>
+      <input
+        max={max}
+        min={min}
+        onChange={(event) => onChange(Number(event.currentTarget.value))}
+        step={step}
+        type="range"
+        value={value}
+      />
+    </label>
+  );
+}

--- a/demo/src/hooks/useDemoRenderer.ts
+++ b/demo/src/hooks/useDemoRenderer.ts
@@ -92,14 +92,17 @@ export interface DemoRendererState {
   readonly setUploadClassNames: (classNames: string) => void;
 }
 
+export interface UseDemoRendererOptions {
+  /**
+   * Lets focused demo experiences start on a known fixture without first
+   * constructing another media session.
+   */
+  readonly initialFixtureId?: string;
+  /** Presentation values applied over that fixture's documented defaults. */
+  readonly initialPresentationSettings?: Partial<DemoPresentationSettings>;
+}
+
 const RENDERER_READOUT_INTERVAL_MS = 250;
-const defaultFixturePresentationSettings = constrainDemoPresentationSettings(
-  {
-    ...defaultDemoPresentationSettings,
-    ...defaultDemoFixture.presentationDefaults,
-  },
-  defaultDemoFixture.presentationAvailability,
-);
 
 const initialDetectionSourceState: DemoDetectionSourceState = {
   datasetId: null,
@@ -121,7 +124,25 @@ const initialUploadInferenceState: UploadInferenceState = {
   totalFrames: 0,
 };
 
-export function useDemoRenderer(): DemoRendererState {
+export function useDemoRenderer(
+  options: UseDemoRendererOptions = {},
+): DemoRendererState {
+  const [initialFixture] = useState(
+    () =>
+      demoFixtures.find(
+        (fixture) => fixture.sampleName === options.initialFixtureId,
+      ) ?? defaultDemoFixture,
+  );
+  const [initialPresentationSettings] = useState(() =>
+    constrainDemoPresentationSettings(
+      {
+        ...defaultDemoPresentationSettings,
+        ...initialFixture.presentationDefaults,
+        ...options.initialPresentationSettings,
+      },
+      initialFixture.presentationAvailability,
+    ),
+  );
   const containerRef = useRef<HTMLDivElement | null>(null);
   const effectRunRef = useRef(0);
   const rendererRef = useRef<MediaRenderer | null>(null);
@@ -130,7 +151,7 @@ export function useDemoRenderer(): DemoRendererState {
   const uploadAbortRef = useRef<AbortController | null>(null);
   const uploadFileRef = useRef<File | null>(null);
   const presentationSettingsRef = useRef<DemoPresentationSettings>(
-    defaultFixturePresentationSettings,
+    initialPresentationSettings,
   );
   const [rendererState, setRendererState] = useState<MediaRendererState | null>(
     null,
@@ -155,7 +176,7 @@ export function useDemoRenderer(): DemoRendererState {
   });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [presentationSettings, setPresentationSettingsState] =
-    useState<DemoPresentationSettings>(defaultFixturePresentationSettings);
+    useState<DemoPresentationSettings>(initialPresentationSettings);
   const [renderQuality, setRenderQuality] = useState<DemoRenderQuality>(
     defaultDemoRenderQuality,
   );
@@ -163,7 +184,7 @@ export function useDemoRenderer(): DemoRendererState {
     DemoSourceMode.Fixture,
   );
   const [sampleFixtureId, setSampleFixtureIdState] = useState(
-    defaultDemoFixture.sampleName,
+    initialFixture.sampleName,
   );
   const [uploadApiKey, setUploadApiKey] = useState("");
   const [uploadClassNames, setUploadClassNames] = useState(

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -50,6 +50,279 @@ body {
   overflow: hidden;
 }
 
+.docs-playground {
+  background:
+    radial-gradient(
+      circle at 100% 0,
+      rgba(196, 181, 253, 0.5),
+      transparent 34%
+    ),
+    linear-gradient(145deg, #ffffff 0%, #f5f3ff 100%);
+  color: var(--text);
+  display: grid;
+  gap: 0;
+  grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.docs-playground__stage {
+  background: #ffffff;
+  border-right: 1px solid #ddd6fe;
+  min-height: 0;
+  position: relative;
+}
+
+.docs-playground__stage .renderer-viewport {
+  background: #f3f4f6;
+  height: 100%;
+}
+
+.docs-playground__stage .renderer-viewport::after {
+  display: none;
+}
+
+.docs-playground__stage-copy {
+  align-items: center;
+  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(196, 181, 253, 0.88);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px rgba(76, 29, 149, 0.12);
+  display: flex;
+  gap: 0.45rem;
+  left: 1rem;
+  padding: 0.42rem 0.72rem;
+  position: absolute;
+  top: 1rem;
+  z-index: 3;
+}
+
+.docs-playground__stage-copy span,
+.docs-playground__stage-copy strong {
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
+.docs-playground__stage-copy span {
+  color: var(--violet);
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-playground__stage-copy strong {
+  color: var(--text);
+  font-weight: 740;
+}
+
+.docs-playground__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  min-height: 0;
+  overflow: auto;
+  padding: clamp(1.2rem, 3vw, 2rem);
+  scrollbar-color: #c4b5fd transparent;
+  scrollbar-width: thin;
+}
+
+.docs-playground__controls-heading {
+  align-items: start;
+  display: flex;
+  gap: 0.8rem;
+  justify-content: space-between;
+}
+
+.docs-playground__controls-heading p,
+.docs-playground__controls-heading h1 {
+  margin: 0;
+}
+
+.docs-playground__controls-heading p,
+.docs-playground legend {
+  color: var(--violet);
+  font-size: 0.68rem;
+  font-weight: 780;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.docs-playground__controls-heading h1 {
+  color: var(--text);
+  font-size: clamp(1.45rem, 2.6vw, 2rem);
+  letter-spacing: -0.045em;
+  line-height: 1.04;
+  margin-top: 0.35rem;
+}
+
+.docs-playground__controls-heading a {
+  color: var(--violet);
+  font-size: 0.76rem;
+  font-weight: 720;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.docs-playground__layer-list,
+.docs-playground__style-list {
+  background: rgba(255, 255, 255, 0.74);
+  border: 1px solid #e4e4e7;
+  border-radius: 13px;
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.95rem;
+}
+
+.docs-playground legend {
+  margin-bottom: 0.18rem;
+  padding: 0;
+}
+
+.docs-playground__layer {
+  align-items: center;
+  border-radius: 9px;
+  cursor: pointer;
+  display: flex;
+  gap: 0.65rem;
+  padding: 0.4rem;
+}
+
+.docs-playground__layer:hover {
+  background: #f5f3ff;
+}
+
+.docs-playground__layer input {
+  accent-color: var(--violet);
+  block-size: 1rem;
+  inline-size: 1rem;
+  margin: 0;
+}
+
+.docs-playground__layer span {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.docs-playground__layer strong {
+  color: var(--text);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.docs-playground__layer small {
+  color: var(--muted);
+  font-size: 0.69rem;
+}
+
+.docs-playground__range {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.docs-playground__range + .docs-playground__range {
+  margin-top: 0.42rem;
+}
+
+.docs-playground__range > span {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+}
+
+.docs-playground__range strong {
+  color: var(--muted-strong);
+  font-size: 0.76rem;
+  font-weight: 680;
+}
+
+.docs-playground__range output {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.docs-playground__range input {
+  accent-color: var(--violet);
+  cursor: pointer;
+  inline-size: 100%;
+}
+
+.docs-playground__playback {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto minmax(3rem, 1fr);
+  margin-top: auto;
+}
+
+.docs-playground__playback button {
+  align-items: center;
+  background: var(--violet);
+  border: 0;
+  border-radius: 9px;
+  box-shadow: 0 8px 16px rgba(109, 40, 217, 0.18);
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 730;
+  gap: 0.38rem;
+  min-height: 2.2rem;
+  padding: 0.45rem 0.72rem;
+}
+
+.docs-playground__playback button:hover:not(:disabled) {
+  background: #6d28d9;
+}
+
+.docs-playground__playback button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.docs-playground__progress {
+  background: #ddd6fe;
+  block-size: 0.35rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.docs-playground__progress span {
+  background: linear-gradient(90deg, #7c3aed, #a78bfa);
+  block-size: 100%;
+  border-radius: inherit;
+  display: block;
+  transition: width 180ms linear;
+}
+
+.docs-playground__loop {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 620;
+  grid-column: 2;
+}
+
+@media (max-width: 720px) {
+  .docs-playground {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(22rem, 1.08fr) minmax(27rem, 0.92fr);
+    overflow: auto;
+  }
+
+  .docs-playground__stage {
+    border-bottom: 1px solid #ddd6fe;
+    border-right: 0;
+    min-height: 22rem;
+  }
+
+  .docs-playground__controls {
+    overflow: visible;
+  }
+}
+
 button,
 input {
   font: inherit;

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -24,6 +24,27 @@
       </p>
     </aside>
   </section>
+  <section class="supervision-home__section supervision-home__playground" aria-labelledby="playground-title">
+    <div class="supervision-home__section-heading">
+      <p class="supervision-home__eyebrow">Interactive playground</p>
+      <h2 id="playground-title">See detections move with the media—not above it.</h2>
+      <p>
+        This looping basketball fixture combines segmentation masks, detection boxes, labels, and pose skeletons. Toggle layers and tune the presentation while the same browser media session keeps every annotation in sync.
+      </p>
+    </div>
+    <div class="supervision-home__playground-frame">
+      <iframe
+        allow="autoplay"
+        loading="lazy"
+        src="../?embed=docs-playground"
+        title="Interactive basketball detection playground"
+      ></iframe>
+    </div>
+    <p class="supervision-home__playground-note">
+      The playground is a small consumer of <code>supervision</code>, using the same session, detection, and style contracts available to your application.
+      <a href="documents/Detections_And_Rendering.html">Learn about detection rendering <span aria-hidden="true">→</span></a>
+    </p>
+  </section>
   <section class="supervision-home__section" aria-labelledby="quick-start-title">
     <div class="supervision-home__section-heading">
       <p class="supervision-home__eyebrow">Quick start</p>

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -35,8 +35,8 @@
     <div class="supervision-home__playground-frame">
       <iframe
         allow="autoplay"
+        data-supervision-playground-src="../?embed=docs-playground"
         loading="lazy"
-        src="../?embed=docs-playground"
         title="Interactive basketball detection playground"
       ></iframe>
     </div>

--- a/docs/public/typedoc-custom.css
+++ b/docs/public/typedoc-custom.css
@@ -730,6 +730,39 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
   max-width: 46rem;
 }
 
+.supervision-home__playground {
+  padding-top: clamp(1rem, 3vw, 2rem);
+}
+
+.supervision-home__playground-frame {
+  background: linear-gradient(135deg, #fcfbff, var(--rf-violet-50));
+  border: 1px solid #dccdff;
+  border-radius: 20px;
+  box-shadow: 0 18px 46px rgba(75, 34, 142, 0.11);
+  margin-top: 1.8rem;
+  overflow: hidden;
+}
+
+.supervision-home__playground-frame iframe {
+  border: 0;
+  display: block;
+  height: clamp(37rem, 58vw, 43rem);
+  width: 100%;
+}
+
+.supervision-home__playground-note {
+  color: var(--rf-gray-500) !important;
+  font-size: 0.88rem;
+  line-height: 1.58;
+  margin: 1rem 0 0 !important;
+}
+
+.supervision-home__playground-note a {
+  font-weight: 720;
+  margin-left: 0.3rem;
+  text-decoration: none !important;
+}
+
 .supervision-home__quick-start {
   align-items: center;
   background: linear-gradient(135deg, #fcfbff, var(--rf-violet-50));
@@ -993,6 +1026,10 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
   .supervision-home__package-grid,
   .supervision-home__pipeline {
     grid-template-columns: 1fr;
+  }
+
+  .supervision-home__playground-frame iframe {
+    height: 57rem;
   }
 }
 

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -101,6 +101,30 @@
     home
       .closest(".container-main")
       ?.classList.add("supervision-docs--home-layout");
+    configureHomePlayground(home);
+  }
+
+  function configureHomePlayground(home) {
+    const playground = home.querySelector(
+      "iframe[data-supervision-playground-src]",
+    );
+    const deployedSource = playground?.dataset.supervisionPlaygroundSrc;
+
+    if (!playground || !deployedSource) {
+      return;
+    }
+
+    // TypeDoc's standalone local server mounts docs at its origin root, while
+    // the assembled Render/Pages site mounts them under /docs/. Point only the
+    // standalone preview at the separately-running Vite demo.
+    const isStandaloneLocalDocs =
+      (window.location.hostname === "localhost" ||
+        window.location.hostname === "127.0.0.1") &&
+      window.location.port === "5175";
+
+    playground.src = isStandaloneLocalDocs
+      ? "http://127.0.0.1:5173/?embed=docs-playground"
+      : deployedSource;
   }
 
   function brandToolbar() {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "docs:build": "npm run build && npm run docs:build:typedoc",
     "docs:build:typedoc": "typedoc && node tools/copy-doc-assets.mjs",
     "docs:check": "node --test tools/docs-contract.test.mjs",
-    "docs:dev": "npm run docs:build && vite docs/site --host 127.0.0.1 --port 5175",
+    "docs:dev": "npm run dev:demo-docs",
     "docs:dev:server": "npm run docs:build:typedoc && vite docs/site --host 127.0.0.1 --port 5175",
     "docs:serve": "npm run docs:build && vite docs/site --host 127.0.0.1 --port 5175",
     "example:vanilla:dev": "npm run build && npm run dev -w examples/vanilla",

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -148,6 +148,9 @@ test("the docs home embeds the local basketball playground", async () => {
     path.join(publicDocsDir, "typedoc-icons.js"),
     "utf8",
   );
+  const packageJson = JSON.parse(
+    await readFile(path.join(rootDir, "package.json"), "utf8"),
+  );
 
   assert.match(
     homepage,
@@ -158,6 +161,7 @@ test("the docs home embeds the local basketball playground", async () => {
     toolbarScript,
     /window\.location\.port === "5175"[\s\S]*?http:\/\/127\.0\.0\.1:5173\/\?embed=docs-playground/,
   );
+  assert.equal(packageJson.scripts["docs:dev"], "npm run dev:demo-docs");
 });
 
 test("Render preview trusts only its assigned hostname", async () => {

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -142,6 +142,13 @@ test("public installation guidance uses the stable browser package", async () =>
   }
 });
 
+test("the docs home embeds the local basketball playground", async () => {
+  const homepage = await readFile(path.join(publicDocsDir, "index.md"), "utf8");
+
+  assert.match(homepage, /src="\.\.\/\?embed=docs-playground"/);
+  assert.match(homepage, /title="Interactive basketball detection playground"/);
+});
+
 test("Render preview trusts only its assigned hostname", async () => {
   const packageJson = JSON.parse(
     await readFile(path.join(rootDir, "package.json"), "utf8"),

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -144,9 +144,20 @@ test("public installation guidance uses the stable browser package", async () =>
 
 test("the docs home embeds the local basketball playground", async () => {
   const homepage = await readFile(path.join(publicDocsDir, "index.md"), "utf8");
+  const toolbarScript = await readFile(
+    path.join(publicDocsDir, "typedoc-icons.js"),
+    "utf8",
+  );
 
-  assert.match(homepage, /src="\.\.\/\?embed=docs-playground"/);
+  assert.match(
+    homepage,
+    /data-supervision-playground-src="\.\.\/\?embed=docs-playground"/,
+  );
   assert.match(homepage, /title="Interactive basketball detection playground"/);
+  assert.match(
+    toolbarScript,
+    /window\.location\.port === "5175"[\s\S]*?http:\/\/127\.0\.0\.1:5173\/\?embed=docs-playground/,
+  );
 });
 
 test("Render preview trusts only its assigned hostname", async () => {


### PR DESCRIPTION
# Description

Adds an interactive basketball fixture immediately after the docs hero. The embedded demo mode starts directly on the combined masks, boxes, labels, and pose-skeleton fixture, while keeping playback and Pixi rendering owned by the existing browser media session.

It provides simple layer toggles, presentation controls, and session-backed play/pause in the existing light Roboflow-purple visual system.

Source: current conversation request.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `npm run verify`
- `npm run pages:build`
- Headless visual inspection of the generated docs home and embedded controls

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- hosting: the docs iframe uses a same-host relative URL, so Render PR previews exercise the branch's embedded demo mode.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
