### PR TITLE
Harden npm release recovery

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -155,8 +155,24 @@ jobs:
         run: |
           set -euo pipefail
           version="$(node -p "require('./packages/web/package.json').version")"
-          published_version="$(npm view "supervision@${DIST_TAG}" version)"
-          test "${published_version}" = "${version}"
+
+          # The upload API can acknowledge a publish before npm's dist-tag
+          # read endpoint reflects it. Poll briefly so a successful publish
+          # cannot strand its immutable version without a GitHub release.
+          for attempt in {1..12}; do
+            published_version="$(npm view "supervision@${DIST_TAG}" version 2>/dev/null || true)"
+            if [[ "${published_version}" == "${version}" ]]; then
+              exit 0
+            fi
+
+            if [[ "${attempt}" -lt 12 ]]; then
+              echo "Waiting for supervision@${DIST_TAG} to resolve to ${version} (attempt ${attempt}/12)."
+              sleep 5
+            fi
+          done
+
+          echo "supervision@${DIST_TAG} did not resolve to ${version} after 60 seconds; saw ${published_version:-nothing}." >&2
+          exit 1
 
       - name: Create or verify release tag
         if: inputs.dist_tag == 'latest'
@@ -167,6 +183,8 @@ jobs:
           tag="v${version}"
           release_sha="$(git rev-parse HEAD)"
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force
 
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -80,8 +80,9 @@ change the published browser package version.
 5. In GitHub Actions, run **Publish npm package** from `main` and select
    `latest` for a stable release. Approve the `npm-publish` environment
    deployment. The workflow verifies, packs, smoke-tests, publishes the
-   generated archive through npm trusted publishing, verifies the selected npm
-   tag, and creates the matching GitHub Release.
+   generated archive through npm trusted publishing, waits briefly for the
+   selected npm tag to propagate, creates the matching annotated Git tag, and
+   creates the matching GitHub Release.
 6. Verify npm metadata, provenance, tarball contents, and a clean installation
    in a separate consumer:
 

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "fixture:geometry:create": "npm run build -w supervision-js-core && node tools/geometry-fixture/create-geometry-fixture.mjs",
     "typecheck": "npm run typecheck -w supervision-js-core && npm run build -w supervision-js-core && npm run typecheck -w supervision-js-react-native && npm run build -w supervision-js-react-native && npm run typecheck -w supervision && npm run build -w supervision && tsc --noEmit -p demo/tsconfig.json && tsc --noEmit -p examples/vanilla/tsconfig.json && npm run example:react-native:typecheck",
     "boundary:check": "node --test tools/package-boundary.test.mjs",
-    "test": "vitest run && npm run boundary:check && npm run docs:check && node --test tools/react-runtime-contract.test.mjs tools/sam3-fixture/*.test.mjs tools/geometry-fixture/*.test.mjs",
+    "test": "vitest run && npm run boundary:check && npm run docs:check && node --test tools/react-runtime-contract.test.mjs tools/release-workflow-contract.test.mjs tools/sam3-fixture/*.test.mjs tools/geometry-fixture/*.test.mjs",
     "package:smoke": "node --test tools/package-smoke.test.mjs",
     "package:tarball": "node tools/pack-web-tarball.mjs",
     "package:tarball:smoke": "node --test tools/tarball-smoke.test.mjs",

--- a/tools/release-workflow-contract.test.mjs
+++ b/tools/release-workflow-contract.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import test from "node:test";
+
+const workflowPath = path.join(
+  process.cwd(),
+  ".github/workflows/publish-npm.yml",
+);
+
+test("npm publish waits for the selected dist-tag to propagate", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /for attempt in \{1\.\.12\}; do/);
+  assert.match(
+    workflow,
+    /npm view "supervision@\$\{DIST_TAG\}" version 2>\/dev\/null \|\| true/,
+  );
+  assert.match(workflow, /sleep 5/);
+  assert.match(workflow, /did not resolve to \$\{version\} after 60 seconds/);
+  assert.match(workflow, /git config user\.name "github-actions\[bot\]"/);
+  assert.match(
+    workflow,
+    /git config user\.email "41898282\+github-actions\[bot\]@users\.noreply\.github\.com"/,
+  );
+});


### PR DESCRIPTION
# Description

Prevents a successful npm upload from leaving the release workflow failed before it can create the matching GitHub tag and release. The workflow now polls briefly for npm dist-tag propagation and configures the GitHub Actions bot identity before creating an annotated tag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Added and ran the release-workflow contract test.
- Inspected the two failed 0.1.1 workflow runs: npm tag propagation and missing Git identity.
- GitHub Actions CI will run the full repository verification.

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Merge before retrying recovery with `recovery_run_id=31171770827`; no new npm publish is needed.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)