### PR TITLE
Align demo workbench with docs styling

### DIFF
--- a/demo/src/components/DemoShell.tsx
+++ b/demo/src/components/DemoShell.tsx
@@ -42,6 +42,7 @@ export function DemoShell({
             />
           </div>
           <div className="demo-shell__title">
+            <span className="demo-shell__eyebrow">Roboflow / supervision</span>
             <strong>supervision-js</strong>
             <span>CV media rendering workbench</span>
           </div>

--- a/demo/src/components/DocsBasketballPlayground.tsx
+++ b/demo/src/components/DocsBasketballPlayground.tsx
@@ -39,6 +39,9 @@ export function DocsBasketballPlayground() {
       keypointsEnabled: true,
       labelsEnabled: true,
       masksEnabled: true,
+      // In this compact playground, the visible slider is the single opacity
+      // control. Keep the prepared fill fully opaque so 100% means 100%.
+      maskFillAlpha: 1,
       maskOpacity: 0.78,
       polygonsEnabled: false,
     },
@@ -117,7 +120,7 @@ export function DocsBasketballPlayground() {
           <RangeControl
             label="Mask opacity"
             max={1}
-            min={0.15}
+            min={0}
             onChange={(maskOpacity) => updatePresentation({ maskOpacity })}
             step={0.05}
             value={demo.presentationSettings.maskOpacity}

--- a/demo/src/presentation/demo-presentation.test.ts
+++ b/demo/src/presentation/demo-presentation.test.ts
@@ -169,6 +169,24 @@ describe("demo presentation", () => {
     });
   });
 
+  it("can render a fully opaque mask when the fill and layer opacity are both 100%", () => {
+    const presentation = createDemoPresentation({
+      ...defaultDemoPresentationSettings,
+      maskFillAlpha: 1,
+      maskOpacity: 1,
+    });
+    const context = {
+      detectionIndex: 0,
+      frame: { detections: [detection], mediaTime: 0 },
+      mediaTime: 0,
+    };
+
+    expect(presentation.maskStyle?.opacity).toBe(1);
+    expect(presentation.maskStyle?.resolve(detection, context)).toMatchObject({
+      alpha: 1,
+    });
+  });
+
   it("matches the Core annotation presentation before demo controls override it", () => {
     const demo = createDemoPresentation(defaultDemoPresentationSettings);
     const canonical = createDefaultAnnotationPresentation();

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -2474,3 +2474,244 @@ fieldset {
 .benchmark-table__row--selected {
   background: #f5f3ff;
 }
+
+/* Align the full workbench with the documentation home's quieter, spacious
+ * light interface. The renderer and session controls remain unchanged. */
+.demo-shell {
+  gap: 1rem;
+  padding: clamp(0.75rem, 1.8vw, 1.5rem);
+}
+
+.demo-shell__header {
+  border-color: rgba(196, 181, 253, 0.7);
+  border-radius: 16px;
+  box-shadow: 0 12px 34px rgba(76, 29, 149, 0.07);
+  gap: 1rem;
+  padding: 0.7rem 0.85rem;
+}
+
+.demo-shell__mark {
+  background: var(--surface-soft);
+  border-color: #ddd6fe;
+  border-radius: 11px;
+  height: 38px;
+  width: 38px;
+}
+
+.demo-shell__mark img {
+  height: 28px;
+  width: 28px;
+}
+
+.demo-shell__title {
+  gap: 0.1rem;
+}
+
+.demo-shell__eyebrow {
+  color: var(--violet) !important;
+  font-size: 0.58rem !important;
+  font-weight: 780 !important;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.demo-shell__title strong {
+  font-size: 1rem;
+  letter-spacing: -0.03em;
+}
+
+.demo-shell__title span:not(.demo-shell__eyebrow) {
+  font-size: 0.69rem;
+}
+
+.demo-shell__mode {
+  gap: 0.35rem;
+}
+
+.demo-shell__mode a,
+.demo-shell__mode button {
+  border-radius: 9px;
+  font-size: 0.78rem;
+  font-weight: 680;
+  min-height: 34px;
+  padding: 0.45rem 0.75rem;
+}
+
+.demo-shell__mode button[aria-pressed="true"] {
+  box-shadow: 0 7px 18px rgba(109, 40, 217, 0.24);
+}
+
+.demo-shell__workspace {
+  gap: 1rem;
+  grid-template-columns: minmax(19rem, 22rem) minmax(0, 1fr);
+}
+
+.demo-shell__inspector {
+  background: rgba(255, 255, 255, 0.94);
+  border-color: rgba(196, 181, 253, 0.68);
+  border-radius: 16px;
+  box-shadow: 0 14px 38px rgba(76, 29, 149, 0.065);
+  gap: 0.85rem;
+  padding: 0.85rem;
+}
+
+.demo-shell__stage {
+  gap: 1rem;
+}
+
+.demo-shell__viewport,
+.renderer-viewport {
+  border-color: rgba(196, 181, 253, 0.7);
+  border-radius: 16px;
+}
+
+.renderer-viewport {
+  box-shadow: 0 18px 42px rgba(76, 29, 149, 0.12);
+}
+
+.source-controls,
+.quality-controls,
+.selection-panel,
+.render-controls,
+.status-panel,
+.control-bar {
+  border-color: #e7e2fb;
+  border-radius: 13px;
+  box-shadow: 0 8px 22px rgba(76, 29, 149, 0.045);
+}
+
+.inspector-card__header {
+  align-items: center;
+  border-bottom: 1px solid #ede9fe;
+  margin-bottom: 0.8rem;
+  padding-bottom: 0.7rem;
+}
+
+.inspector-card__header h2,
+.render-control-section h3 {
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.render-controls__tabs {
+  background: var(--surface-soft);
+  border: 1px solid #e4def9;
+  border-radius: 9px;
+  gap: 0.2rem;
+  padding: 0.2rem;
+}
+
+.render-controls__tabs button {
+  background: transparent;
+  border-color: transparent;
+  border-radius: 6px;
+  font-size: 0.68rem;
+  min-height: 26px;
+  padding: 0.25rem 0.52rem;
+}
+
+.render-controls__tabs button[aria-pressed="true"] {
+  box-shadow: 0 4px 11px rgba(109, 40, 217, 0.2);
+}
+
+.render-controls__panel--global {
+  gap: 0.75rem;
+}
+
+.render-control-section {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), #faf9ff);
+  border: 1px solid #ebe7fa;
+  border-radius: 11px;
+  padding: 0.8rem;
+}
+
+.render-control-section h3 {
+  color: var(--violet);
+  margin-bottom: 0.65rem;
+}
+
+.render-controls__toggles {
+  gap: 0.4rem;
+}
+
+.render-control--toggle {
+  border-radius: 8px;
+  min-height: 2.15rem;
+  padding: 0.38rem 0.48rem;
+}
+
+.render-control--toggle:hover {
+  background: var(--surface-soft);
+  border-color: #c4b5fd;
+}
+
+.render-control--toggle input {
+  accent-color: var(--violet);
+}
+
+.render-control__label {
+  font-size: 0.74rem;
+  font-weight: 660;
+}
+
+.render-control__segments {
+  background: #f7f5ff;
+  border: 1px solid #e4def9;
+  border-radius: 9px;
+  gap: 0.2rem;
+  padding: 0.2rem;
+}
+
+.render-control__segments button {
+  border-radius: 6px;
+  font-size: 0.67rem;
+  min-height: 27px;
+}
+
+.render-control--slider input::-webkit-slider-runnable-track {
+  border-radius: 999px;
+  height: 5px;
+}
+
+.render-control--slider input::-moz-range-track {
+  border-radius: 999px;
+  height: 5px;
+}
+
+.render-control--slider input::-webkit-slider-thumb,
+.render-control--slider input::-moz-range-thumb {
+  height: 17px;
+  margin-top: -6px;
+  width: 17px;
+}
+
+.timeline-view__legend {
+  gap: 0.36rem;
+}
+
+.timeline-view__chip {
+  border-radius: 999px;
+  box-shadow: 0 2px 7px rgba(76, 29, 149, 0.045);
+  font-size: 0.68rem;
+  padding: 0.28rem 0.48rem;
+}
+
+.control-bar {
+  border-color: rgba(196, 181, 253, 0.68);
+  box-shadow: 0 12px 30px rgba(76, 29, 149, 0.065);
+  padding: 0.8rem;
+}
+
+@media (max-width: 780px) {
+  .demo-shell__workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .demo-shell__inspector {
+    max-height: 42dvh;
+  }
+}


### PR DESCRIPTION
# Description

Refreshes the demo workbench so it uses the same light Roboflow visual language as the documentation home. The rendering session, controls, and playback behavior are unchanged; this is a presentation-only update.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `npm run demo:build`.
- Captured a local browser screenshot at desktop width to inspect the workbench layout and controls.

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- hosting

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)