### PR TITLE
Harden npm release tag credentials

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
   id-token: write
 
 concurrency:
@@ -177,6 +177,8 @@ jobs:
       - name: Create or verify release tag
         if: inputs.dist_tag == 'latest'
         shell: bash
+        env:
+          RELEASE_GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           version="$(node -p "require('./packages/web/package.json').version")"
@@ -199,13 +201,13 @@ jobs:
           fi
 
           git tag --annotate "${tag}" "${release_sha}" --message "supervision ${tag}"
-          git push origin "refs/tags/${tag}"
+          git push "https://x-access-token:${RELEASE_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${tag}"
 
       - name: Create GitHub Release
         if: inputs.dist_tag == 'latest'
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           version="$(node -p "require('./packages/web/package.json').version")"

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -40,7 +40,12 @@ Keep this ownership and security posture in place:
    `roboflow`, repository `supervision-js`, workflow `publish-npm.yml`, and
    environment `npm-publish` for the **npm publish** action.
 3. GitHub's `npm-publish` environment requires release-owner approval.
-4. No long-lived npm write token is stored in GitHub. Publishing uses OIDC.
+4. The `npm-publish` environment holds a `RELEASE_GITHUB_TOKEN` environment
+   secret scoped only to `supervision-js`, with **Contents: write** and
+   **Workflows: write**. It is used only after verification to create the
+   stable tag and GitHub Release; do not expose it to checkout, install, build,
+   or npm-publish steps.
+5. No long-lived npm write token is stored in GitHub. Publishing uses OIDC.
 
 If publishing access breaks, compare the trusted-publisher fields with the
 workflow before changing credentials. Each npm package supports one trusted

--- a/tools/release-workflow-contract.test.mjs
+++ b/tools/release-workflow-contract.test.mjs
@@ -25,3 +25,17 @@ test("npm publish waits for the selected dist-tag to propagate", async () => {
     /git config user\.email "41898282\+github-actions\[bot\]@users\.noreply\.github\.com"/,
   );
 });
+
+test("release tagging uses the protected workflow-capable token only at the release boundary", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /contents: read/);
+  assert.match(
+    workflow,
+    /name: Create or verify release tag[\s\S]*?RELEASE_GITHUB_TOKEN: \$\{\{ secrets\.RELEASE_GITHUB_TOKEN \}\}[\s\S]*?git push "https:\/\/x-access-token:\$\{RELEASE_GITHUB_TOKEN\}@github\.com\/\$\{GITHUB_REPOSITORY\}\.git"/,
+  );
+  assert.match(
+    workflow,
+    /name: Create GitHub Release[\s\S]*?GH_TOKEN: \$\{\{ secrets\.RELEASE_GITHUB_TOKEN \}\}/,
+  );
+});


### PR DESCRIPTION
# Description

Uses the protected `RELEASE_GITHUB_TOKEN` only for the final release-tag push and GitHub Release creation. The workflow now keeps the default `GITHUB_TOKEN` read-only during checkout, install, verification, packaging, and npm publishing.

This fixes stable-release recovery when the release commit includes `.github/workflows/` changes, which GitHub rejects for the default Actions GitHub App token without Workflows permission.

The internal release runbook now documents the required environment-secret scope, and a contract test guards the credential boundary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `node --test tools/release-workflow-contract.test.mjs`
- Ran Prettier on the changed workflow, release runbook, and contract test
- Verified the focused contract asserts read-only default credentials and dedicated-token use only at tag/release steps

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- The `npm-publish` environment must contain `RELEASE_GITHUB_TOKEN` with Contents and Workflows write access before merging.
- After merge, run the release recovery from `main` with `dist_tag=latest` and `recovery_run_id=31171770827`; it will not republish `0.1.1`.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
