### PR TITLE
Use release token for recovery tag pushes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Resolve release source
         id: release_source

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -44,7 +44,9 @@ Keep this ownership and security posture in place:
    secret scoped only to `supervision-js`, with **Contents: write** and
    **Workflows: write**. It is used only after verification to create the
    stable tag and GitHub Release; do not expose it to checkout, install, build,
-   or npm-publish steps.
+   or npm-publish steps. Checkout must use `persist-credentials: false` so its
+   short-lived `GITHUB_TOKEN` cannot override the dedicated token during the
+   tag push.
 5. No long-lived npm write token is stored in GitHub. Publishing uses OIDC.
 
 If publishing access breaks, compare the trusted-publisher fields with the

--- a/tools/release-workflow-contract.test.mjs
+++ b/tools/release-workflow-contract.test.mjs
@@ -32,6 +32,10 @@ test("release tagging uses the protected workflow-capable token only at the rele
   assert.match(workflow, /contents: read/);
   assert.match(
     workflow,
+    /name: Check out repository[\s\S]*?fetch-depth: 0[\s\S]*?persist-credentials: false/,
+  );
+  assert.match(
+    workflow,
     /name: Create or verify release tag[\s\S]*?RELEASE_GITHUB_TOKEN: \$\{\{ secrets\.RELEASE_GITHUB_TOKEN \}\}[\s\S]*?git push "https:\/\/x-access-token:\$\{RELEASE_GITHUB_TOKEN\}@github\.com\/\$\{GITHUB_REPOSITORY\}\.git"/,
   );
   assert.match(


### PR DESCRIPTION
# Description

Disables credential persistence in the release workflow checkout. The prior recovery injected `RELEASE_GITHUB_TOKEN` into the final tag push, but the persisted default Actions credential took precedence and GitHub still identified the push as `github-actions[bot]`.

With no persisted checkout credential, the final tag push uses only the protected environment token; all checkout, install, verification, build, and npm-publish steps remain on the short-lived read-only `GITHUB_TOKEN`.

The internal release runbook and workflow contract test now cover that boundary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `node --test tools/release-workflow-contract.test.mjs`
- Ran Prettier on the changed workflow, release runbook, and contract test
- Inspected failed recovery run `31186511008`, which reported the tag push as `github-actions[bot]` despite the environment secret being present

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Keep the existing `RELEASE_GITHUB_TOKEN` environment secret in `npm-publish`.
- After merge, rerun the `latest` recovery with `recovery_run_id=31171770827`. It will not republish `0.1.1`.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
