### PR TITLE
Serve docs at root and demo under /demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ import { createMaskBrushEditor } from "supervision/editing";
 
 The public demo and generated API reference are hosted on Render:
 
-- [Demo](https://supervision-js-demo.onrender.com/)
-- [Documentation](https://supervision-js-demo.onrender.com/docs/)
+- [Documentation](https://supervision-js-demo.onrender.com/)
+- [Demo](https://supervision-js-demo.onrender.com/demo/)
 - [Vanilla example](https://supervision-js-demo.onrender.com/examples/vanilla/)
 
 Hosted surfaces deliberately use public fixtures only. Media upload and SAM3

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -20,7 +20,7 @@ const docsUrl =
   (globalThis.location.hostname === "localhost" ||
   globalThis.location.hostname === "127.0.0.1"
     ? "http://127.0.0.1:5175"
-    : `${import.meta.env.BASE_URL}docs/`);
+    : new URL("../", globalThis.location.href).href);
 const allowUpload = import.meta.env.VITE_DEMO_ALLOW_UPLOAD !== "false";
 
 export function App() {

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -10,17 +10,16 @@ import { RendererViewport } from "./components/RendererViewport";
 import { SelectionPanel } from "./components/SelectionPanel";
 import { SourceControls } from "./components/SourceControls";
 import { StatusPanel } from "./components/StatusPanel";
+import { resolveDemoDocsUrl } from "./docs-url";
 import { DemoSourceMode, useDemoRenderer } from "./hooks/useDemoRenderer";
 import { defaultDemoClassNames } from "./presentation/demo-presentation";
 import { DemoViewMode } from "./session/demo-view-mode";
 import type { TimelineRange } from "./session/demo-session-types";
 
-const docsUrl =
-  import.meta.env.VITE_SUPERVISION_DOCS_URL ??
-  (globalThis.location.hostname === "localhost" ||
-  globalThis.location.hostname === "127.0.0.1"
-    ? "http://127.0.0.1:5175"
-    : new URL("../", globalThis.location.href).href);
+const docsUrl = resolveDemoDocsUrl(
+  import.meta.env.VITE_SUPERVISION_DOCS_URL,
+  globalThis.location,
+);
 const allowUpload = import.meta.env.VITE_DEMO_ALLOW_UPLOAD !== "false";
 
 export function App() {

--- a/demo/src/components/DocsBasketballPlayground.tsx
+++ b/demo/src/components/DocsBasketballPlayground.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { MediaRendererPlaybackState } from "supervision";
+import { resolveDemoDocsUrl } from "../docs-url";
 import {
   type DemoPresentationSettings,
   type DemoPresentationLayerSetting,
@@ -7,12 +8,10 @@ import {
 import { useDemoRenderer } from "../hooks/useDemoRenderer";
 import { RendererViewport } from "./RendererViewport";
 
-const docsUrl =
-  import.meta.env.VITE_SUPERVISION_DOCS_URL ??
-  (globalThis.location.hostname === "localhost" ||
-  globalThis.location.hostname === "127.0.0.1"
-    ? "http://127.0.0.1:5175"
-    : `${import.meta.env.BASE_URL}docs/`);
+const docsUrl = resolveDemoDocsUrl(
+  import.meta.env.VITE_SUPERVISION_DOCS_URL,
+  globalThis.location,
+);
 
 const annotationLayers: readonly {
   readonly key: DemoPresentationLayerSetting;

--- a/demo/src/docs-url.test.ts
+++ b/demo/src/docs-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resolveDemoDocsUrl } from "./docs-url";
+
+describe("resolveDemoDocsUrl", () => {
+  it("returns an explicitly configured docs URL", () => {
+    expect(
+      resolveDemoDocsUrl("https://docs.example.com/", {
+        hostname: "demo.example.com",
+        href: "https://demo.example.com/demo/",
+      }),
+    ).toBe("https://docs.example.com/");
+  });
+
+  it("keeps local demo and docs servers separate", () => {
+    expect(
+      resolveDemoDocsUrl(undefined, {
+        hostname: "127.0.0.1",
+        href: "http://127.0.0.1:5173/",
+      }),
+    ).toBe("http://127.0.0.1:5175");
+  });
+
+  it("returns from the deployed demo route to root docs", () => {
+    expect(
+      resolveDemoDocsUrl(undefined, {
+        hostname: "supervision-js-demo.onrender.com",
+        href: "https://supervision-js-demo.onrender.com/demo/?embed=docs-playground",
+      }),
+    ).toBe("https://supervision-js-demo.onrender.com/");
+  });
+});

--- a/demo/src/docs-url.ts
+++ b/demo/src/docs-url.ts
@@ -1,0 +1,19 @@
+interface DemoLocation {
+  readonly hostname: string;
+  readonly href: string;
+}
+
+export function resolveDemoDocsUrl(
+  configuredUrl: string | undefined,
+  location: DemoLocation,
+) {
+  if (configuredUrl) {
+    return configuredUrl;
+  }
+
+  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
+    return "http://127.0.0.1:5175";
+  }
+
+  return new URL("../", location.href).href;
+}

--- a/docs/internal/github-pages-deployment.md
+++ b/docs/internal/github-pages-deployment.md
@@ -9,8 +9,8 @@ source and runtime configuration.
 
 `npm run pages:build` assembles `dist/pages` with this layout:
 
-- `/` contains the fixture-only demo;
-- `/docs/` contains the TypeDoc site;
+- `/` contains the TypeDoc site and its interactive playground;
+- `/demo/` contains the fixture-only demo workbench;
 - `/examples/vanilla/` contains the minimal vanilla example.
 
 The workflow checks out Git LFS assets before building, then uses the standard

--- a/docs/internal/render-deployment.md
+++ b/docs/internal/render-deployment.md
@@ -5,7 +5,8 @@ The public demo and documentation are served by the existing Render web service:
 - service: `supervision-js-demo`
 - resource ID: `srv-d8felq6gvqtc7398i2ng`
 - URL: <https://supervision-js-demo.onrender.com>
-- docs: <https://supervision-js-demo.onrender.com/docs/>
+- docs: <https://supervision-js-demo.onrender.com/>
+- demo: <https://supervision-js-demo.onrender.com/demo/>
 
 Render deploys the canonical repository directly:
 `https://github.com/roboflow/supervision-js` on `main`. Do not introduce a
@@ -25,8 +26,8 @@ Auto-deploy: On commit
 
 `npm run pages:build` creates one static artifact in `dist/pages`:
 
-- `/` contains the fixture demo;
-- `/docs/` contains the TypeDoc site;
+- `/` contains the TypeDoc site and its interactive playground;
+- `/demo/` contains the fixture demo workbench;
 - `/examples/vanilla/` contains the vanilla integration example.
 
 `npm run pages:serve` serves that same artifact on Render's `PORT`. This keeps
@@ -67,11 +68,11 @@ Check the deployed routes after Render reports the deploy as live:
 
 ```sh
 curl --fail --location https://supervision-js-demo.onrender.com/
-curl --fail --location https://supervision-js-demo.onrender.com/docs/
+curl --fail --location https://supervision-js-demo.onrender.com/demo/
 curl --fail --location \
-  https://supervision-js-demo.onrender.com/docs/documents/Application_Integration.html
+  https://supervision-js-demo.onrender.com/documents/Application_Integration.html
 curl --fail --location \
-  https://supervision-js-demo.onrender.com/docs/modules/Editing.html
+  https://supervision-js-demo.onrender.com/modules/Editing.html
 curl --fail --location \
   https://supervision-js-demo.onrender.com/examples/vanilla/
 ```

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -9,7 +9,7 @@
       <p class="supervision-home__install"><code>npm install supervision</code></p>
       <div class="supervision-home__actions">
         <a class="supervision-home__button supervision-home__button--primary" href="documents/Application_Integration.html">Get started</a>
-        <a class="supervision-home__button supervision-home__button--secondary" href="https://supervision-js-demo.onrender.com/">Open the demo</a>
+        <a class="supervision-home__button supervision-home__button--secondary" data-supervision-demo-link href="demo/">Open the demo</a>
       </div>
     </div>
     <aside class="supervision-home__scene-card" aria-label="Media session composition">
@@ -35,7 +35,7 @@
     <div class="supervision-home__playground-frame">
       <iframe
         allow="autoplay"
-        data-supervision-playground-src="../?embed=docs-playground"
+        data-supervision-playground-src="demo/?embed=docs-playground"
         loading="lazy"
         title="Interactive basketball detection playground"
       ></iframe>

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -114,17 +114,26 @@
       return;
     }
 
+    playground.src = resolveDemoUrl(deployedSource);
+
+    const demoLink = home.querySelector("[data-supervision-demo-link]");
+    if (demoLink) {
+      demoLink.href = resolveDemoUrl(demoLink.getAttribute("href") ?? "demo/");
+    }
+  }
+
+  function resolveDemoUrl(deployedPath) {
     // TypeDoc's standalone local server mounts docs at its origin root, while
-    // the assembled Render/Pages site mounts them under /docs/. Point only the
-    // standalone preview at the separately-running Vite demo.
+    // the assembled site mounts docs at the domain root and the demo at /demo/.
+    // Point only the standalone preview at the separately-running Vite demo.
     const isStandaloneLocalDocs =
       (window.location.hostname === "localhost" ||
         window.location.hostname === "127.0.0.1") &&
       window.location.port === "5175";
 
-    playground.src = isStandaloneLocalDocs
-      ? "http://127.0.0.1:5173/?embed=docs-playground"
-      : deployedSource;
+    return isStandaloneLocalDocs
+      ? `http://127.0.0.1:5173/${deployedPath.includes("?") ? deployedPath.slice(deployedPath.indexOf("?")) : ""}`
+      : new URL(deployedPath, window.location.href).href;
   }
 
   function brandToolbar() {
@@ -142,6 +151,7 @@
       `${base}assets/brand/roboflow-logomark.svg`,
       window.location.href,
     ).href;
+    const demoUrl = resolveDemoUrl(`${base}demo/`);
     const version = packageReleaseStatus
       ? `v${packageVersion} (${packageReleaseStatus})`
       : `v${packageVersion}`;
@@ -156,7 +166,7 @@
     `;
 
     links.innerHTML = `
-      <a class="supervision-docs__nav-link" href="https://supervision-js-demo.onrender.com/">Demo</a>
+      <a class="supervision-docs__nav-link" href="${demoUrl}">Demo</a>
       <a class="supervision-docs__nav-link supervision-docs__nav-link--active" href="${docsHome}">Docs</a>
       <a class="supervision-docs__nav-link supervision-docs__github" href="https://github.com/roboflow/supervision-js">GitHub</a>
     `;

--- a/tools/build-pages.mjs
+++ b/tools/build-pages.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const pagesDirectory = resolve(projectRoot, "dist/pages");
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-const pagesBasePath = "/";
+const demoBasePath = "/demo/";
 
 await main();
 
@@ -25,7 +25,7 @@ async function main() {
   await runNpm(["run", "build"]);
   await runNpm(["run", "build", "-w", "demo"], {
     VITE_DEMO_ALLOW_UPLOAD: "false",
-    VITE_DEMO_BASE_PATH: pagesBasePath,
+    VITE_DEMO_BASE_PATH: demoBasePath,
   });
   await runNpm(["run", "build", "-w", "examples/vanilla"], {
     VITE_VANILLA_BASE_PATH: "/examples/vanilla/",
@@ -33,12 +33,12 @@ async function main() {
   await runNpm(["run", "docs:build:typedoc"]);
 
   await copyDirectoryContents(
-    resolve(projectRoot, "demo/dist"),
+    resolve(projectRoot, "docs/site"),
     pagesDirectory,
   );
   await copyDirectoryContents(
-    resolve(projectRoot, "docs/site"),
-    join(pagesDirectory, "docs"),
+    resolve(projectRoot, "demo/dist"),
+    join(pagesDirectory, "demo"),
   );
   await copyDirectoryContents(
     resolve(projectRoot, "examples/vanilla/dist"),
@@ -63,7 +63,7 @@ async function copyDirectoryContents(source, destination) {
 async function verifyPagesArtifact() {
   const requiredFiles = [
     "index.html",
-    "docs/index.html",
+    "demo/index.html",
     "examples/vanilla/index.html",
   ];
 
@@ -72,7 +72,7 @@ async function verifyPagesArtifact() {
   );
 
   const generatedHtml = await Promise.all(
-    ["index.html", "examples/vanilla/index.html"].map((file) =>
+    ["demo/index.html", "examples/vanilla/index.html"].map((file) =>
       readFile(join(pagesDirectory, file), "utf8"),
     ),
   );

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -195,11 +195,11 @@ test("deployed site presents docs at the root and the workbench at /demo/", asyn
   assert.match(pagesBuild, /const demoBasePath = "\/demo\/";/);
   assert.match(
     pagesBuild,
-    /resolve\(projectRoot, "docs\/site"\),\n    pagesDirectory/,
+    /resolve\(projectRoot, "docs\/site"\),\n {4}pagesDirectory/,
   );
   assert.match(
     pagesBuild,
-    /resolve\(projectRoot, "demo\/dist"\),\n    join\(pagesDirectory, "demo"\)/,
+    /resolve\(projectRoot, "demo\/dist"\),\n {4}join\(pagesDirectory, "demo"\)/,
   );
   assert.match(pagesBuild, /"demo\/index\.html"/);
   assert.doesNotMatch(pagesBuild, /"docs\/index\.html"/);

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -186,6 +186,10 @@ test("deployed site presents docs at the root and the workbench at /demo/", asyn
     path.join(rootDir, "demo/src/App.tsx"),
     "utf8",
   );
+  const docsUrl = await readFile(
+    path.join(rootDir, "demo/src/docs-url.ts"),
+    "utf8",
+  );
   const homepage = await readFile(path.join(publicDocsDir, "index.md"), "utf8");
   const toolbar = await readFile(
     path.join(publicDocsDir, "typedoc-icons.js"),
@@ -203,7 +207,8 @@ test("deployed site presents docs at the root and the workbench at /demo/", asyn
   );
   assert.match(pagesBuild, /"demo\/index\.html"/);
   assert.doesNotMatch(pagesBuild, /"docs\/index\.html"/);
-  assert.match(demoApp, /new URL\("\.\.\/", globalThis\.location\.href\)/);
+  assert.match(demoApp, /resolveDemoDocsUrl\(/);
+  assert.match(docsUrl, /return new URL\("\.\.\/", location\.href\)\.href/);
   assert.match(homepage, /data-supervision-demo-link href="demo\/"/);
   assert.match(
     homepage,

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -154,12 +154,12 @@ test("the docs home embeds the local basketball playground", async () => {
 
   assert.match(
     homepage,
-    /data-supervision-playground-src="\.\.\/\?embed=docs-playground"/,
+    /data-supervision-playground-src="demo\/\?embed=docs-playground"/,
   );
   assert.match(homepage, /title="Interactive basketball detection playground"/);
   assert.match(
     toolbarScript,
-    /window\.location\.port === "5175"[\s\S]*?http:\/\/127\.0\.0\.1:5173\/\?embed=docs-playground/,
+    /window\.location\.port === "5175"[\s\S]*?http:\/\/127\.0\.0\.1:5173\//,
   );
   assert.equal(packageJson.scripts["docs:dev"], "npm run dev:demo-docs");
 });
@@ -175,6 +175,41 @@ test("Render preview trusts only its assigned hostname", async () => {
     /__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=\$\{RENDER_EXTERNAL_HOSTNAME:-supervision-js-demo\.onrender\.com\}/,
   );
   assert.doesNotMatch(serveCommand, /allowedHosts=(?:true|\*)/);
+});
+
+test("deployed site presents docs at the root and the workbench at /demo/", async () => {
+  const pagesBuild = await readFile(
+    path.join(rootDir, "tools/build-pages.mjs"),
+    "utf8",
+  );
+  const demoApp = await readFile(
+    path.join(rootDir, "demo/src/App.tsx"),
+    "utf8",
+  );
+  const homepage = await readFile(path.join(publicDocsDir, "index.md"), "utf8");
+  const toolbar = await readFile(
+    path.join(publicDocsDir, "typedoc-icons.js"),
+    "utf8",
+  );
+
+  assert.match(pagesBuild, /const demoBasePath = "\/demo\/";/);
+  assert.match(
+    pagesBuild,
+    /resolve\(projectRoot, "docs\/site"\),\n    pagesDirectory/,
+  );
+  assert.match(
+    pagesBuild,
+    /resolve\(projectRoot, "demo\/dist"\),\n    join\(pagesDirectory, "demo"\)/,
+  );
+  assert.match(pagesBuild, /"demo\/index\.html"/);
+  assert.doesNotMatch(pagesBuild, /"docs\/index\.html"/);
+  assert.match(demoApp, /new URL\("\.\.\/", globalThis\.location\.href\)/);
+  assert.match(homepage, /data-supervision-demo-link href="demo\/"/);
+  assert.match(
+    homepage,
+    /data-supervision-playground-src="demo\/\?embed=docs-playground"/,
+  );
+  assert.match(toolbar, /function resolveDemoUrl\(deployedPath\)/);
 });
 
 test("copyable integration examples typecheck", async () => {


### PR DESCRIPTION
# Description

Makes the documentation homepage the canonical hosted root and moves the deeper fixture workbench to /demo/.

The static site assembler now copies TypeDoc to the artifact root and builds the demo with a /demo/ asset base. Docs navigation, the playground iframe, the demo-to-docs link, README, and deployment runbooks follow the new routes. A docs contract test protects the layout.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- node --test tools/docs-contract.test.mjs (11/11)
- npm run pages:build
- Served the assembled artifact locally and verified /, /demo/, /documents/Application_Integration.html, and /demo/?embed=docs-playground with HTTP requests.

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- hosting: Render should deploy the merged static artifact; docs become / and the demo becomes /demo/.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)