### PR TITLE
Make static demo assets portable

### DIFF
--- a/docs/internal/github-pages-deployment.md
+++ b/docs/internal/github-pages-deployment.md
@@ -13,6 +13,11 @@ source and runtime configuration.
 - `/demo/` contains the fixture-only demo workbench;
 - `/examples/vanilla/` contains the minimal vanilla example.
 
+The fixture demo and vanilla example use relative asset URLs. The artifact
+therefore works both at the root of a custom domain and at GitHub Pages'
+project URL (`https://roboflow.github.io/supervision-js/`) before a custom
+domain is configured.
+
 The workflow checks out Git LFS assets before building, then uses the standard
 GitHub Pages artifact and deployment actions. GitHub Pages must be configured
 once in repository settings with **Source: GitHub Actions**.

--- a/docs/internal/render-deployment.md
+++ b/docs/internal/render-deployment.md
@@ -34,6 +34,10 @@ Auto-deploy: On commit
 the Render and GitHub Pages output identical and avoids maintaining a second
 production server or image delivery path.
 
+The static applications emit relative asset URLs, so this layout remains valid
+when served at Render's domain root or from a GitHub Pages project URL before a
+custom domain is attached.
+
 The start command passes Render's exact `RENDER_EXTERNAL_HOSTNAME` to Vite's
 additional-host allowlist. This supports branch preview services without
 trusting arbitrary hosts; local runs fall back to the canonical production

--- a/tools/build-pages.mjs
+++ b/tools/build-pages.mjs
@@ -15,7 +15,9 @@ import { fileURLToPath } from "node:url";
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const pagesDirectory = resolve(projectRoot, "dist/pages");
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
-const demoBasePath = "/demo/";
+// Relative asset URLs let the same static artifact work at the root of a
+// custom domain (Render) and below a project prefix (GitHub Pages).
+const staticAppBasePath = "./";
 
 await main();
 
@@ -25,10 +27,10 @@ async function main() {
   await runNpm(["run", "build"]);
   await runNpm(["run", "build", "-w", "demo"], {
     VITE_DEMO_ALLOW_UPLOAD: "false",
-    VITE_DEMO_BASE_PATH: demoBasePath,
+    VITE_DEMO_BASE_PATH: staticAppBasePath,
   });
   await runNpm(["run", "build", "-w", "examples/vanilla"], {
-    VITE_VANILLA_BASE_PATH: "/examples/vanilla/",
+    VITE_VANILLA_BASE_PATH: staticAppBasePath,
   });
   await runNpm(["run", "docs:build:typedoc"]);
 
@@ -80,6 +82,16 @@ async function verifyPagesArtifact() {
   if (generatedHtml.some((html) => html.includes("/supervision-js/"))) {
     throw new Error(
       "GitHub Pages artifact contains a /supervision-js/ asset prefix, but this deployment is served from the domain root.",
+    );
+  }
+
+  if (
+    generatedHtml.some((html) =>
+      /(?:src|href)="\/(?:demo|examples)\//.test(html),
+    )
+  ) {
+    throw new Error(
+      "Static application assets must use relative URLs so the artifact works under a project URL prefix.",
     );
   }
 }

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -196,7 +196,9 @@ test("deployed site presents docs at the root and the workbench at /demo/", asyn
     "utf8",
   );
 
-  assert.match(pagesBuild, /const demoBasePath = "\/demo\/";/);
+  assert.match(pagesBuild, /const staticAppBasePath = "\.\/";/);
+  assert.match(pagesBuild, /VITE_DEMO_BASE_PATH: staticAppBasePath/);
+  assert.match(pagesBuild, /VITE_VANILLA_BASE_PATH: staticAppBasePath/);
   assert.match(
     pagesBuild,
     /resolve\(projectRoot, "docs\/site"\),\n {4}pagesDirectory/,


### PR DESCRIPTION
# Description

Build the fixture demo and vanilla example with relative asset URLs so the same static artifact works on Render at the domain root and on GitHub Pages under the repository URL prefix.

The Pages artifact verification now rejects absolute demo/example asset paths, and internal deployment guidance records the supported layouts.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `npm run pages:build` and inspected the assembled demo and vanilla HTML for relative asset URLs.
- Ran `node --test tools/docs-contract.test.mjs` (11 passing).
- Ran ESLint, Prettier, and `git diff --check` for the changed files.

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- Hosting: safe for the existing Render deployment and makes the GitHub Pages project URL usable before a custom domain is attached.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)