### PR TITLE
Document annotator use-case roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,11 @@ code contributions.
 For project boundaries and commands, read
 [docs/internal/agent-guidance.md](docs/internal/agent-guidance.md).
 
+Contributions that add visualization recipes or annotator-style facades should
+also follow the
+[annotator use-case roadmap](docs/internal/annotator-use-case-roadmap.md),
+including its one-annotator-per-PR and frozen-fixture requirements.
+
 ## Local Development
 
 Use Node.js 20.19 or newer.

--- a/docs/internal/agent-guidance.md
+++ b/docs/internal/agent-guidance.md
@@ -11,6 +11,8 @@ Before making project-direction or architecture changes, read:
 - [`problem-framing.md`](problem-framing.md)
 - [`architecture-principles.md`](architecture-principles.md)
 - [`renderer-first-roadmap.md`](renderer-first-roadmap.md)
+- [`annotator-use-case-roadmap.md`](annotator-use-case-roadmap.md) when adding
+  visualization recipes, fixtures, or annotator facades
 - [`pixijs-guidance.md`](pixijs-guidance.md)
 - [`library-contract.md`](library-contract.md)
 - [`react-native-architecture.md`](react-native-architecture.md)
@@ -21,7 +23,9 @@ Before making project-direction or architecture changes, read:
 - [`../public/guides/public-api.md`](../public/guides/public-api.md)
 
 Those docs define the current product intent: maintain a focused, session-first
-browser API without promising a broad Python-parity annotation framework.
+browser API without promising a one-to-one Python annotation framework. Python
+Supervision may inform use-case facades when they preserve the renderer-first
+and composable architecture.
 
 ## Public Docs Home
 

--- a/docs/internal/annotator-use-case-roadmap.md
+++ b/docs/internal/annotator-use-case-roadmap.md
@@ -244,10 +244,13 @@ which frames the user happened to watch.
 Heat maps should expose explicit accumulation semantics:
 
 - `trailing-window`: accumulate over the previous duration;
-- `full-timeline`: precompute over a finite enumerable source.
+- `full-timeline`: precompute only when the implementation can establish a
+  finite, complete source range.
 
 An implicit “frames watched during this session” mode should not be the
-default.
+default. The source capability that proves a complete range is intentionally
+provisional and must be resolved by the temporal-foundation PR before this mode
+becomes public.
 
 ### Media Effects
 
@@ -334,14 +337,22 @@ replace working fixture provenance.
 ### Local Inference Authoring
 
 Use a local [Roboflow Inference](https://github.com/roboflow/inference) server
-only to author fixtures. The official development flow is:
+only to author fixtures. Self-hosted Inference does not require authentication
+by default, so fixture authoring must bind it to loopback or use equivalent
+network isolation. Follow the official
+[self-hosting security guidance](https://inference.roboflow.com/install/security/)
+and run a hardware-appropriate image by immutable digest, conceptually:
 
 ```bash
-pip install inference-cli
-inference server start --dev
+INFERENCE_IMAGE="roboflow/roboflow-inference-server-cpu@sha256:REPLACE_WITH_DIGEST"
+docker run --rm \
+  -p 127.0.0.1:9001:9001 \
+  "$INFERENCE_IMAGE"
 ```
 
-The default local endpoint is `http://localhost:9001`. Submit frames through
+Do not publish the Inference port to an untrusted network, and do not enable the
+development port when fixture generation does not need it. Submit frames to
+`http://127.0.0.1:9001` through
 the
 [`InferenceHTTPClient`](https://inference.roboflow.com/inference_helpers/inference_sdk/)
 using a documented
@@ -349,19 +360,22 @@ using a documented
 
 A reproducible authoring run must:
 
-1. pin the Inference server container tag and digest, SDK, Python, Python
-   Supervision, FFmpeg, and generator commit;
+1. pin the Inference server image digest, SDK, Python, Python Supervision,
+   FFmpeg, and generator commit;
 2. verify source media and any deterministic derived-media hash;
 3. decode exact presentation timestamps and durations rather than deriving time
    as `frameIndex / fps`;
-4. record the model alias, confidence, IoU, resize, class-filter, and batching
-   parameters;
-5. preserve every raw response in JSONL before normalization;
-6. normalize stable ids, classes, confidence, rectangles, keypoints, compressed
+4. record the model alias, resolved model artifact or version, downloaded
+   weight checksum, model-family license, confidence, IoU, resize, class-filter,
+   and batching parameters;
+5. fail provenance validation when the resolved model artifact cannot be
+   identified and hashed;
+6. preserve every raw response in JSONL before normalization;
+7. normalize stable ids, classes, confidence, rectangles, keypoints, compressed
    RLE, and media times;
-7. apply only named and versioned deterministic post-processing;
-8. create and validate the existing one-second chunk manifest;
-9. run Python and JavaScript references with network access disabled.
+8. apply only named and versioned deterministic post-processing;
+9. create and validate the existing one-second chunk manifest;
+10. run Python and JavaScript references with network access disabled.
 
 Conceptually:
 
@@ -461,20 +475,27 @@ sibling source import or `npm pack --dry-run` is not sufficient evidence.
 
 ## Delivery Sequence
 
+### Existing Foundation
+
+`npm run package:tarball:smoke` already builds the portable package, installs it
+in a temporary external consumer, imports the public entrypoints, and produces
+a minimal Vite build. This clean-consumer baseline is complete; do not create a
+duplicate compatibility-harness PR. Extend the smoke coverage only when a
+roadmap change introduces a concrete consumer behavior that it does not already
+exercise.
+
 ### Foundation PRs: No New Annotators
 
 1. **Inference fixture authoring.** Generic local-server generator, provenance
    schema, fixture validation, and `people_walking_detection_v1`.
-2. **External-consumer compatibility harness.** Reproducible tarball install and
-   focused integration checks without sibling-repository imports.
-3. **Recipe composition contract.** Stable identity, phases, coordinate spaces,
+2. **Recipe composition contract.** Stable identity, phases, coordinate spaces,
    picking, backend capabilities, and diagnostics while compiling existing
    presentation unchanged.
-4. **Generic vector primitives.** Path, ellipse, marker, text-anchor, and
+3. **Generic vector primitives.** Path, ellipse, marker, text-anchor, and
    quadrilateral instructions justified by the first facades.
-5. **Prepared media-effect primitives.** Bounded filters, mask reuse, worker
+4. **Prepared media-effect primitives.** Bounded filters, mask reuse, worker
    ownership, invalidation, and fallback capability reporting.
-6. **Temporal and HUD primitives.** Media-time windows, seek/loop behavior,
+5. **Temporal and HUD primitives.** Media-time windows, seek/loop behavior,
    cache bounds, viewport anchoring, and deterministic counters.
 
 ### Tier 1: Foundational Geometry Facades
@@ -519,9 +540,11 @@ should not move ahead of the primitives and lifecycle rules they require.
 
 Review every roadmap PR against these questions:
 
-- Does the change add exactly one annotator facade?
+- Is the PR kind explicit? A foundation/infrastructure PR adds zero annotator
+  facades; an annotator PR adds exactly one.
 - Could the facade lower to existing primitives instead of adding a new
-  renderer path?
+  renderer path? For a foundation PR, does the primitive have a documented
+  near-term facade that justifies it?
 - Does it preserve existing session, presentation, style, interaction, and
   editing contracts?
 - Are picking and layer order explicit?
@@ -544,7 +567,8 @@ Review every roadmap PR against these questions:
 3. Does simultaneous segmentation-polygon and oriented-box data justify an
    `orientedBox` field, or should adapters continue lowering it to polygons?
 4. Which recipes should the experimental React Native backend support first?
-5. Should full-timeline heat maps require a finite enumerable source?
+5. Which source capability should prove a finite, complete range for
+   full-timeline heat maps?
 6. Should pure zone counters live in core before a second non-renderer consumer
    needs them?
 7. What browser matrix and image-diff tolerance define visual parity?

--- a/docs/internal/annotator-use-case-roadmap.md
+++ b/docs/internal/annotator-use-case-roadmap.md
@@ -1,0 +1,573 @@
+# Annotator Use-Case Roadmap
+
+Status: proposed contribution and sequencing guide
+
+Last reviewed: August 7, 2026
+
+Scope: browser visualization capabilities; this is not an API commitment
+
+## Purpose
+
+Python Supervision provides a useful catalog of computer-vision visualization
+use cases. `supervision-js` should learn from that catalog without recreating
+its class hierarchy or making one renderer implementation per Python
+annotator.
+
+This roadmap defines how contributors can expand those use cases safely:
+
+- build on the session-first browser API;
+- keep detections semantic and renderer-neutral;
+- express familiar annotators as composable facades over a small set of recipes
+  and rendering primitives;
+- use reproducible, frozen fixture data rather than live inference in tests or
+  demos;
+- deliver one new annotator facade per pull request;
+- land foundational geometry and runtime capabilities before compound facades.
+
+The word **annotator** is used for the familiar user-facing capability. Inside
+the library, an annotator should normally lower to reusable recipes, layers,
+and backend primitives. This roadmap targets use-case parity where it is useful,
+not API parity with Python Supervision.
+
+## Relationship To The Renderer Roadmap
+
+The [renderer-first roadmap](renderer-first-roadmap.md) records the foundation:
+renderer-owned media composition, media-time synchronization, measured shape
+rendering, and the smallest useful semantic model. Those constraints continue
+to apply.
+
+This document begins after that foundation. It does not replace the primary
+`MediaSession` API, promote PixiJS into public types, or turn
+`MediaRendererPresentation` into a Python compatibility layer.
+
+## Goals
+
+- Cover the most useful Python annotator scenarios in browsers.
+- Make common visualizations discoverable through familiar names.
+- Compose multiple visual treatments over the same semantic detections.
+- Keep the normal API framework-agnostic and independent of React.
+- Preserve existing presentation, editing, picking, timing, and cache behavior.
+- Keep PixiJS private to the browser backend.
+- Let other backends declare a supported subset explicitly.
+- Build deterministic fixtures that Python and JavaScript reference renderers
+  can consume.
+- Make every new annotator independently reviewable and measurable.
+
+## Non-Goals
+
+- Reproduce Python constructor signatures or inheritance.
+- Promise every Python annotator on a fixed schedule.
+- Create one Pixi container or renderer class per facade.
+- Guarantee pixel-identical OpenCV and PixiJS rasterization.
+- Put tracking, persistence, or product-specific analytics in the renderer.
+- Expose Pixi containers, shaders, filters, textures, or display objects as the
+  public extension API.
+- Change current rendering when no new layers are configured.
+- Run inference from unit tests, documentation, or the hosted demo.
+
+## Existing Foundation
+
+The current package already separates the important responsibilities:
+
+- `Detection` owns semantic geometry, class, confidence, metadata, and masks.
+- `MediaRendererPresentation` owns renderer-neutral styles and interaction
+  presentation.
+- `MediaSession` owns media, detection-source, rendering, playback, and
+  preparation lifecycles.
+- `packages/web` owns PixiJS, Mediabunny, browser workers, storage adapters, and
+  prepared browser artifacts.
+- host applications own controlled product state, persistence, undo/redo, and
+  domain analytics.
+
+The missing capability is ordered composition. A consumer should eventually be
+able to request a presentation such as:
+
+```text
+mask + halo + box corners + label + confidence bar + trace
+```
+
+without adding a new singleton property to `MediaRendererPresentation` for
+every possible feature.
+
+## Capability Map
+
+This inventory is based on the 32 public annotators in Python Supervision
+0.30.0. It is a source of use cases, not a public delivery promise.
+
+| Python use case                 | Current JavaScript status | Proposed JavaScript expression                           |
+| ------------------------------- | ------------------------- | -------------------------------------------------------- |
+| `BoxAnnotator`                  | Covered                   | Existing box style and renderer                          |
+| `RoundBoxAnnotator`             | Covered                   | Existing rounded box shape                               |
+| `ColorAnnotator`                | Covered in essence        | Fill-only box recipe                                     |
+| `MaskAnnotator`                 | Covered                   | Existing mask style and prepared artifacts               |
+| `PolygonAnnotator`              | Covered in essence        | Polygon style or mask-derived polygon treatment          |
+| `LabelAnnotator`                | Covered                   | Existing label style with extensible anchors             |
+| `RichLabelAnnotator`            | Covered in essence        | Normal browser text and label recipe                     |
+| `VertexAnnotator`               | Covered                   | Existing keypoint markers                                |
+| `EdgeAnnotator`                 | Covered                   | Existing skeleton edges                                  |
+| `OrientedBoxAnnotator`          | Partial                   | Oriented quadrilateral lowered to polygon/path geometry  |
+| `BoxCornerAnnotator`            | Planned                   | Four open path segments                                  |
+| `CircleAnnotator`               | Planned                   | Ellipse or marker derived from detection bounds          |
+| `EllipseAnnotator`              | Planned                   | Ellipse/path derived from detection bounds               |
+| `DotAnnotator`                  | Planned                   | Anchored marker                                          |
+| `TriangleAnnotator`             | Planned                   | Anchored polygon marker                                  |
+| `IconAnnotator`                 | Planned                   | Atlas-backed sprite with asset resolver                  |
+| `PercentageBarAnnotator`        | Planned                   | Composite rectangles with numeric resolver               |
+| `VertexLabelAnnotator`          | Planned                   | Per-keypoint text recipe                                 |
+| `VertexEllipseAreaAnnotator`    | Planned                   | Covariance utility plus filled ellipse                   |
+| `VertexEllipseOutlineAnnotator` | Planned                   | Covariance utility plus stroked ellipse                  |
+| `VertexEllipseHaloAnnotator`    | Planned                   | Covariance utility plus halo effect                      |
+| `HaloAnnotator`                 | Planned                   | Prepared mask halo effect                                |
+| `BlurAnnotator`                 | Planned                   | Media effect clipped by semantic geometry                |
+| `PixelateAnnotator`             | Planned                   | Pixelation clipped by semantic geometry                  |
+| `BackgroundOverlayAnnotator`    | Partial                   | Generalized complement-of-region spotlight               |
+| `CropAnnotator`                 | Planned                   | Magnified media-texture crop at a detection anchor       |
+| `TraceAnnotator`                | Planned                   | Deterministic media-time trace                           |
+| `HeatMapAnnotator`              | Planned                   | Deterministic timeline heat field                        |
+| `ComparisonAnnotator`           | Planned                   | Pure two-source comparison transform plus normal recipes |
+| `LineZoneAnnotator`             | Planned                   | Media-space guide consuming external analytical state    |
+| `PolygonZoneAnnotator`          | Planned                   | Polygon guide consuming external analytical state        |
+| `LineZoneAnnotatorMulticlass`   | Planned                   | Viewport HUD consuming external analytical state         |
+
+`supervision-js` also supports polylines as a general primitive outside the
+Python annotator catalog.
+
+Sources:
+
+- [Python detection annotators](https://github.com/roboflow/supervision/blob/0.30.0/src/supervision/annotators/core.py)
+- [Python keypoint annotators](https://github.com/roboflow/supervision/blob/0.30.0/src/supervision/key_points/annotators.py)
+- [Python line-zone implementation](https://github.com/roboflow/supervision/blob/0.30.0/src/supervision/detection/line_zone.py)
+- [Python polygon-zone implementation](https://github.com/roboflow/supervision/blob/0.30.0/src/supervision/detection/tools/polygon_zone.py)
+- [Public annotator gallery](https://supervision.roboflow.com/latest/detection/annotators/)
+
+## Composition Direction
+
+Named facades are valuable for discoverability. They should lower to a smaller
+set of renderer-neutral recipes:
+
+- boxes and rounded boxes;
+- open and closed paths;
+- ellipses;
+- anchored markers;
+- text and labels;
+- solid bars;
+- sprites and media crops;
+- mask and region effects;
+- temporal fields;
+- media-space guides;
+- viewport-space HUD elements.
+
+Examples:
+
+```text
+BoxCorner     -> four open paths
+Circle        -> ellipse with equal radii
+Dot           -> anchored circle marker
+Triangle      -> anchored polygon marker
+PercentageBar -> background rectangle + value rectangle + optional text
+VertexLabel   -> one label per visible keypoint
+PolygonZone   -> polygon path + count label
+LineZone      -> line path + endpoint markers + count labels
+```
+
+An illustrative public shape could be:
+
+```ts
+session.setPresentation({
+  boxStyle,
+  maskStyle,
+  labelStyle,
+  layers: [
+    annotationLayers.boxCorners({
+      stroke: detectionClassStroke,
+    }),
+    annotationLayers.percentageBar({
+      value: (detection) => detection.confidence ?? 0,
+    }),
+    annotationLayers.trace({
+      anchor: "bottom-center",
+      identity: (detection) => detection.id,
+      windowSeconds: 1.5,
+    }),
+  ],
+});
+```
+
+This is a design direction, not final naming. The first composition PR must
+justify the exact API with tests and a real facade.
+
+### Recipe Contract Requirements
+
+The platform-neutral core should own only renderer-neutral recipe fields:
+
+- stable layer identity;
+- semantic phase and ordering;
+- media or viewport coordinate space;
+- explicit pick behavior;
+- static values or detection/style-context resolvers;
+- backend capability validation.
+
+Recipes must not expose PixiJS, DOM, worker, or Mediabunny types. The initial
+public extension should contain supported built-in recipes, not an arbitrary
+third-party Pixi hook.
+
+### Compatibility Requirements
+
+New recipes and facades must preserve these invariants:
+
+1. Existing presentation fields and style subclasses continue to work.
+2. New layers are additive; omitting them keeps current rendering behavior.
+3. Decorations do not become independent editable annotations.
+4. Picking is explicit and does not unexpectedly occlude existing geometry,
+   handles, or labels.
+5. Existing editing, interaction, guide, and label ordering remains stable.
+6. Updating one layer does not rebuild the media session or invalidate
+   unrelated masks, workers, media samples, viewport state, or editing state.
+7. Visibility, loading, ephemeral, and creation state propagate consistently.
+8. Temporal layers use canonical media time, including seek, loop, VFR, and
+   non-zero media origins.
+9. Media effects reuse renderer-owned media and do not create a second decoder
+   or visible media element.
+10. The browser package remains independent of React.
+
+## Stateful And Media-Aware Recipes
+
+### Trace
+
+A trace must be reproducible from the detection timeline. It should require
+stable identity, use a duration rather than an implicit frame count, rebuild
+after seeking, and reset predictably at loop boundaries. It must not depend on
+which frames the user happened to watch.
+
+### Heat Map
+
+Heat maps should expose explicit accumulation semantics:
+
+- `trailing-window`: accumulate over the previous duration;
+- `full-timeline`: precompute over a finite enumerable source.
+
+An implicit “frames watched during this session” mode should not be the
+default.
+
+### Media Effects
+
+Blur, pixelate, halo, background overlay, and crop should sample the existing
+renderer media and prepared semantic geometry. They must avoid full-canvas CPU
+readback, bound effects to affected regions, and reuse shaders, textures, mask
+artifacts, and geometry.
+
+The crop facade is a view of the source media texture, not a bitmap copied after
+annotations have been composited.
+
+### Analytics
+
+Zone facades visualize analytical state; the renderer should not decide whether
+an object crossed a line or entered a polygon. The host or a platform-neutral
+analytics utility supplies line, polygon, count, and per-class state.
+
+Comparison should likewise be a pure transform over two semantic detection
+sets. Normal recipes render the resulting regions and labels.
+
+## Fixture And Data Plan
+
+The Python gallery publishes rendered examples but not the exact detections
+used to create them. Rendered PNGs are useful visual references, not canonical
+detection data: antialiasing changes boundaries, effects destroy source pixels,
+and temporal or covariance state cannot be recovered from final images.
+
+Generate our own detections, preserve the raw model responses, normalize them
+deterministically, and freeze them in the existing `demo/fixtures` structure.
+Do not create a second fixture system.
+
+### Existing Fixture Convention
+
+```text
+demo/fixtures/<fixture-name>/
+  README.md
+  fixture.meta.json
+  raw-<model-or-stage>.jsonl
+  detections.manifest.json
+  detections/
+    <one-second-chunks>.json
+  <optional local media or shared-media reference>
+```
+
+The existing basketball and horse fixtures already demonstrate raw output
+provenance, exact media times, compressed COCO RLE masks, derived polygons,
+deterministic association policies, and timeline chunks. A generic
+`tools/inference-fixture/` authoring tool should reuse those schemas and
+helpers.
+
+### Public Media References
+
+The properties below were measured from the source files. MD5 values come from
+Python Supervision 0.30.0's
+[`assets/list.py`](https://github.com/roboflow/supervision/blob/0.30.0/src/supervision/assets/list.py).
+
+| Source                                                                                           | Intended coverage                                                                         | Source properties                                             | Upstream MD5                       |
+| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------- |
+| [`people-walking.mp4`](https://media.roboflow.com/supervision/video-examples/people-walking.mp4) | Dense people, markers, labels, tracks, comparison, traces, heat maps, and privacy effects | 1920x1080 H.264, 25 fps, 13.64 s, 7,606,633 bytes             | `0574c053c8686c3f1dc0aa3743e45cb9` |
+| [`people-walking.jpg`](https://media.roboflow.com/supervision/image-examples/people-walking.jpg) | Static geometry and screenshot reference                                                  | Published source still                                        | `e6bda00b47f2908eeae7df86ef995dcd` |
+| [`vehicles-2.mp4`](https://media.roboflow.com/supervision/video-examples/vehicles-2.mp4)         | Traffic tracking, line crossings, polygon zones, and counts                               | 1920x1080 H.264, 30000/1001 fps, 42.5425 s, 29,782,444 bytes  | `830af6fba21ffbf14867a7fea595937b` |
+| [`basketball-1.mp4`](https://media.roboflow.com/supervision/video-examples/basketball-1.mp4)     | Optional pose and articulation stress source                                              | 1920x1080 H.264, 60000/1001 fps, 8.042667 s, 27,178,650 bytes | `60d94a3c7c47d16f09d342b088012ecc` |
+| [`skiing.mp4`](https://media.roboflow.com/supervision/video-examples/skiing.mp4)                 | Optional motion and occlusion stress source                                               | 1920x1080 H.264, 25 fps, 14.12 s, 8,896,267 bytes             | `d30987cbab1bbc5934199cdd1b293119` |
+
+A public URL is not by itself a redistribution license. Record the rights and
+provenance decision before committing new media. Store the upstream hash, an
+exact FFmpeg derivation command, and the derived SHA-256 for every clipped or
+normalized asset.
+
+### Canonical Fixture Matrix
+
+| Fixture                          | Media                                                              | Authoring model and deterministic processing                                                                                                                        | Primary coverage                                                                                      |
+| -------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Existing `basketball_geometry`   | Keep the committed normalized basketball media                     | Regeneration target: `yolov8m-pose-640`; retain existing SAM3 masks, pose-to-mask association, and compressed RLE. Derive explicitly marked covariance when needed. | Existing shapes, masks, polygons, keypoints, skeletons, oriented boxes, covariance, and media effects |
+| `people_walking_detection_v1`    | Full 13.64 s source, optionally normalized to 1280x720 at 25 fps   | Primary `yolov8n-1280`, `person` only, confidence >= 0.25; pinned ByteTrack at 25 fps. Secondary `rfdetr-small` set for comparison.                                 | Foundational geometry facades, labels, bars, traces, heat maps, and comparison                        |
+| `people_walking_segmentation_v1` | Deterministic representative 3 s interval                          | `yolov8s-seg-640`, `person` only, confidence >= 0.25; compressed RLE; polygons simplified to at most 48 points; versioned minimum-area rectangle derivation.        | Oriented boxes, halo, blur, pixelate, background overlay, and crop                                    |
+| `vehicles_zone_v1`               | Candidate 10.0-22.0 s interval, finalized after a tracking preview | `yolov8s-640`; car, truck, bus, and motorcycle; confidence >= 0.25; pinned ByteTrack at 30000/1001 fps; frozen line/polygon coordinates and events.                 | Traces, line zones, polygon zones, counts, and multiclass HUD                                         |
+| Optional `skiing_pose_stress_v1` | Full source or deterministic high-motion interval                  | `yolov8m-pose-640`; preserve missing and low-confidence joints                                                                                                      | Seek, motion, and occlusion stress for pose and trace rendering                                       |
+
+The existing basketball fixture is the primary mask/keypoint reference.
+`basketball-1.mp4` is a fallback or additional stress source, not a reason to
+replace working fixture provenance.
+
+### Local Inference Authoring
+
+Use a local [Roboflow Inference](https://github.com/roboflow/inference) server
+only to author fixtures. The official development flow is:
+
+```bash
+pip install inference-cli
+inference server start --dev
+```
+
+The default local endpoint is `http://localhost:9001`. Submit frames through
+the
+[`InferenceHTTPClient`](https://inference.roboflow.com/inference_helpers/inference_sdk/)
+using a documented
+[`pre-trained model alias`](https://inference.roboflow.com/quickstart/aliases/).
+
+A reproducible authoring run must:
+
+1. pin the Inference server container tag and digest, SDK, Python, Python
+   Supervision, FFmpeg, and generator commit;
+2. verify source media and any deterministic derived-media hash;
+3. decode exact presentation timestamps and durations rather than deriving time
+   as `frameIndex / fps`;
+4. record the model alias, confidence, IoU, resize, class-filter, and batching
+   parameters;
+5. preserve every raw response in JSONL before normalization;
+6. normalize stable ids, classes, confidence, rectangles, keypoints, compressed
+   RLE, and media times;
+7. apply only named and versioned deterministic post-processing;
+8. create and validate the existing one-second chunk manifest;
+9. run Python and JavaScript references with network access disabled.
+
+Conceptually:
+
+```bash
+python tools/inference-fixture/run.py \
+  --server http://localhost:9001 \
+  --source people-walking.mp4 \
+  --model yolov8n-1280 \
+  --task object-detection \
+  --confidence 0.25 \
+  --output demo/fixtures/people_walking_detection_v1/raw-yolov8n.jsonl
+
+npm run fixture:inference:create -- \
+  --fixture people_walking_detection_v1
+```
+
+The concrete CLI may differ. Raw-output preservation, deterministic
+normalization, and offline runtime behavior are the contract.
+
+### Derived Geometry
+
+Derived data must never be presented as direct model output.
+
+- `mask-min-area-rect-v1` may derive an oriented quadrilateral from a mask
+  contour.
+- An initial `pose-covariance-v1` may derive uncertainty from keypoint
+  confidence and person scale, align it with an adjacent skeleton edge, and
+  clamp its radii.
+- A later quality fixture may calculate empirical covariance through pinned
+  test-time augmentation and inverse-transformed pose matching.
+
+Every algorithm name, version, parameter, and output hash belongs in fixture
+metadata.
+
+### Reference Validation
+
+For a frozen fixture:
+
+1. a pinned Python Supervision reference generator produces expected outputs;
+2. a JavaScript adapter feeds the same detections into `DetectionFrameSource`;
+3. structural tests compare resolved geometry, labels, ordering, and temporal
+   state;
+4. browser tests capture JavaScript output;
+5. tolerant image comparisons catch visual regressions without requiring two
+   rasterizers to produce identical edge pixels.
+
+## Platform Ownership
+
+| Domain                                                                                 | Owner                   |
+| -------------------------------------------------------------------------------------- | ----------------------- |
+| Semantic geometry, recipe types, anchors, covariance math, and pure transforms         | `packages/core`         |
+| Pixi batching, filters, textures, media crops, workers, and browser prepared artifacts | `packages/web`          |
+| Skia mapping for an explicitly declared supported subset                               | `packages/react-native` |
+| Persistence, undo/redo, product tools, and product analytics                           | Host application        |
+| Fixtures, gallery, examples, and performance demonstrations                            | Docs and demo           |
+
+Unsupported recipes must be reported through capabilities or validation. A
+backend must not silently omit them.
+
+## Performance Requirements
+
+- Batch by primitive/runtime layer rather than facade or detection.
+- Pool display objects and avoid per-frame create/destroy churn.
+- Avoid rebuilding geometry when only color or alpha changes.
+- Update text only when content or layout changes.
+- Use texture atlases for icons.
+- Bound filters and prepared effect textures to affected regions.
+- Prepare expensive mask, halo, heat-map, and comparison work outside the
+  critical frame loop.
+- Add per-layer diagnostics through stable ids instead of one top-level metric
+  per annotator.
+- Benchmark dense detections, masks, labels, and temporal layers separately and
+  in realistic compositions.
+
+## Pull Request Contract
+
+**Every new annotator facade is exactly one pull request.** Infrastructure PRs
+may add a shared primitive or fixture capability without exposing an annotator,
+but an annotator PR must not bundle a second annotator merely because both lower
+to the same primitive.
+
+Each annotator PR includes:
+
+- one public facade and its lowering to existing recipes/primitives;
+- fixture coverage using frozen data;
+- pure resolution/lowering tests and browser renderer tests;
+- a screenshot or visual-regression reference;
+- public API docs and one focused playground/example control;
+- package-boundary and clean-consumer verification;
+- relevant performance evidence;
+- proof that default presentation is unchanged when unused.
+
+Any PR changing presentation semantics, masks, layer ordering, picking,
+prepared-artifact caching, media time, workers, or package entrypoints must be
+validated through the generated tarball in at least one external consumer. A
+sibling source import or `npm pack --dry-run` is not sufficient evidence.
+
+## Delivery Sequence
+
+### Foundation PRs: No New Annotators
+
+1. **Inference fixture authoring.** Generic local-server generator, provenance
+   schema, fixture validation, and `people_walking_detection_v1`.
+2. **External-consumer compatibility harness.** Reproducible tarball install and
+   focused integration checks without sibling-repository imports.
+3. **Recipe composition contract.** Stable identity, phases, coordinate spaces,
+   picking, backend capabilities, and diagnostics while compiling existing
+   presentation unchanged.
+4. **Generic vector primitives.** Path, ellipse, marker, text-anchor, and
+   quadrilateral instructions justified by the first facades.
+5. **Prepared media-effect primitives.** Bounded filters, mask reuse, worker
+   ownership, invalidation, and fallback capability reporting.
+6. **Temporal and HUD primitives.** Media-time windows, seek/loop behavior,
+   cache bounds, viewport anchoring, and deterministic counters.
+
+### Tier 1: Foundational Geometry Facades
+
+1. `OrientedBoxAnnotator`
+2. `BoxCornerAnnotator`
+3. `CircleAnnotator`
+4. `EllipseAnnotator`
+5. `DotAnnotator`
+6. `TriangleAnnotator`
+7. `VertexLabelAnnotator`
+8. `VertexEllipseAreaAnnotator`
+9. `VertexEllipseOutlineAnnotator`
+10. `VertexEllipseHaloAnnotator`
+
+### Tier 2: Prepared Mask And Media-Effect Facades
+
+11. `HaloAnnotator`
+12. `BlurAnnotator`
+13. `PixelateAnnotator`
+14. `BackgroundOverlayAnnotator`
+
+### Tier 3: Temporal Facades
+
+15. `TraceAnnotator`
+16. `HeatMapAnnotator`
+
+### Tier 4: Compound And Analytics Facades
+
+17. `CropAnnotator`
+18. `IconAnnotator`
+19. `PercentageBarAnnotator`
+20. `ComparisonAnnotator`
+21. `LineZoneAnnotator`
+22. `PolygonZoneAnnotator`
+23. `LineZoneAnnotatorMulticlass`
+
+The sequence may pause for platform or performance work, but compound facades
+should not move ahead of the primitives and lifecycle rules they require.
+
+## Review Checklist
+
+Review every roadmap PR against these questions:
+
+- Does the change add exactly one annotator facade?
+- Could the facade lower to existing primitives instead of adding a new
+  renderer path?
+- Does it preserve existing session, presentation, style, interaction, and
+  editing contracts?
+- Are picking and layer order explicit?
+- Is cache invalidation scoped to the changed semantic inputs?
+- Are temporal results deterministic across seek, loop, VFR, and non-zero
+  media origins?
+- Do media effects reuse the renderer-owned media and prepared artifacts?
+- Is inference absent from runtime and test paths?
+- Can the fixture be reproduced from pinned public inputs and raw outputs?
+- Does the backend report unsupported behavior instead of silently dropping it?
+- Do docs, package smoke, visual evidence, and relevant performance evidence
+  match the actual change?
+
+## Open Decisions
+
+1. Which downloaded media have explicit redistribution terms suitable for the
+   repository, rather than remaining linked references?
+2. Should the first release expose only factory-built recipes or also a
+   low-level custom recipe extension?
+3. Does simultaneous segmentation-polygon and oriented-box data justify an
+   `orientedBox` field, or should adapters continue lowering it to polygons?
+4. Which recipes should the experimental React Native backend support first?
+5. Should full-timeline heat maps require a finite enumerable source?
+6. Should pure zone counters live in core before a second non-renderer consumer
+   needs them?
+7. What browser matrix and image-diff tolerance define visual parity?
+8. Which `vehicles-2` interval and zone coordinates produce the most stable
+   zone fixture?
+9. Is the skiing pose fixture necessary before basketball exposes a concrete
+   coverage gap?
+10. Which Inference image digest and aliases become the first frozen authoring
+    toolchain?
+
+## Decision
+
+Proceed through composable use-case facades after the fixture, compatibility,
+and composition foundations land. Reuse the existing fixture architecture,
+generate detections through a pinned local Inference authoring workflow, and
+freeze every runtime input.
+
+Land annotators from foundational geometry to compound analytics, exactly one
+new facade per PR. A facade may—and generally should—be a small composition of
+primitives introduced earlier.
+
+The central invariant is:
+
+> A new visual facade may compile to existing primitives, but it must not change
+> the meaning, lifecycle, identity, editability, or cache behavior of existing
+> detections and presentation styles.

--- a/docs/internal/renderer-first-roadmap.md
+++ b/docs/internal/renderer-first-roadmap.md
@@ -1,5 +1,11 @@
 # Renderer-First Roadmap
 
+> This document records the project's foundational sequence. Several
+> capabilities originally deferred here have since landed. New visualization
+> recipes and annotator facades are sequenced by the
+> [annotator use-case roadmap](annotator-use-case-roadmap.md), while the
+> renderer-first constraints below remain authoritative.
+
 The first milestones should prove rendering capability before committing to a
 large annotation API. Each milestone should leave the project with something
 observable, measurable, and demoable.


### PR DESCRIPTION
# Description

Adds a public, contributor-facing roadmap for expanding supervision-js visualization use cases through composable annotator facades. The roadmap documents the capability inventory, renderer and compatibility invariants, public fixture sources, reproducible local Inference authoring, deterministic fixture requirements, one-annotator-per-PR policy, delivery order, and review checklist.

It also links the roadmap from contributor and agent guidance, and identifies the existing renderer-first roadmap as the historical foundation for this next phase.

The document intentionally targets use-case parity rather than Python API parity and contains no private consumer references.

## Type of change

- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran npm run verify: 544 tests passed together with lint, typecheck, package smoke, demo build, and benchmark builds
- Ran npm run docs:check: 11 documentation contract tests passed
- Compared the public inventory, model aliases, media sources, and delivery sequence against the full private research note
- Verified that no private repository, pull request, application path, or test-suite reference remains
- Ran Prettier and git diff --check

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

None. This is an internal documentation and contribution-guidance change.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)