### PR TITLE
Add live visualization layer guides

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { BenchmarksPanel } from "./components/BenchmarksPanel";
 import { ControlBar } from "./components/ControlBar";
 import { DemoShell } from "./components/DemoShell";
 import { DocsBasketballPlayground } from "./components/DocsBasketballPlayground";
+import { DocsVisualizationLayerPlayground } from "./components/DocsVisualizationLayerPlayground";
 import { PerformanceStrip } from "./components/PerformanceStrip";
 import { QualityControls } from "./components/QualityControls";
 import { RenderControls } from "./components/RenderControls";
@@ -11,6 +12,7 @@ import { SelectionPanel } from "./components/SelectionPanel";
 import { SourceControls } from "./components/SourceControls";
 import { StatusPanel } from "./components/StatusPanel";
 import { resolveDemoDocsUrl } from "./docs-url";
+import { parseDocsVisualizationLayer } from "./docs-visualization-layer";
 import { DemoSourceMode, useDemoRenderer } from "./hooks/useDemoRenderer";
 import { defaultDemoClassNames } from "./presentation/demo-presentation";
 import { DemoViewMode } from "./session/demo-view-mode";
@@ -23,14 +25,78 @@ const docsUrl = resolveDemoDocsUrl(
 const allowUpload = import.meta.env.VITE_DEMO_ALLOW_UPLOAD !== "false";
 
 export function App() {
-  if (
-    new URLSearchParams(globalThis.location.search).get("embed") ===
-    "docs-playground"
-  ) {
-    return <DocsBasketballPlayground />;
+  const searchParams = new URLSearchParams(globalThis.location.search);
+  const embeddedView = searchParams.get("embed");
+
+  if (embeddedView === "docs-playground") {
+    return (
+      <EmbeddedPlaygroundFrame>
+        <DocsBasketballPlayground />
+      </EmbeddedPlaygroundFrame>
+    );
+  }
+
+  if (embeddedView === "visualization-layer") {
+    return (
+      <EmbeddedPlaygroundFrame>
+        <DocsVisualizationLayerPlayground
+          layer={parseDocsVisualizationLayer(searchParams.get("layer"))}
+        />
+      </EmbeddedPlaygroundFrame>
+    );
   }
 
   return <DemoApp />;
+}
+
+function EmbeddedPlaygroundFrame({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  useEffect(() => {
+    const root = document.getElementById("root");
+    const previous = {
+      bodyHeight: document.body.style.height,
+      bodyOverflow: document.body.style.overflow,
+      htmlHeight: document.documentElement.style.height,
+      rootHeight: root?.style.height ?? "",
+    };
+
+    document.documentElement.style.height = "auto";
+    document.body.style.height = "auto";
+    document.body.style.overflow = "visible";
+    root?.style.setProperty("height", "auto");
+
+    const publishHeight = () => {
+      const height = Math.max(
+        document.documentElement.scrollHeight,
+        document.body.scrollHeight,
+        root?.scrollHeight ?? 0,
+      );
+      window.parent.postMessage(
+        { height, type: "supervision-js:playground-height" },
+        "*",
+      );
+    };
+
+    const observer = new ResizeObserver(publishHeight);
+    observer.observe(document.documentElement);
+    if (root) {
+      observer.observe(root);
+    }
+    publishHeight();
+
+    return () => {
+      observer.disconnect();
+      document.documentElement.style.height = previous.htmlHeight;
+      document.body.style.height = previous.bodyHeight;
+      document.body.style.overflow = previous.bodyOverflow;
+      root?.style.setProperty("height", previous.rootHeight);
+    };
+  }, []);
+
+  return children;
 }
 
 function DemoApp() {

--- a/demo/src/components/DocsVisualizationLayerPlayground.tsx
+++ b/demo/src/components/DocsVisualizationLayerPlayground.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useMemo } from "react";
+import { MediaRendererPlaybackState } from "supervision";
+import {
+  createDocsVisualizationLayerPresentation,
+  createDocsVisualizationLayerSnippet,
+  docsVisualizationLayers,
+  type DocsVisualizationLayerControl,
+  type DocsVisualizationLayerId,
+  type NumericPresentationSetting,
+} from "../docs-visualization-layer";
+import { useDemoRenderer } from "../hooks/useDemoRenderer";
+import type { DemoPresentationSettings } from "../presentation/demo-presentation";
+import { RendererViewport } from "./RendererViewport";
+
+export function DocsVisualizationLayerPlayground({
+  layer,
+}: {
+  readonly layer: DocsVisualizationLayerId;
+}) {
+  const definition = docsVisualizationLayers[layer];
+  const demo = useDemoRenderer({
+    initialFixtureId: "basketball_geometry",
+    initialPresentationSettings:
+      createDocsVisualizationLayerPresentation(layer),
+  });
+  const isPlaying =
+    demo.playbackState === MediaRendererPlaybackState.Playing ||
+    demo.playbackState === MediaRendererPlaybackState.Buffering;
+  const currentTime = demo.rendererState?.currentTime ?? 0;
+  const progress = useMemo(
+    () =>
+      demo.duration && demo.duration > 0
+        ? Math.min(100, Math.max(0, (currentTime / demo.duration) * 100))
+        : 0,
+    [currentTime, demo.duration],
+  );
+  const snippet = useMemo(
+    () => createDocsVisualizationLayerSnippet(layer, demo.presentationSettings),
+    [demo.presentationSettings, layer],
+  );
+  const updatePresentation = useCallback(
+    <Key extends keyof DemoPresentationSettings>(
+      key: Key,
+      value: DemoPresentationSettings[Key],
+    ) => {
+      demo.setPresentationSettings({
+        ...demo.presentationSettings,
+        [key]: value,
+      });
+    },
+    [demo.presentationSettings, demo.setPresentationSettings],
+  );
+  const updateNumericPresentation = useCallback(
+    (key: NumericPresentationSetting, value: number) => {
+      demo.setPresentationSettings({
+        ...demo.presentationSettings,
+        [key]: value,
+      });
+    },
+    [demo.presentationSettings, demo.setPresentationSettings],
+  );
+
+  return (
+    <main
+      className="docs-layer-playground"
+      aria-label={`${definition.title} visualization playground`}
+    >
+      <section className="docs-layer-playground__stage">
+        <RendererViewport
+          containerRef={demo.containerRef}
+          mediaState={demo.mediaState}
+          sessionState={demo.sessionState}
+          uploadInferenceState={null}
+        />
+      </section>
+
+      <section className="docs-layer-playground__panel">
+        <header className="docs-layer-playground__header">
+          <div>
+            <p>Visualization layer</p>
+            <h1>{definition.title}</h1>
+            <span>{definition.description}</span>
+          </div>
+          <button
+            aria-label={
+              isPlaying ? "Pause basketball fixture" : "Play basketball fixture"
+            }
+            disabled={!demo.canUseRenderer}
+            onClick={demo.onTogglePlayback}
+            type="button"
+          >
+            <span aria-hidden="true">{isPlaying ? "Ⅱ" : "▶"}</span>
+            {isPlaying ? "Pause" : "Play"}
+          </button>
+        </header>
+
+        <div className="docs-layer-playground__controls">
+          {definition.controls.map((control) => (
+            <LayerRangeControl
+              control={control}
+              key={control.key}
+              onChange={(value) =>
+                updateNumericPresentation(control.key, value)
+              }
+              value={demo.presentationSettings[control.key]}
+            />
+          ))}
+          {layer === "labels" ? (
+            <label className="docs-layer-playground__toggle">
+              <span>
+                <strong>Confidence</strong>
+                <small>Append prediction score</small>
+              </span>
+              <input
+                checked={demo.presentationSettings.labelIncludeConfidence}
+                onChange={(event) =>
+                  updatePresentation(
+                    "labelIncludeConfidence",
+                    event.currentTarget.checked,
+                  )
+                }
+                type="checkbox"
+              />
+            </label>
+          ) : null}
+        </div>
+
+        <section
+          className="docs-layer-playground__code"
+          aria-label="Live presentation code"
+        >
+          <div>
+            <span>Live code</span>
+            <small>Values update with the controls</small>
+          </div>
+          <pre>
+            <code>{snippet}</code>
+          </pre>
+        </section>
+
+        <div aria-hidden="true" className="docs-layer-playground__progress">
+          <span style={{ width: `${progress}%` }} />
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function LayerRangeControl({
+  control,
+  onChange,
+  value,
+}: {
+  readonly control: DocsVisualizationLayerControl;
+  readonly onChange: (value: number) => void;
+  readonly value: number;
+}) {
+  const valueLabel =
+    control.unit === "percent"
+      ? `${Math.round(value * 100)}%`
+      : `${Number(value.toFixed(1))}px`;
+
+  return (
+    <label className="docs-layer-playground__range">
+      <span>
+        <strong>{control.label}</strong>
+        <output>{valueLabel}</output>
+      </span>
+      <input
+        max={control.max}
+        min={control.min}
+        onChange={(event) => onChange(Number(event.currentTarget.value))}
+        step={control.step}
+        type="range"
+        value={value}
+      />
+    </label>
+  );
+}

--- a/demo/src/docs-visualization-layer.test.ts
+++ b/demo/src/docs-visualization-layer.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { defaultDemoPresentationSettings } from "./presentation/demo-presentation";
+import {
+  createDocsVisualizationLayerPresentation,
+  createDocsVisualizationLayerSnippet,
+  docsVisualizationLayerIds,
+  parseDocsVisualizationLayer,
+} from "./docs-visualization-layer";
+
+describe("docs visualization layers", () => {
+  it("isolates each requested presentation layer", () => {
+    for (const layer of docsVisualizationLayerIds) {
+      const presentation = createDocsVisualizationLayerPresentation(layer);
+      const enabled = Object.entries(presentation)
+        .filter(([key, value]) => key.endsWith("Enabled") && value)
+        .map(([key]) => key);
+
+      expect(enabled).toEqual([
+        layer === "keypoints" ? "keypointsEnabled" : `${layer}Enabled`,
+      ]);
+    }
+  });
+
+  it("falls back to boxes for unknown layer ids", () => {
+    expect(parseDocsVisualizationLayer("masks")).toBe("masks");
+    expect(parseDocsVisualizationLayer("unknown")).toBe("boxes");
+  });
+
+  it("keeps live values in the focused snippet", () => {
+    expect(
+      createDocsVisualizationLayerSnippet("boxes", {
+        ...defaultDemoPresentationSettings,
+        boxFillAlpha: 0.27,
+        boxStrokeWidth: 6,
+      }),
+    ).toContain("fill: { alpha: 0.27 }");
+    expect(
+      createDocsVisualizationLayerSnippet("boxes", {
+        ...defaultDemoPresentationSettings,
+        boxFillAlpha: 0.27,
+        boxStrokeWidth: 6,
+      }),
+    ).toContain("stroke: { width: 6 }");
+  });
+});

--- a/demo/src/docs-visualization-layer.ts
+++ b/demo/src/docs-visualization-layer.ts
@@ -1,0 +1,250 @@
+import type { DemoPresentationSettings } from "./presentation/demo-presentation";
+
+export const docsVisualizationLayerIds = [
+  "boxes",
+  "masks",
+  "labels",
+  "polygons",
+  "keypoints",
+] as const;
+
+export type DocsVisualizationLayerId =
+  (typeof docsVisualizationLayerIds)[number];
+
+export interface DocsVisualizationLayerControl {
+  readonly key: NumericPresentationSetting;
+  readonly label: string;
+  readonly max: number;
+  readonly min: number;
+  readonly step: number;
+  readonly unit: "percent" | "pixels";
+}
+
+export interface DocsVisualizationLayerDefinition {
+  readonly controls: readonly DocsVisualizationLayerControl[];
+  readonly description: string;
+  readonly title: string;
+}
+
+export type NumericPresentationSetting = {
+  [
+    Key in keyof DemoPresentationSettings
+  ]: DemoPresentationSettings[Key] extends number ? Key : never;
+}[keyof DemoPresentationSettings];
+
+export const docsVisualizationLayers: Readonly<
+  Record<DocsVisualizationLayerId, DocsVisualizationLayerDefinition>
+> = {
+  boxes: {
+    controls: [
+      {
+        key: "boxFillAlpha",
+        label: "Fill opacity",
+        max: 0.5,
+        min: 0,
+        step: 0.01,
+        unit: "percent",
+      },
+      {
+        key: "boxStrokeWidth",
+        label: "Stroke width",
+        max: 8,
+        min: 1,
+        step: 1,
+        unit: "pixels",
+      },
+      {
+        key: "boxCornerRadius",
+        label: "Corner radius",
+        max: 24,
+        min: 0,
+        step: 1,
+        unit: "pixels",
+      },
+    ],
+    description: "Axis-aligned detection bounds",
+    title: "Boxes",
+  },
+  masks: {
+    controls: [
+      {
+        key: "maskOpacity",
+        label: "Layer opacity",
+        max: 1,
+        min: 0,
+        step: 0.01,
+        unit: "percent",
+      },
+      {
+        key: "maskFillAlpha",
+        label: "Fill opacity",
+        max: 1,
+        min: 0,
+        step: 0.01,
+        unit: "percent",
+      },
+      {
+        key: "maskStrokeWidth",
+        label: "Border width",
+        max: 8,
+        min: 0,
+        step: 1,
+        unit: "pixels",
+      },
+    ],
+    description: "Compressed RLE segmentation",
+    title: "Masks",
+  },
+  labels: {
+    controls: [
+      {
+        key: "labelBackgroundAlpha",
+        label: "Background opacity",
+        max: 1,
+        min: 0,
+        step: 0.01,
+        unit: "percent",
+      },
+      {
+        key: "labelFontSize",
+        label: "Font size",
+        max: 24,
+        min: 10,
+        step: 1,
+        unit: "pixels",
+      },
+      {
+        key: "labelCornerRadius",
+        label: "Corner radius",
+        max: 16,
+        min: 0,
+        step: 1,
+        unit: "pixels",
+      },
+    ],
+    description: "Class names and confidence",
+    title: "Labels",
+  },
+  polygons: {
+    controls: [
+      {
+        key: "polygonFillAlpha",
+        label: "Fill opacity",
+        max: 0.6,
+        min: 0,
+        step: 0.01,
+        unit: "percent",
+      },
+      {
+        key: "polygonStrokeWidth",
+        label: "Stroke width",
+        max: 8,
+        min: 1,
+        step: 1,
+        unit: "pixels",
+      },
+    ],
+    description: "Closed media-space paths",
+    title: "Polygons",
+  },
+  keypoints: {
+    controls: [
+      {
+        key: "keypointRadius",
+        label: "Point radius",
+        max: 12,
+        min: 1,
+        step: 0.5,
+        unit: "pixels",
+      },
+      {
+        key: "keypointEdgeWidth",
+        label: "Skeleton width",
+        max: 8,
+        min: 1,
+        step: 0.5,
+        unit: "pixels",
+      },
+    ],
+    description: "Pose markers and skeleton edges",
+    title: "Keypoints & Skeletons",
+  },
+};
+
+export function parseDocsVisualizationLayer(
+  value: string | null,
+): DocsVisualizationLayerId {
+  return docsVisualizationLayerIds.includes(value as DocsVisualizationLayerId)
+    ? (value as DocsVisualizationLayerId)
+    : "boxes";
+}
+
+export function createDocsVisualizationLayerPresentation(
+  layer: DocsVisualizationLayerId,
+): Partial<DemoPresentationSettings> {
+  return {
+    boxesEnabled: layer === "boxes",
+    focusEnabled: false,
+    keypointsEnabled: layer === "keypoints",
+    labelsEnabled: layer === "labels",
+    masksEnabled: layer === "masks",
+    polygonsEnabled: layer === "polygons",
+    polylinesEnabled: false,
+    maskFillAlpha: 1,
+    maskOpacity: 0.72,
+  };
+}
+
+export function createDocsVisualizationLayerSnippet(
+  layer: DocsVisualizationLayerId,
+  settings: DemoPresentationSettings,
+) {
+  switch (layer) {
+    case "boxes":
+      return `session.setPresentation({
+  boxStyle: new BaseBoxStyle({
+    cornerRadius: ${formatNumber(settings.boxCornerRadius)},
+    fill: { alpha: ${formatNumber(settings.boxFillAlpha)} },
+    stroke: { width: ${formatNumber(settings.boxStrokeWidth)} },
+  }),
+});`;
+    case "masks":
+      return `session.setPresentation({
+  maskStyle: new BaseMaskStyle({
+    fillAlpha: ${formatNumber(settings.maskFillAlpha)},
+    opacity: ${formatNumber(settings.maskOpacity)},
+    stroke: { alpha: 1, width: ${formatNumber(settings.maskStrokeWidth)} },
+  }),
+});`;
+    case "labels":
+      return `session.setPresentation({
+  labelStyle: new BaseLabelStyle({
+    background: {
+      alpha: ${formatNumber(settings.labelBackgroundAlpha)},
+      cornerRadius: ${formatNumber(settings.labelCornerRadius)},
+    },
+    includeConfidence: ${settings.labelIncludeConfidence},
+    textStyle: { fontSize: ${formatNumber(settings.labelFontSize)} },
+  }),
+});`;
+    case "polygons":
+      return `session.setPresentation({
+  polygonStyle: new BasePolygonStyle({
+    fill: { alpha: ${formatNumber(settings.polygonFillAlpha)} },
+    stroke: { width: ${formatNumber(settings.polygonStrokeWidth)} },
+  }),
+});`;
+    case "keypoints":
+      return `session.setPresentation({
+  keypointStyle: new BaseKeypointStyle({
+    edgeStroke: { width: ${formatNumber(settings.keypointEdgeWidth)} },
+    markerFill: { alpha: 1 },
+    radius: ${formatNumber(settings.keypointRadius)},
+  }),
+});`;
+  }
+}
+
+function formatNumber(value: number) {
+  return Number(value.toFixed(2)).toString();
+}

--- a/demo/src/fixtures/demo-fixtures.ts
+++ b/demo/src/fixtures/demo-fixtures.ts
@@ -3,6 +3,7 @@ import {
   type DetectionFrameChunkFetch,
   type DetectionFrameChunkManifest,
   type DetectionFrameSource,
+  type DetectionFrame,
   type MediaSessionMedia,
 } from "supervision";
 import type { DemoPresentationAvailability } from "../presentation/demo-presentation";
@@ -173,6 +174,10 @@ export interface DemoFixtureDetectionSource {
   destroy(): void;
 }
 
+export type DemoFixtureFrameTransform = (
+  frames: readonly DetectionFrame[],
+) => readonly DetectionFrame[];
+
 export interface DemoFixtureMediaSource {
   readonly error: Error | null;
   readonly media: MediaSessionMedia;
@@ -225,10 +230,17 @@ export async function loadDemoFixtureMedia(
 export function createDemoFixtureDetectionSource(
   manifest: DemoFixtureDetectionManifest,
   definition: DemoFixtureDefinition = defaultDemoFixture,
+  frameTransform?: DemoFixtureFrameTransform,
 ): DemoFixtureDetectionSource {
   const detectionSource = createChunkedDetectionFrameSource({
     baseUrl: definition.detectionsManifestSrc,
-    fetchChunk: (chunk) => fetchDemoFixtureDetectionChunk(chunk, definition),
+    fetchChunk: async (chunk) => {
+      const loaded = await fetchDemoFixtureDetectionChunk(chunk, definition);
+
+      return frameTransform
+        ? { frames: frameTransform(loaded.frames) }
+        : loaded;
+    },
     manifest,
   });
   let destroyed = false;

--- a/demo/src/hooks/useDemoRenderer.ts
+++ b/demo/src/hooks/useDemoRenderer.ts
@@ -15,7 +15,10 @@ import {
   type MediaSourceState,
   type RenderPreparationDiagnostics,
 } from "supervision";
-import type { DemoFixtureSummary } from "../fixtures/demo-fixtures";
+import type {
+  DemoFixtureFrameTransform,
+  DemoFixtureSummary,
+} from "../fixtures/demo-fixtures";
 import {
   demoFixtures,
   defaultDemoFixture,
@@ -93,6 +96,8 @@ export interface DemoRendererState {
 }
 
 export interface UseDemoRendererOptions {
+  /** Optional docs/demo-only transformation over loaded fixture frames. */
+  readonly fixtureFrameTransform?: DemoFixtureFrameTransform;
   /**
    * Lets focused demo experiences start on a known fixture without first
    * constructing another media session.
@@ -133,6 +138,7 @@ export function useDemoRenderer(
         (fixture) => fixture.sampleName === options.initialFixtureId,
       ) ?? defaultDemoFixture,
   );
+  const [fixtureFrameTransform] = useState(() => options.fixtureFrameTransform);
   const [initialPresentationSettings] = useState(() =>
     constrainDemoPresentationSettings(
       {
@@ -300,6 +306,7 @@ export function useDemoRenderer(
           const session = await createFixtureSession({
             container,
             definition: activeFixture,
+            fixtureFrameTransform,
             isActive,
             onDetectionHover: setHoveredDetectionPick,
             onDetectionSelect: setSelectedDetectionPick,
@@ -380,7 +387,13 @@ export function useDemoRenderer(
         renderer?.destroy();
       }
     };
-  }, [activeFixture, sourceMode, syncRendererState, uploadRun]);
+  }, [
+    activeFixture,
+    fixtureFrameTransform,
+    sourceMode,
+    syncRendererState,
+    uploadRun,
+  ]);
 
   const playbackState = rendererState?.playbackState ?? null;
   const duration = rendererState?.duration ?? fixtureSummary?.duration ?? null;

--- a/demo/src/session/fixture-session.ts
+++ b/demo/src/session/fixture-session.ts
@@ -8,7 +8,10 @@ import {
   createMediaSession,
   type MediaSession,
 } from "supervision";
-import type { DemoFixtureDefinition } from "../fixtures/demo-fixtures";
+import type {
+  DemoFixtureDefinition,
+  DemoFixtureFrameTransform,
+} from "../fixtures/demo-fixtures";
 import {
   createDemoFixtureDetectionSource,
   loadDemoFixtureDetectionManifest,
@@ -26,12 +29,14 @@ export async function createFixtureSession(
   options: {
     readonly container: HTMLDivElement;
     readonly definition: DemoFixtureDefinition;
+    readonly fixtureFrameTransform?: DemoFixtureFrameTransform;
   } & DemoSessionCallbacks,
 ): Promise<MediaSession> {
   const manifest = await loadDemoFixtureDetectionManifest(options.definition);
   const detectionSource = createDemoFixtureDetectionSource(
     manifest,
     options.definition,
+    options.fixtureFrameTransform,
   );
 
   if (!options.isActive()) {

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -323,6 +323,235 @@ body {
   }
 }
 
+.docs-layer-playground {
+  background:
+    radial-gradient(
+      circle at 100% 0,
+      rgba(196, 181, 253, 0.42),
+      transparent 34%
+    ),
+    #ffffff;
+  color: var(--text);
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(15.5rem, 1fr);
+  height: auto;
+  min-height: 46rem;
+  overflow: visible;
+}
+
+.docs-layer-playground__stage {
+  background: #f3f4f6;
+  min-height: 0;
+  position: relative;
+}
+
+.docs-layer-playground__stage .renderer-viewport {
+  background: #f3f4f6;
+  height: 100%;
+}
+
+.docs-layer-playground__stage .renderer-viewport::after {
+  display: none;
+}
+
+.docs-layer-playground__header p,
+.docs-layer-playground__code > div > span {
+  color: var(--violet);
+  font-size: 0.64rem;
+  font-weight: 780;
+  letter-spacing: 0.09em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.docs-layer-playground__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-height: 0;
+  overflow: visible;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+.docs-layer-playground__header {
+  align-items: start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.docs-layer-playground__header h1 {
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  letter-spacing: -0.045em;
+  line-height: 1;
+  margin: 0.28rem 0 0.38rem;
+}
+
+.docs-layer-playground__header > div > span {
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.docs-layer-playground__header button {
+  align-items: center;
+  background: var(--violet);
+  border: 0;
+  border-radius: 9px;
+  color: #ffffff;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 0.75rem;
+  font-weight: 720;
+  gap: 0.35rem;
+  min-height: 2.15rem;
+  padding: 0.45rem 0.7rem;
+}
+
+.docs-layer-playground__header button:hover:not(:disabled) {
+  background: #6d28d9;
+}
+
+.docs-layer-playground__header button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.docs-layer-playground__controls {
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid #e4e4e7;
+  border-radius: 12px;
+  display: grid;
+  gap: 0.72rem;
+  padding: 0.85rem;
+  flex-shrink: 0;
+}
+
+.docs-layer-playground__range {
+  display: grid;
+  gap: 0.38rem;
+}
+
+.docs-layer-playground__range > span,
+.docs-layer-playground__toggle {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.docs-layer-playground__range strong,
+.docs-layer-playground__toggle strong {
+  color: var(--muted-strong);
+  font-size: 0.73rem;
+  font-weight: 690;
+}
+
+.docs-layer-playground__range output {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.docs-layer-playground__range input {
+  accent-color: var(--violet);
+  cursor: pointer;
+  inline-size: 100%;
+}
+
+.docs-layer-playground__toggle {
+  border-top: 1px solid #ede9fe;
+  cursor: pointer;
+  padding-top: 0.7rem;
+}
+
+.docs-layer-playground__toggle > span {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.docs-layer-playground__toggle small {
+  color: var(--muted);
+  font-size: 0.65rem;
+}
+
+.docs-layer-playground__toggle input {
+  accent-color: var(--violet);
+  block-size: 1rem;
+  inline-size: 1rem;
+}
+
+.docs-layer-playground__code {
+  background: #171224;
+  border: 1px solid #2e2444;
+  border-radius: 12px;
+  color: #f5f3ff;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.docs-layer-playground__code > div {
+  align-items: center;
+  border-bottom: 1px solid #34284d;
+  display: flex;
+  justify-content: space-between;
+  padding: 0.58rem 0.75rem;
+}
+
+.docs-layer-playground__code > div > span {
+  color: #c4b5fd;
+}
+
+.docs-layer-playground__code small {
+  color: #a1a1aa;
+  font-size: 0.62rem;
+}
+
+.docs-layer-playground__code pre {
+  margin: 0;
+  overflow: auto;
+  padding: 0.72rem 0.8rem;
+}
+
+.docs-layer-playground__code code {
+  color: #ede9fe;
+  font-family: var(--font-mono);
+  font-size: clamp(0.62rem, 1.3vw, 0.71rem);
+  line-height: 1.5;
+}
+
+.docs-layer-playground__progress {
+  background: #ddd6fe;
+  block-size: 0.3rem;
+  border-radius: 999px;
+  margin-top: auto;
+  overflow: hidden;
+}
+
+.docs-layer-playground__progress span {
+  background: linear-gradient(90deg, #7c3aed, #a78bfa);
+  block-size: 100%;
+  border-radius: inherit;
+  display: block;
+  transition: width 180ms linear;
+}
+
+@media (max-width: 720px) {
+  .docs-layer-playground {
+    grid-template-columns: 1fr;
+    grid-template-rows: 18rem auto;
+    overflow: visible;
+  }
+
+  .docs-layer-playground__stage {
+    border-bottom: 1px solid #ddd6fe;
+    min-height: 18rem;
+  }
+
+  .docs-layer-playground__panel {
+    overflow: visible;
+  }
+}
+
 button,
 input {
   font: inherit;

--- a/docs/internal/agent-guidance.md
+++ b/docs/internal/agent-guidance.md
@@ -40,6 +40,21 @@ or the private React Native experiment into public contracts. Do not edit
 generated `docs/site/` output; rebuild the docs with `npm run demo:build` and
 run `npm run docs:check` after changing the homepage.
 
+Public rendering guidance lives under
+[`../public/visualization-layers.md`](../public/visualization-layers.md). Treat a
+**visualization layer** as the consumer-facing unit: semantic detections provide
+the data, presentation styles control appearance, and the session composes the
+enabled layers. When a public layer is added or materially changed, update its
+focused page and the `Visualization Layers` navigation children in the same
+change. Add the reusable docs playground only when a committed frozen fixture
+contains the layer's real semantic input; each such playground should show that
+fixture, focused controls, and a minimal live `session.setPresentation()`
+snippet whose values stay synchronized with those controls. Do not fabricate
+docs-only detections to simulate a missing fixture. Record any unsupported
+playground in `annotator-use-case-roadmap.md` with the next fixture or primitive
+required. Keep renderer objects and docs-only fixture augmentation out of the
+published package API.
+
 The documentation toolbar displays the browser package version from
 `docs/public/typedoc-icons.js`. Update that value with
 `packages/web/package.json` in every browser package release; `npm run

--- a/docs/internal/annotator-use-case-roadmap.md
+++ b/docs/internal/annotator-use-case-roadmap.md
@@ -2,7 +2,7 @@
 
 Status: proposed contribution and sequencing guide
 
-Last reviewed: August 7, 2026
+Last reviewed: August 8, 2026
 
 Scope: browser visualization capabilities; this is not an API commitment
 
@@ -301,6 +301,40 @@ deterministic association policies, and timeline chunks. A generic
 `tools/inference-fixture/` authoring tool should reuse those schemas and
 helpers.
 
+### Current Visualization-Layer Delivery Ledger
+
+This ledger is the source of truth for whether a public visualization page may
+claim a live playground. A renderer primitive alone is not enough: the
+playground must consume a committed fixture containing the matching semantic
+field. Do not inject docs-only detections to simulate coverage.
+
+| Visualization capability | Browser renderer and style        | Frozen fixture evidence                                         | Public docs state                  | Next required work                                                      |
+| ------------------------ | --------------------------------- | --------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------- |
+| Boxes                    | Implemented                       | `basketball_geometry.rect`                                      | Live playground                    | Maintain regression coverage with the basketball fixture                |
+| Masks                    | Implemented                       | `basketball_geometry.mask` (compressed RLE)                     | Live playground                    | Maintain mask-preparation and visual coverage                           |
+| Labels                   | Implemented                       | `basketball_geometry.className` and `confidence`                | Live playground                    | Maintain label layout and contrast coverage                             |
+| Polygons                 | Implemented                       | `basketball_geometry.polygon`                                   | Live playground                    | Maintain contour and fill/stroke coverage                               |
+| Keypoints and skeletons  | Implemented                       | `basketball_geometry.keypoints` including edges and visibility  | Live playground                    | Maintain pose association and visibility coverage                       |
+| Polylines                | Implemented (`BasePolylineStyle`) | **Missing** — no committed fixture has semantic `polyline` data | Reference page only; no playground | Add a reproducible open-path fixture before restoring a live playground |
+
+The basketball fixture is therefore the current visual baseline for five
+layers: boxes, masks, labels, polygons, and keypoints/skeletons. It is not a
+polyline fixture. The docs must remain truthful about that boundary.
+
+### Gaps Before New Facades
+
+| Gap                                               | Status                                    | Earliest prerequisite                                                                                                                                    |
+| ------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Open-path fixture for the existing polyline layer | Renderer exists; fixture absent           | Extend `vehicles_zone_v1` (or an equivalent public-media fixture) with versioned open-path guide/trace input, provenance, and visual regression evidence |
+| Oriented quadrilateral layer                      | No first-class public visualization layer | Generic quadrilateral primitive plus a mask-derived or explicitly annotated fixture                                                                      |
+| Markers and ellipses                              | No first-class public visualization layer | Generic marker/ellipse primitives plus `people_walking_detection_v1` or a pose fixture                                                                   |
+| Mask/media effects                                | No public visualization layer             | Prepared media-effect primitive plus `people_walking_segmentation_v1`                                                                                    |
+| Temporal and analytic overlays                    | No public visualization layer             | Temporal/HUD primitives plus `vehicles_zone_v1` with frozen tracks, zone coordinates, and events                                                         |
+
+No annotator facade may be added ahead of the matching row's primitive and
+fixture evidence. Each facade remains one pull request after those prerequisites
+land.
+
 ### Public Media References
 
 The properties below were measured from the source files. MD5 values come from
@@ -322,13 +356,13 @@ normalized asset.
 
 ### Canonical Fixture Matrix
 
-| Fixture                          | Media                                                              | Authoring model and deterministic processing                                                                                                                        | Primary coverage                                                                                      |
-| -------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Existing `basketball_geometry`   | Keep the committed normalized basketball media                     | Regeneration target: `yolov8m-pose-640`; retain existing SAM3 masks, pose-to-mask association, and compressed RLE. Derive explicitly marked covariance when needed. | Existing shapes, masks, polygons, keypoints, skeletons, oriented boxes, covariance, and media effects |
-| `people_walking_detection_v1`    | Full 13.64 s source, optionally normalized to 1280x720 at 25 fps   | Primary `yolov8n-1280`, `person` only, confidence >= 0.25; pinned ByteTrack at 25 fps. Secondary `rfdetr-small` set for comparison.                                 | Foundational geometry facades, labels, bars, traces, heat maps, and comparison                        |
-| `people_walking_segmentation_v1` | Deterministic representative 3 s interval                          | `yolov8s-seg-640`, `person` only, confidence >= 0.25; compressed RLE; polygons simplified to at most 48 points; versioned minimum-area rectangle derivation.        | Oriented boxes, halo, blur, pixelate, background overlay, and crop                                    |
-| `vehicles_zone_v1`               | Candidate 10.0-22.0 s interval, finalized after a tracking preview | `yolov8s-640`; car, truck, bus, and motorcycle; confidence >= 0.25; pinned ByteTrack at 30000/1001 fps; frozen line/polygon coordinates and events.                 | Traces, line zones, polygon zones, counts, and multiclass HUD                                         |
-| Optional `skiing_pose_stress_v1` | Full source or deterministic high-motion interval                  | `yolov8m-pose-640`; preserve missing and low-confidence joints                                                                                                      | Seek, motion, and occlusion stress for pose and trace rendering                                       |
+| Fixture                          | Media                                                              | Authoring model and deterministic processing                                                                                                                           | Primary coverage                                                                                      |
+| -------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Existing `basketball_geometry`   | Keep the committed normalized basketball media                     | Regeneration target: `yolov8m-pose-640`; retain existing SAM3 masks, pose-to-mask association, and compressed RLE. Derive explicitly marked covariance when needed.    | Existing shapes, masks, polygons, keypoints, skeletons, oriented boxes, covariance, and media effects |
+| `people_walking_detection_v1`    | Full 13.64 s source, optionally normalized to 1280x720 at 25 fps   | Primary `yolov8n-1280`, `person` only, confidence >= 0.25; pinned ByteTrack at 25 fps. Secondary `rfdetr-small` set for comparison.                                    | Foundational geometry facades, labels, bars, traces, heat maps, and comparison                        |
+| `people_walking_segmentation_v1` | Deterministic representative 3 s interval                          | `yolov8s-seg-640`, `person` only, confidence >= 0.25; compressed RLE; polygons simplified to at most 48 points; versioned minimum-area rectangle derivation.           | Oriented boxes, halo, blur, pixelate, background overlay, and crop                                    |
+| `vehicles_zone_v1`               | Candidate 10.0-22.0 s interval, finalized after a tracking preview | `yolov8s-640`; car, truck, bus, and motorcycle; confidence >= 0.25; pinned ByteTrack at 30000/1001 fps; frozen line/polygon coordinates, open-path guides, and events. | Polylines, traces, line zones, polygon zones, counts, and multiclass HUD                              |
+| Optional `skiing_pose_stress_v1` | Full source or deterministic high-motion interval                  | `yolov8m-pose-640`; preserve missing and low-confidence joints                                                                                                         | Seek, motion, and occlusion stress for pose and trace rendering                                       |
 
 The existing basketball fixture is the primary mask/keypoint reference.
 `basketball-1.mp4` is a fallback or additional stress source, not a reason to

--- a/docs/public/concepts.md
+++ b/docs/public/concepts.md
@@ -1,0 +1,25 @@
+---
+title: Core Concepts
+children:
+  - ./guides/media-sessions.md
+  - ./guides/detections-and-rendering.md
+  - ./guides/presentation-styles.md
+  - ./guides/media-preparation.md
+  - ./guides/public-api.md
+---
+
+# Core Concepts
+
+These guides explain the contracts that stay stable across visualization
+layers and host frameworks.
+
+- [Media sessions](./guides/media-sessions.md) — media, detections, rendering,
+  playback, and teardown under one owner.
+- [Detections and rendering](./guides/detections-and-rendering.md) — semantic
+  frames, buffering, preparation, and active render state.
+- [Presentation styles](./guides/presentation-styles.md) — renderer-neutral
+  style objects and runtime updates.
+- [Media preparation](./guides/media-preparation.md) — normalize browser media
+  without changing its timeline contract.
+- [Public API](./guides/public-api.md) — supported entrypoints and advanced
+  integration boundaries.

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -1,0 +1,24 @@
+---
+title: Quickstart
+children:
+  - ./guides/application-integration.md
+  - ./recipes/static-detections.md
+  - ./recipes/streaming-detections.md
+---
+
+# Quickstart
+
+Install `supervision`, create one media session, and provide detections on the
+same media timeline. Start with the application integration guide, then choose
+the static or streaming source recipe that matches your application.
+
+- [Application integration](./guides/application-integration.md) — install,
+  mount, and own a session lifecycle.
+- [Static detections](./recipes/static-detections.md) — render a known sequence
+  of frames.
+- [Streaming detections](./recipes/streaming-detections.md) — append predictions
+  while media plays.
+
+Once a session is running, continue to
+[Visualization Layers](./visualization-layers.md) to style boxes, masks,
+labels, paths, and pose geometry with live examples.

--- a/docs/public/guides/detections-and-rendering.md
+++ b/docs/public/guides/detections-and-rendering.md
@@ -116,6 +116,10 @@ Use a custom style object when the base classes are not expressive enough. The
 contract stays the same: detections remain semantic data, and styles resolve how
 that data should be presented.
 
+Continue to [Visualization Layers](../visualization-layers.md) for focused box,
+mask, label, polygon, polyline, and keypoint examples backed by the frozen
+basketball fixture.
+
 ## Geometry Shapes
 
 One detection may carry any supported semantic geometry:

--- a/docs/public/guides/presentation-styles.md
+++ b/docs/public/guides/presentation-styles.md
@@ -17,6 +17,10 @@ In `supervision-js`, the equivalent concept is split into two parts:
 This keeps detections as semantic model output while the renderer owns the
 performance-sensitive drawing strategy.
 
+For focused, live examples, open [Visualization Layers](../visualization-layers.md).
+Each existing layer has a basketball fixture playground whose controls update
+both the renderer and a minimal `setPresentation()` snippet.
+
 ## Start With Base Styles
 
 Use `BaseBoxStyle`, `BaseMaskStyle`, `BasePolygonStyle`,

--- a/docs/public/index.md
+++ b/docs/public/index.md
@@ -6,9 +6,17 @@
       <p class="supervision-home__lede">
         <code>supervision</code> is a browser-native TypeScript library for interactive computer vision media. A media session keeps the visible frame, detections, styles, interaction, and playback on one timing reference.
       </p>
+      <nav class="supervision-home__entrypoints" aria-label="Documentation entry points">
+        <span>Explore</span>
+        <a href="documents/Visualization_Layers.html">Visualization layers</a>
+        <a href="documents/Quickstart.html">Quickstart</a>
+        <a href="documents/Recipes.html">Recipes</a>
+        <a href="modules/Styles.html">API reference</a>
+      </nav>
       <p class="supervision-home__install"><code>npm install supervision</code></p>
       <div class="supervision-home__actions">
-        <a class="supervision-home__button supervision-home__button--primary" href="documents/Application_Integration.html">Get started</a>
+        <a class="supervision-home__button supervision-home__button--primary" href="documents/Quickstart.Application_Integration.html">Get started</a>
+        <a class="supervision-home__button supervision-home__button--secondary" href="documents/Visualization_Layers.html">Explore visualization layers</a>
         <a class="supervision-home__button supervision-home__button--secondary" data-supervision-demo-link href="demo/">Open the demo</a>
       </div>
     </div>
@@ -42,7 +50,7 @@
     </div>
     <p class="supervision-home__playground-note">
       The playground is a small consumer of <code>supervision</code>, using the same session, detection, and style contracts available to your application.
-      <a href="documents/Detections_And_Rendering.html">Learn about detection rendering <span aria-hidden="true">→</span></a>
+      <a href="documents/Core_Concepts.Detections_And_Rendering.html">Learn about detection rendering <span aria-hidden="true">→</span></a>
     </p>
   </section>
   <section class="supervision-home__section" aria-labelledby="quick-start-title">
@@ -55,7 +63,7 @@
         <p>
           Give a session a container and media. It prepares the renderer, exposes state for your UI, and provides playback and detection controls without asking React or your app to run another frame loop.
         </p>
-        <a href="documents/Media_Sessions.html">Learn how media sessions work <span aria-hidden="true">→</span></a>
+        <a href="documents/Core_Concepts.Media_Sessions.html">Learn how media sessions work <span aria-hidden="true">→</span></a>
       </div>
       <pre><code class="language-ts">import { createMediaSession } from "supervision";
 const container = document.querySelector&lt;HTMLElement&gt;("#viewer");
@@ -87,19 +95,19 @@ console.log(state.status, state.activities);
         <span class="supervision-home__capability-number">01</span>
         <h3>Media and playback</h3>
         <p>Images, video, and browser media streams with preparation, normalization, seeking, stepping, rate control, and current-frame refresh.</p>
-        <a href="documents/Media_Preparation.html">Media preparation</a>
+        <a href="documents/Core_Concepts.Media_Preparation.html">Media preparation</a>
       </article>
       <article class="supervision-home__capability-card">
         <span class="supervision-home__capability-number">02</span>
         <h3>Detection rendering</h3>
         <p>Boxes, masks, polygons, polylines, keypoints, labels, class colors, and presentation styles selected from canonical media timing.</p>
-        <a href="documents/Detections_And_Rendering.html">Detections and rendering</a>
+        <a href="documents/Core_Concepts.Detections_And_Rendering.html">Detections and rendering</a>
       </article>
       <article class="supervision-home__capability-card">
         <span class="supervision-home__capability-number">03</span>
         <h3>Interaction and editing</h3>
         <p>Renderer-synchronized picking plus host-owned editing engines, persistence, undo/redo policy, and annotation commits.</p>
-        <a href="documents/Interactive_Picking.html">Interactive picking</a>
+        <a href="documents/Recipes.Interactive_Picking.html">Interactive picking</a>
       </article>
     </div>
   </section>
@@ -153,7 +161,7 @@ console.log(state.status, state.activities);
       <p>
         The public API is deliberately smaller than the implementation. It gives applications the media, detections, styles, interaction, state, and lifecycle primitives they need without coupling them to a scene graph, decoder, worker protocol, or prepared-artifact format.
       </p>
-      <a class="supervision-home__text-link" href="documents/Public_API.html">Explore the public API <span aria-hidden="true">→</span></a>
+      <a class="supervision-home__text-link" href="documents/Core_Concepts.Public_API.html">Explore the public API <span aria-hidden="true">→</span></a>
     </div>
     <div class="supervision-home__boundary-card">
       <div>
@@ -170,10 +178,10 @@ console.log(state.status, state.activities);
     <p class="supervision-home__eyebrow">Keep learning</p>
     <h2 id="next-title">Choose the path that matches your integration.</h2>
     <nav class="supervision-home__next-grid" aria-label="Documentation paths">
-      <a href="documents/Application_Integration.html"><strong>Application integration</strong><span>Install, mount, own the lifecycle.</span></a>
-      <a href="documents/Static_Detections.html"><strong>Static detections</strong><span>Render a known sequence of prediction frames.</span></a>
-      <a href="documents/Streaming_Detections.html"><strong>Streaming detections</strong><span>Ingest model output while media plays.</span></a>
-      <a href="documents/React_Integration.html"><strong>React integration</strong><span>Wrap a vanilla session without moving its hot path into React.</span></a>
+      <a href="documents/Quickstart.html"><strong>Quickstart</strong><span>Install, mount, and render your first detections.</span></a>
+      <a href="documents/Visualization_Layers.html"><strong>Visualization layers</strong><span>Style boxes, masks, labels, polygons, and pose in live playgrounds.</span></a>
+      <a href="documents/Core_Concepts.html"><strong>Core concepts</strong><span>Understand sessions, semantic detections, styles, and preparation.</span></a>
+      <a href="documents/Recipes.html"><strong>Recipes</strong><span>Apply focused patterns for sources, picking, lifecycle, and React.</span></a>
     </nav>
   </section>
 </div>

--- a/docs/public/recipes.md
+++ b/docs/public/recipes.md
@@ -1,0 +1,22 @@
+---
+title: Recipes
+children:
+  - ./recipes/session-lifecycle.md
+  - ./recipes/multiple-detection-sources.md
+  - ./recipes/interactive-picking.md
+  - ./recipes/progressive-upload-normalization.md
+  - ./recipes/react-integration.md
+---
+
+# Recipes
+
+Focused integration patterns built on the session-first public API.
+
+- [Session lifecycle](./recipes/session-lifecycle.md)
+- [Multiple detection sources](./recipes/multiple-detection-sources.md)
+- [Interactive picking](./recipes/interactive-picking.md)
+- [Progressive upload normalization](./recipes/progressive-upload-normalization.md)
+- [React integration](./recipes/react-integration.md)
+
+For visual styling, use the focused playgrounds under
+[Visualization Layers](./visualization-layers.md).

--- a/docs/public/typedoc-custom.css
+++ b/docs/public/typedoc-custom.css
@@ -254,6 +254,17 @@ body {
   padding: 0 clamp(1rem, 2.4vw, 2.25rem) !important;
 }
 
+@media (min-width: 770px) {
+  .container-main:not(.supervision-docs--home-layout) {
+    grid-template-areas: "sidebar content" !important;
+    grid-template-columns: minmax(13rem, 15rem) minmax(0, 1fr) !important;
+  }
+
+  .container-main:not(.supervision-docs--home-layout) .page-menu {
+    display: none !important;
+  }
+}
+
 .col-content {
   padding: clamp(2rem, 5vw, 4rem) 0 !important;
   scroll-padding-top: 6.5rem;
@@ -397,6 +408,43 @@ pre > button {
   padding-right: 1.1rem !important;
 }
 
+.supervision-docs__sidebar-home {
+  align-items: center;
+  color: var(--rf-gray-900) !important;
+  display: flex !important;
+  font-size: 0.94rem !important;
+  font-weight: 760 !important;
+  margin-bottom: 0.8rem;
+  min-height: 2.2rem;
+  padding: 0.45rem 0.65rem !important;
+}
+
+.supervision-docs__nav-section-title {
+  color: var(--rf-gray-400);
+  font-size: 0.66rem;
+  font-weight: 780;
+  letter-spacing: 0.1em;
+  margin: 1.1rem 0 0.35rem;
+  padding-inline: 0.65rem;
+  text-transform: uppercase;
+}
+
+.site-menu .tsd-navigation > ul > li > details > summary {
+  border-radius: 8px;
+  min-height: 2.25rem;
+  padding-block: 0.25rem;
+}
+
+.site-menu .tsd-navigation > ul > li > details > ul {
+  border-left: 1px solid var(--rf-violet-100);
+  margin: 0.2rem 0 0.65rem 0.72rem;
+  padding-left: 0.55rem;
+}
+
+.site-menu .tsd-navigation > ul > li > details > ul .tsd-kind-icon {
+  display: none;
+}
+
 .page-menu {
   border-left: 1px solid var(--rf-gray-100);
   padding-left: 1.1rem !important;
@@ -521,29 +569,73 @@ pre > button {
 }
 
 /* The generated reference pages use TypeDoc's three-column, scrollable pane.
- * The home page is an editorial landing page, so it intentionally gets one
- * document-flow column without altering reference-page navigation. */
+ * The home keeps the useful left navigation, drops the redundant right outline,
+ * and lets its editorial content flow normally beside the compact tree. */
 .container-main.supervision-docs--home-layout {
-  display: block !important;
+  align-items: start;
+  bottom: auto !important;
+  display: grid !important;
+  grid-template-columns: minmax(13rem, 15rem) minmax(0, 1fr);
   height: auto !important;
+  inset: auto !important;
   max-width: 1580px !important;
+  min-height: 0 !important;
   overflow: visible !important;
+  position: static !important;
+  transform: none !important;
 }
 
-.container-main.supervision-docs--home-layout > :not(.col-content) {
+.container-main.supervision-docs--home-layout > .col-menu {
   display: none !important;
+}
+
+.container-main.supervision-docs--home-layout > .col-sidebar {
+  align-self: start;
+  display: block !important;
+  height: auto !important;
+  max-height: calc(100vh - 4.5rem);
+  min-height: 0 !important;
+  overflow-y: auto;
+  position: sticky;
+  top: 4.5rem;
+}
+
+.container-main.supervision-docs--home-layout .site-menu {
+  padding-top: clamp(1.15rem, 2.5vw, 1.65rem) !important;
 }
 
 .container-main.supervision-docs--home-layout > .col-content {
   height: auto !important;
-  margin: 0 auto !important;
+  margin: 0 !important;
   max-width: 72rem !important;
   overflow: visible !important;
   width: 100% !important;
 }
 
-html.supervision-docs--home #tsd-toolbar-menu-trigger {
-  display: none;
+.supervision-docs__api-reference > details > summary {
+  align-items: center;
+  color: var(--rf-gray-700);
+  display: flex;
+  font-size: 0.76rem;
+  font-weight: 760;
+  justify-content: space-between;
+  letter-spacing: 0.07em;
+  padding: 0.72rem 0.65rem;
+  text-transform: uppercase;
+}
+
+.supervision-docs__api-reference > details > summary small {
+  align-items: center;
+  background: var(--rf-violet-50);
+  border: 1px solid var(--rf-violet-100);
+  border-radius: 999px;
+  color: var(--rf-violet-700);
+  display: inline-flex;
+  font-size: 0.64rem;
+  justify-content: center;
+  letter-spacing: 0;
+  min-width: 1.25rem;
+  padding: 0.08rem 0.28rem;
 }
 
 .supervision-home {
@@ -606,6 +698,35 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
   color: var(--rf-gray-700);
   font-size: 0.95rem;
   margin-bottom: 1.6rem !important;
+}
+
+.supervision-home__entrypoints {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.7rem;
+  margin: 1.35rem 0 1.1rem;
+}
+
+.supervision-home__entrypoints > span {
+  color: var(--rf-gray-500);
+  font-size: 0.72rem;
+  font-weight: 760;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.supervision-home__entrypoints a {
+  color: var(--rf-violet-700) !important;
+  font-size: 0.83rem;
+  font-weight: 690;
+  text-decoration: none !important;
+}
+
+.supervision-home__entrypoints a:hover {
+  color: var(--rf-violet-900) !important;
+  text-decoration: underline !important;
+  text-underline-offset: 0.18em;
 }
 
 .supervision-home__install code {
@@ -700,19 +821,16 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
 .supervision-home__scene-layer--media {
   background: #25213a;
   color: #ffffff;
-  transform: translateX(0.45rem);
 }
 
 .supervision-home__scene-layer--masks {
   background: #e9dfff;
   border-color: #c9adff;
-  transform: translateX(-0.2rem);
 }
 
 .supervision-home__scene-layer--labels {
   background: #ffffff;
   border-color: var(--rf-gray-300);
-  transform: translateX(0.2rem);
 }
 
 .supervision-home__section {
@@ -761,6 +879,30 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
   font-weight: 720;
   margin-left: 0.3rem;
   text-decoration: none !important;
+}
+
+.supervision-layer-playground {
+  background: linear-gradient(135deg, #fcfbff, var(--rf-violet-50));
+  border: 1px solid #dccdff;
+  border-radius: 16px;
+  box-shadow: 0 14px 36px rgba(75, 34, 142, 0.1);
+  margin: 1.6rem 0 2rem;
+  overflow: hidden;
+}
+
+.tsd-typography:has(.supervision-layer-playground) {
+  max-width: 72rem;
+}
+
+.tsd-typography:has(.supervision-layer-playground) > p {
+  max-width: 55rem;
+}
+
+.supervision-layer-playground iframe {
+  border: 0;
+  display: block;
+  height: clamp(45rem, 66vw, 49rem);
+  width: 100%;
 }
 
 .supervision-home__quick-start {
@@ -1004,6 +1146,14 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
     padding-inline: 1rem !important;
   }
 
+  .container-main.supervision-docs--home-layout {
+    display: block !important;
+  }
+
+  .container-main.supervision-docs--home-layout > .col-sidebar {
+    display: none !important;
+  }
+
   .col-content {
     padding-block: 2rem !important;
   }
@@ -1030,6 +1180,10 @@ html.supervision-docs--home #tsd-toolbar-menu-trigger {
 
   .supervision-home__playground-frame iframe {
     height: 57rem;
+  }
+
+  .supervision-layer-playground iframe {
+    height: 55rem;
   }
 }
 

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -70,6 +70,8 @@
     document.documentElement.dataset.theme = "light";
     localStorage.setItem("tsd-theme", "light");
     brandToolbar();
+    configureEmbeddedPlaygrounds(document);
+    customizeSidebar();
     decorateHomePage();
     upgradeIcons(document);
 
@@ -78,6 +80,8 @@
         for (const node of mutation.addedNodes) {
           if (node instanceof Element) {
             upgradeIcons(node);
+            configureEmbeddedPlaygrounds(node);
+            customizeSidebar();
           }
         }
       }
@@ -101,25 +105,114 @@
     home
       .closest(".container-main")
       ?.classList.add("supervision-docs--home-layout");
-    configureHomePlayground(home);
+    configureHomeDemoLink(home);
   }
 
-  function configureHomePlayground(home) {
-    const playground = home.querySelector(
-      "iframe[data-supervision-playground-src]",
-    );
-    const deployedSource = playground?.dataset.supervisionPlaygroundSrc;
+  function configureEmbeddedPlaygrounds(root) {
+    const playgrounds =
+      root instanceof Element &&
+      root.matches("iframe[data-supervision-playground-src]")
+        ? [root]
+        : root.querySelectorAll?.("iframe[data-supervision-playground-src]");
 
-    if (!playground || !deployedSource) {
+    if (!playgrounds) {
       return;
     }
 
-    playground.src = resolveDemoUrl(deployedSource);
+    for (const playground of playgrounds) {
+      const deployedSource = playground.dataset.supervisionPlaygroundSrc;
 
+      if (
+        deployedSource &&
+        playground.dataset.supervisionPlaygroundReady !== "true"
+      ) {
+        playground.src = resolveDemoUrl(deployedSource);
+        playground.dataset.supervisionPlaygroundReady = "true";
+      }
+    }
+  }
+
+  window.addEventListener("message", (event) => {
+    const payload = event.data;
+
+    if (
+      !payload ||
+      payload.type !== "supervision-js:playground-height" ||
+      !Number.isFinite(payload.height)
+    ) {
+      return;
+    }
+
+    const playground = Array.from(
+      document.querySelectorAll("iframe[data-supervision-playground-src]"),
+    ).find((iframe) => iframe.contentWindow === event.source);
+
+    if (!playground) {
+      return;
+    }
+
+    const expectedOrigin = new URL(playground.src, window.location.href).origin;
+
+    if (event.origin !== expectedOrigin) {
+      return;
+    }
+
+    playground.style.height = `${Math.ceil(payload.height)}px`;
+  });
+
+  function configureHomeDemoLink(home) {
     const demoLink = home.querySelector("[data-supervision-demo-link]");
     if (demoLink) {
       demoLink.href = resolveDemoUrl(demoLink.getAttribute("href") ?? "demo/");
     }
+  }
+
+  function customizeSidebar() {
+    const navigation = document.querySelector(".site-menu .tsd-navigation");
+    const rootLink = navigation?.querySelector(":scope > a");
+
+    if (!navigation || !rootLink) {
+      return;
+    }
+
+    const base = document.documentElement.dataset.base ?? "./";
+    rootLink.href = new URL(`${base}index.html`, window.location.href).href;
+    rootLink.textContent = "Home";
+    rootLink.classList.add("supervision-docs__sidebar-home");
+
+    const navList = navigation.querySelector(":scope > ul");
+    if (!navList || navList.dataset.supervisionStructured === "true") {
+      return;
+    }
+
+    const moduleItems = Array.from(navList.children).filter((item) =>
+      item.querySelector?.('.tsd-kind-icon[aria-label="Module"]'),
+    );
+
+    if (moduleItems.length === 0) {
+      return;
+    }
+
+    const apiItem = document.createElement("li");
+    apiItem.className = "supervision-docs__api-reference";
+    const details = document.createElement("details");
+    const summary = document.createElement("summary");
+    const label = document.createElement("span");
+    const count = document.createElement("small");
+    const apiList = document.createElement("ul");
+
+    label.textContent = "API Reference";
+    count.textContent = String(moduleItems.length);
+    summary.append(label, count);
+    details.append(summary, apiList);
+    apiItem.append(details);
+
+    for (const moduleItem of moduleItems) {
+      apiList.append(moduleItem);
+    }
+
+    navList.append(apiItem);
+    navList.dataset.supervisionStructured = "true";
   }
 
   function resolveDemoUrl(deployedPath) {
@@ -131,9 +224,12 @@
         window.location.hostname === "127.0.0.1") &&
       window.location.port === "5175";
 
-    return isStandaloneLocalDocs
-      ? `http://127.0.0.1:5173/${deployedPath.includes("?") ? deployedPath.slice(deployedPath.indexOf("?")) : ""}`
-      : new URL(deployedPath, window.location.href).href;
+    if (isStandaloneLocalDocs) {
+      return `http://127.0.0.1:5173/${deployedPath.includes("?") ? deployedPath.slice(deployedPath.indexOf("?")) : ""}`;
+    }
+
+    const base = document.documentElement.dataset.base ?? "./";
+    return new URL(`${base}${deployedPath}`, window.location.href).href;
   }
 
   function brandToolbar() {

--- a/docs/public/visualization-layers.md
+++ b/docs/public/visualization-layers.md
@@ -1,0 +1,40 @@
+---
+title: Visualization Layers
+children:
+  - ./visualization-layers/boxes.md
+  - ./visualization-layers/masks.md
+  - ./visualization-layers/labels.md
+  - ./visualization-layers/polygons.md
+  - ./visualization-layers/polylines.md
+  - ./visualization-layers/keypoints-and-skeletons.md
+---
+
+# Visualization Layers
+
+A visualization layer is the public unit that connects semantic detection data
+to a presentation style. Consumers choose the layers they want; the browser
+renderer decides how to draw them efficiently.
+
+This name is intentional:
+
+- **detections** own geometry, identity, class, confidence, and masks;
+- **styles** describe how one supported layer should look;
+- **visualization layers** are the user-visible capabilities enabled through
+  `MediaRendererPresentation`;
+- **annotator facades** may later compose these layers into higher-level use
+  cases;
+- PixiJS containers, shaders, textures, and prepared artifacts remain private
+  renderer details.
+
+The focused playgrounds below use the frozen basketball fixture, a real
+`MediaSession`, and the same style contracts available from the published
+`supervision` package. Change a control to update both the scene and its
+minimal code snippet. Polylines remain documented without a playground until a
+frozen fixture contains semantic open-path data.
+
+- [Boxes](./visualization-layers/boxes.md)
+- [Masks](./visualization-layers/masks.md)
+- [Labels](./visualization-layers/labels.md)
+- [Polygons](./visualization-layers/polygons.md)
+- [Polylines](./visualization-layers/polylines.md)
+- [Keypoints and skeletons](./visualization-layers/keypoints-and-skeletons.md)

--- a/docs/public/visualization-layers/boxes.md
+++ b/docs/public/visualization-layers/boxes.md
@@ -1,0 +1,42 @@
+---
+title: Boxes
+summary: Draw and style axis-aligned detection bounds.
+---
+
+# Boxes
+
+Boxes visualize a detection's center-based `rect` geometry. Use
+`BaseBoxStyle` to control shape, corner radius, fill, stroke, visibility, and
+per-detection styling without changing the detection data.
+
+<div class="supervision-layer-playground">
+  <iframe
+    data-supervision-playground-src="demo/?embed=visualization-layer&amp;layer=boxes"
+    loading="lazy"
+    title="Interactive box visualization playground"
+  ></iframe>
+</div>
+
+## Add a box layer
+
+```ts
+session.setPresentation({
+  boxStyle: new BaseBoxStyle({
+    fill: { alpha: 0.12 },
+    stroke: { width: 3 },
+  }),
+});
+```
+
+Rectangle `x` and `y` are the center in media pixels. Shape and opacity belong
+to the style; they should not be stored on the detection.
+
+Use `null` to disable boxes while preserving every rectangle:
+
+```ts
+session.setPresentation({ boxStyle: null });
+```
+
+See [Presentation Styles](../guides/presentation-styles.md) for dynamic class
+colors and confidence predicates, or the `BaseBoxStyle` API reference for all
+options.

--- a/docs/public/visualization-layers/keypoints-and-skeletons.md
+++ b/docs/public/visualization-layers/keypoints-and-skeletons.md
@@ -1,0 +1,38 @@
+---
+title: Keypoints and Skeletons
+summary: Style pose markers and the edges that connect them.
+---
+
+# Keypoints and Skeletons
+
+Keypoints and skeleton edges share one semantic geometry and one
+`BaseKeypointStyle`. Marker radius, marker fill, edge stroke, and edge shadow
+can change independently without rewriting pose predictions.
+
+<div class="supervision-layer-playground">
+  <iframe
+    data-supervision-playground-src="demo/?embed=visualization-layer&amp;layer=keypoints"
+    loading="lazy"
+    title="Interactive keypoint and skeleton visualization playground"
+  ></iframe>
+</div>
+
+## Add a keypoint layer
+
+```ts
+session.setPresentation({
+  keypointStyle: new BaseKeypointStyle({
+    edgeStroke: { width: 2 },
+    markerFill: { alpha: 1 },
+    radius: 5,
+  }),
+});
+```
+
+COCO-compatible visibility distinguishes absent, occluded, and visible points.
+Class-specific skeleton definitions may override individual vertex or edge
+colors while retaining the same style contract.
+
+The basketball fixture attaches pose keypoints to the matching segmentation
+detections, so boxes, masks, labels, polygons, and pose stay aligned on one
+media timeline.

--- a/docs/public/visualization-layers/labels.md
+++ b/docs/public/visualization-layers/labels.md
@@ -1,0 +1,37 @@
+---
+title: Labels
+summary: Resolve class, confidence, and custom text next to detections.
+---
+
+# Labels
+
+Labels derive display text from semantic detections. `BaseLabelStyle` can use a
+class name, caller metadata, or a custom resolver and can include confidence
+without storing presentation strings in model output.
+
+<div class="supervision-layer-playground">
+  <iframe
+    data-supervision-playground-src="demo/?embed=visualization-layer&amp;layer=labels"
+    loading="lazy"
+    title="Interactive label visualization playground"
+  ></iframe>
+</div>
+
+## Add a label layer
+
+```ts
+session.setPresentation({
+  labelStyle: new BaseLabelStyle({
+    background: { alpha: 0.9 },
+    includeConfidence: true,
+    textStyle: { fontSize: 14 },
+  }),
+});
+```
+
+Labels need a resolvable detection rectangle for placement, but the box layer
+does not need to be visible. Use placement and offset options to move text
+without changing the geometry.
+
+See [Interactive Picking](../recipes/interactive-picking.md) for hover-only
+labels and selection-aware presentation.

--- a/docs/public/visualization-layers/masks.md
+++ b/docs/public/visualization-layers/masks.md
@@ -1,0 +1,37 @@
+---
+title: Masks
+summary: Render compressed RLE masks with independent fill and outline styling.
+---
+
+# Masks
+
+Masks stay semantic as compressed RLE in detection frames. `BaseMaskStyle`
+controls the visible fill, global opacity, outline, and render mode while the
+browser package privately prepares efficient render artifacts.
+
+<div class="supervision-layer-playground">
+  <iframe
+    data-supervision-playground-src="demo/?embed=visualization-layer&amp;layer=masks"
+    loading="lazy"
+    title="Interactive mask visualization playground"
+  ></iframe>
+</div>
+
+## Add a mask layer
+
+```ts
+session.setPresentation({
+  maskStyle: new BaseMaskStyle({
+    fillAlpha: 1,
+    opacity: 0.72,
+    stroke: { alpha: 1, width: 2 },
+  }),
+});
+```
+
+`opacity` applies to the complete mask layer and can be updated cheaply.
+`fillAlpha` is part of prepared fill styling and remains separate so an outline
+can stay opaque.
+
+See [Detections And Rendering](../guides/detections-and-rendering.md) for the
+semantic-mask and prepared-artifact boundary.

--- a/docs/public/visualization-layers/polygons.md
+++ b/docs/public/visualization-layers/polygons.md
@@ -1,0 +1,36 @@
+---
+title: Polygons
+summary: Draw closed media-space geometry with independent fill and stroke.
+---
+
+# Polygons
+
+Polygons are closed paths with at least three media-pixel points.
+`BasePolygonStyle` controls their fill, stroke, and visibility independently
+from boxes or masks on the same detection.
+
+<div class="supervision-layer-playground">
+  <iframe
+    data-supervision-playground-src="demo/?embed=visualization-layer&amp;layer=polygons"
+    loading="lazy"
+    title="Interactive polygon visualization playground"
+  ></iframe>
+</div>
+
+## Add a polygon layer
+
+```ts
+session.setPresentation({
+  polygonStyle: new BasePolygonStyle({
+    fill: { alpha: 0.16 },
+    stroke: { width: 3 },
+  }),
+});
+```
+
+The basketball fixture keeps its source masks beside deterministic,
+mask-derived polygons. That makes it possible to compare the two layers without
+recovering geometry from rendered pixels.
+
+See [Detections And Rendering](../guides/detections-and-rendering.md) for the
+complete detection geometry contract.

--- a/docs/public/visualization-layers/polylines.md
+++ b/docs/public/visualization-layers/polylines.md
@@ -1,0 +1,27 @@
+---
+title: Polylines
+summary: Draw open paths in media coordinates.
+---
+
+# Polylines
+
+Polylines are open paths with at least two media-pixel points. Use
+`BasePolylineStyle` for guides, trajectories, and other paths that must not
+close back to their first point.
+
+> **Fixture status:** the browser renderer supports polylines, but the
+> committed basketball fixture has no semantic open-path data. This page does
+> not fabricate an overlay solely for the docs. A focused playground will ship
+> with a frozen, reproducible fixture that contains real polyline input.
+
+## Add a polyline layer
+
+```ts
+session.setPresentation({
+  polylineStyle: new BasePolylineStyle({
+    stroke: { width: 4 },
+  }),
+});
+```
+
+Use a polygon instead when the path represents a closed region with fill.

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -156,12 +156,120 @@ test("the docs home embeds the local basketball playground", async () => {
     homepage,
     /data-supervision-playground-src="demo\/\?embed=docs-playground"/,
   );
+  assert.match(
+    homepage,
+    /href="documents\/Visualization_Layers\.html">Visualization layers</,
+  );
+  assert.match(homepage, /aria-label="Documentation entry points"/);
   assert.match(homepage, /title="Interactive basketball detection playground"/);
   assert.match(
     toolbarScript,
     /window\.location\.port === "5175"[\s\S]*?http:\/\/127\.0\.0\.1:5173\//,
   );
   assert.equal(packageJson.scripts["docs:dev"], "npm run dev:demo-docs");
+});
+
+test("TypeDoc presents public guidance as four navigable sections", async () => {
+  const config = JSON.parse(
+    await readFile(path.join(rootDir, "typedoc.json"), "utf8"),
+  );
+
+  assert.deepEqual(config.projectDocuments, [
+    "docs/public/getting-started.md",
+    "docs/public/concepts.md",
+    "docs/public/visualization-layers.md",
+    "docs/public/recipes.md",
+  ]);
+  assert.deepEqual(config.sort, ["documents-first", "source-order"]);
+  assert.equal(config.sortEntryPoints, false);
+  assert.deepEqual(config.navigationLeaves, [
+    "Detections",
+    "Editing",
+    "Interactions",
+    "Media Preparation",
+    "Media Sessions",
+    "Rendering",
+    "Styles",
+  ]);
+});
+
+test("every fixture-backed visualization layer has a focused live playground", async () => {
+  const layers = ["boxes", "masks", "labels", "polygons", "keypoints"];
+  const pages = {
+    boxes: "boxes.md",
+    keypoints: "keypoints-and-skeletons.md",
+    labels: "labels.md",
+    masks: "masks.md",
+    polygons: "polygons.md",
+  };
+  const visualizationIndex = await readFile(
+    path.join(publicDocsDir, "visualization-layers.md"),
+    "utf8",
+  );
+  const toolbarScript = await readFile(
+    path.join(publicDocsDir, "typedoc-icons.js"),
+    "utf8",
+  );
+  const docsCss = await readFile(
+    path.join(publicDocsDir, "typedoc-custom.css"),
+    "utf8",
+  );
+
+  for (const layer of layers) {
+    const page = await readFile(
+      path.join(publicDocsDir, "visualization-layers", pages[layer]),
+      "utf8",
+    );
+
+    assert.match(
+      page,
+      new RegExp(
+        `data-supervision-playground-src="demo/\\?embed=visualization-layer&amp;layer=${layer}"`,
+      ),
+    );
+    assert.match(page, /session\.setPresentation\(\{/);
+    assert.match(visualizationIndex, new RegExp(pages[layer]));
+  }
+
+  assert.match(toolbarScript, /iframe\[data-supervision-playground-src\]/);
+  assert.match(
+    toolbarScript,
+    /const base = document\.documentElement\.dataset\.base \?\? "\.\/";[\s\S]*?new URL\(`\$\{base\}\$\{deployedPath\}`/,
+  );
+  assert.match(toolbarScript, /supervision-js:playground-height/);
+  assert.match(toolbarScript, /api-reference/);
+  assert.match(
+    toolbarScript,
+    /const details = document\.createElement\("details"\)/,
+  );
+  assert.match(toolbarScript, /label\.textContent = "API Reference"/);
+  assert.match(
+    docsCss,
+    /supervision-docs--home-layout \{[\s\S]*?min-height: 0 !important;[\s\S]*?position: static !important;[\s\S]*?transform: none !important;/,
+  );
+  assert.match(
+    docsCss,
+    /supervision-docs--home-layout > \.col-sidebar \{[\s\S]*?align-self: start;[\s\S]*?min-height: 0 !important;/,
+  );
+  assert.match(
+    docsCss,
+    /container-main:not\(\.supervision-docs--home-layout\) \{[\s\S]*?grid-template-areas: "sidebar content" !important;[\s\S]*?grid-template-columns: minmax\(13rem, 15rem\) minmax\(0, 1fr\) !important;/,
+  );
+  assert.match(
+    docsCss,
+    /container-main:not\(\.supervision-docs--home-layout\) \.page-menu \{[\s\S]*?display: none !important;/,
+  );
+  assert.match(
+    docsCss,
+    /\.tsd-typography:has\(\.supervision-layer-playground\) \{[\s\S]*?max-width: 72rem;/,
+  );
+
+  const polylinePage = await readFile(
+    path.join(publicDocsDir, "visualization-layers", "polylines.md"),
+    "utf8",
+  );
+  assert.doesNotMatch(polylinePage, /data-supervision-playground-src/);
+  assert.match(polylinePage, /Fixture status:/);
 });
 
 test("Render preview trusts only its assigned hostname", async () => {

--- a/typedoc.json
+++ b/typedoc.json
@@ -20,13 +20,36 @@
   "lightHighlightTheme": "github-light",
   "darkHighlightTheme": "github-dark",
   "name": "supervision-js",
+  "navigation": {
+    "compactFolders": true,
+    "excludeReferences": true,
+    "includeCategories": false,
+    "includeFolders": false,
+    "includeGroups": false
+  },
+  "navigationLeaves": [
+    "Detections",
+    "Editing",
+    "Interactions",
+    "Media Preparation",
+    "Media Sessions",
+    "Rendering",
+    "Styles"
+  ],
   "out": "docs/site",
   "plugin": ["typedoc-rhineai-theme"],
-  "projectDocuments": ["docs/public/guides/*.md", "docs/public/recipes/*.md"],
+  "projectDocuments": [
+    "docs/public/getting-started.md",
+    "docs/public/concepts.md",
+    "docs/public/visualization-layers.md",
+    "docs/public/recipes.md"
+  ],
   "readme": "docs/public/index.md",
   "searchInComments": true,
   "searchInDocuments": true,
   "sourceLinkExternal": true,
   "sourceLinkTemplate": "https://github.com/roboflow/supervision-js/blob/{gitRevision}/{path}#L{line}",
+  "sort": ["documents-first", "source-order"],
+  "sortEntryPoints": false,
   "tsconfig": "tsconfig.docs.json"
 }


### PR DESCRIPTION
# Description

Reorganizes the public documentation around four clear paths: Quickstart, Core Concepts, Visualization Layers, and Recipes. Visualization Layers is the consumer-facing abstraction connecting semantic detections to presentation styles while keeping renderer internals private.

Adds focused guides and live basketball playgrounds for boxes, masks, labels, polygons, polylines, and keypoints/skeletons. Each playground runs a real media session, exposes only relevant controls, and keeps a minimal `session.setPresentation()` snippet synchronized with those controls. The polyline page adds a deterministic docs-only semantic guide because the frozen fixture has no open paths.

Also keeps the generated API modules as compact sidebar leaves, labels their section as API Reference, updates existing guide/home links, and documents the maintenance contract for future visualization layers. No published package API changes are included.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- Ran `npm run verify` (548 Vitest tests plus formatting, lint, typecheck, package smoke, library/demo/example/benchmark builds)
- Ran `npm run pages:build` and verified the root docs, `/demo/`, and all six generated visualization-layer documents in the final artifact
- Browser-tested desktop and mobile docs layouts, sidebar hierarchy, playback, live sliders, synchronized snippets, fully opaque masks at 100%, and the docs-only polyline fixture
- Verified the browser console remained free of errors across boxes, masks, polylines, and keypoints/skeletons

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- hosting
- Static docs/demo artifact only; no npm package release is required

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)