### PR TITLE
Superseded: icon primitive

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -174,17 +174,8 @@ export {
   type IdMaskFrame,
   type IdMaskInstruction,
 } from "#utils/id-mask-frame";
-export {
-  resolveEllipseSegmentCount,
-  resolveMarkerGeometry,
-  sampleEllipseArc,
-} from "#utils/shape-geometry";
-export type {
-  EllipseGeometry,
-  MarkerGeometry,
-  MarkerGeometryInput,
-  SampledShapePath,
-} from "#utils/shape-geometry";
+export { resolveMarkerGeometry, sampleEllipseArc } from "#utils/shape-geometry";
+export type { MarkerGeometry, SampledShapePath } from "#utils/shape-geometry";
 export { includeDefined } from "#utils/object";
 export { lightenColor, resolveContrastTextColor } from "#utils/color";
 export { resolveAnnotationStyleState } from "#utils/annotation-visibility";
@@ -361,14 +352,9 @@ export {
   ShapeInstructionKind,
 } from "#types/shape-style";
 export type {
-  ClosedEllipseShapeInstruction,
-  ClosedMarkerShapeInstruction,
-  ClosedPathShapeInstruction,
-  CrossMarkerShapeInstruction,
-  EllipseArcShapeInstruction,
   EllipseShapeInstruction,
+  IconShapeInstruction,
   MarkerShapeInstruction,
-  OpenPathShapeInstruction,
   PathShapeInstruction,
   ShapeDrawInstruction,
   ShapeStyle,

--- a/packages/core/src/types/shape-style.ts
+++ b/packages/core/src/types/shape-style.ts
@@ -1,9 +1,5 @@
+import type { BoxFillStyle, BoxStrokeStyle } from "#types/box-style";
 import type { Detection, Point } from "#types/detections";
-import type {
-  FillStyle,
-  OpenStrokeStyle,
-  StrokeStyle,
-} from "#types/paint-style";
 import type { AnnotationStyleContext } from "#types/style";
 
 /**
@@ -11,6 +7,7 @@ import type { AnnotationStyleContext } from "#types/style";
  */
 export enum ShapeInstructionKind {
   Ellipse = "ellipse",
+  Icon = "icon",
   Marker = "marker",
   Path = "path",
 }
@@ -37,90 +34,70 @@ export enum MarkerSizeSpace {
  * Omitting both angles draws a closed ellipse. Angles are radians measured
  * from the positive x axis before `rotation` is applied.
  */
-interface EllipseShapeInstructionBase {
+export interface EllipseShapeInstruction {
   readonly kind: ShapeInstructionKind.Ellipse;
   readonly center: Point;
   readonly radiusX: number;
   readonly radiusY: number;
   /** Rotation in radians around the center. */
   readonly rotation?: number;
+  readonly startAngle?: number;
+  readonly endAngle?: number;
+  readonly fill?: BoxFillStyle;
+  readonly stroke?: BoxStrokeStyle;
 }
-
-export interface ClosedEllipseShapeInstruction extends EllipseShapeInstructionBase {
-  readonly startAngle?: never;
-  readonly endAngle?: never;
-  readonly fill?: FillStyle;
-  readonly stroke?: StrokeStyle;
-}
-
-export interface EllipseArcShapeInstruction extends EllipseShapeInstructionBase {
-  readonly startAngle: number;
-  readonly endAngle: number;
-  readonly fill?: never;
-  readonly stroke?: OpenStrokeStyle;
-}
-
-export type EllipseShapeInstruction =
-  ClosedEllipseShapeInstruction | EllipseArcShapeInstruction;
 
 /**
  * Anchored marker at a media-space point.
  *
- * At rotation `0` a triangle points toward positive y (down in media space).
- * `center` is always the geometric center; semantic anchoring belongs to the
- * renderer that creates this lower-level instruction.
+ * At rotation `0` a triangle points toward positive y (down in media space),
+ * matching the annotator convention of marking the object beneath the tip.
  */
-interface MarkerShapeInstructionBase {
+export interface MarkerShapeInstruction {
   readonly kind: ShapeInstructionKind.Marker;
-  readonly center: Point;
+  readonly point: Point;
+  readonly shape: MarkerShape;
   /** Marker diameter in the declared size space. */
   readonly size: number;
   readonly sizeSpace: MarkerSizeSpace;
-  /** Rotation in radians around the center. */
+  /** Rotation in radians around the anchor point. */
   readonly rotation?: number;
+  readonly fill?: BoxFillStyle;
+  readonly stroke?: BoxStrokeStyle;
 }
-
-export interface ClosedMarkerShapeInstruction extends MarkerShapeInstructionBase {
-  readonly shape:
-    MarkerShape.Circle | MarkerShape.Square | MarkerShape.Triangle;
-  readonly fill?: FillStyle;
-  readonly stroke?: StrokeStyle;
-}
-
-export interface CrossMarkerShapeInstruction extends MarkerShapeInstructionBase {
-  readonly shape: MarkerShape.Cross;
-  readonly fill?: never;
-  readonly stroke?: OpenStrokeStyle;
-}
-
-export type MarkerShapeInstruction =
-  ClosedMarkerShapeInstruction | CrossMarkerShapeInstruction;
 
 /**
  * One or more disconnected subpaths sharing a single style.
  */
-interface PathShapeInstructionBase {
+export interface PathShapeInstruction {
   readonly kind: ShapeInstructionKind.Path;
   readonly segments: readonly (readonly Point[])[];
+  readonly closed: boolean;
+  readonly fill?: BoxFillStyle;
+  readonly stroke: BoxStrokeStyle;
 }
 
-export interface ClosedPathShapeInstruction extends PathShapeInstructionBase {
-  readonly closed: true;
-  readonly fill?: FillStyle;
-  readonly stroke: StrokeStyle;
+/**
+ * Image icon anchored at a media-space point.
+ *
+ * `href` is a renderer-neutral image reference (URL or data URL). Backends
+ * load and cache the image asynchronously; an icon whose image has not
+ * finished loading is skipped for that frame and drawn once available.
+ */
+export interface IconShapeInstruction {
+  readonly kind: ShapeInstructionKind.Icon;
+  readonly point: Point;
+  readonly href: string;
+  /** Icon width and height in the declared size space. */
+  readonly size: number;
+  readonly sizeSpace: MarkerSizeSpace;
 }
-
-export interface OpenPathShapeInstruction extends PathShapeInstructionBase {
-  readonly closed: false;
-  readonly fill?: never;
-  readonly stroke: OpenStrokeStyle;
-}
-
-export type PathShapeInstruction =
-  ClosedPathShapeInstruction | OpenPathShapeInstruction;
 
 export type ShapeDrawInstruction =
-  EllipseShapeInstruction | MarkerShapeInstruction | PathShapeInstruction;
+  | EllipseShapeInstruction
+  | IconShapeInstruction
+  | MarkerShapeInstruction
+  | PathShapeInstruction;
 
 export type ShapeStyleContext = AnnotationStyleContext;
 

--- a/packages/core/src/utils/shape-geometry.test.ts
+++ b/packages/core/src/utils/shape-geometry.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { MarkerShape, MarkerSizeSpace } from "#types/shape-style";
-import {
-  resolveEllipseSegmentCount,
-  resolveMarkerGeometry,
-  sampleEllipseArc,
-} from "#utils/shape-geometry";
+import { resolveMarkerGeometry, sampleEllipseArc } from "#utils/shape-geometry";
 
 describe("shape geometry", () => {
   it("samples a closed ellipse without repeating the first point", () => {
@@ -74,7 +70,7 @@ describe("shape geometry", () => {
   it("divides screen-space marker sizes by the viewport scale", () => {
     const geometry = resolveMarkerGeometry(
       {
-        center: { x: 0, y: 0 },
+        point: { x: 0, y: 0 },
         shape: MarkerShape.Circle,
         size: 12,
         sizeSpace: MarkerSizeSpace.Screen,
@@ -92,7 +88,7 @@ describe("shape geometry", () => {
   it("keeps media-space marker sizes unscaled", () => {
     const geometry = resolveMarkerGeometry(
       {
-        center: { x: 0, y: 0 },
+        point: { x: 0, y: 0 },
         shape: MarkerShape.Circle,
         size: 12,
         sizeSpace: MarkerSizeSpace.Media,
@@ -109,7 +105,7 @@ describe("shape geometry", () => {
 
   it("builds a downward-pointing triangle at rotation zero", () => {
     const geometry = resolveMarkerGeometry({
-      center: { x: 10, y: 10 },
+      point: { x: 10, y: 10 },
       shape: MarkerShape.Triangle,
       size: 8,
       sizeSpace: MarkerSizeSpace.Media,
@@ -130,7 +126,7 @@ describe("shape geometry", () => {
 
   it("builds crosses as two open diagonal subpaths", () => {
     const geometry = resolveMarkerGeometry({
-      center: { x: 0, y: 0 },
+      point: { x: 0, y: 0 },
       shape: MarkerShape.Cross,
       size: 10,
       sizeSpace: MarkerSizeSpace.Media,
@@ -150,7 +146,7 @@ describe("shape geometry", () => {
 
   it("rotates square markers around the anchor", () => {
     const geometry = resolveMarkerGeometry({
-      center: { x: 0, y: 0 },
+      point: { x: 0, y: 0 },
       rotation: Math.PI / 4,
       shape: MarkerShape.Square,
       size: 10,
@@ -162,45 +158,5 @@ describe("shape geometry", () => {
     const corner = geometry.subpaths[0]![0]!;
     expect(corner.x).toBeCloseTo(0);
     expect(corner.y).toBeCloseTo(-Math.SQRT2 * 5);
-  });
-
-  it("increases ellipse detail with on-screen size", () => {
-    const ellipse = {
-      center: { x: 0, y: 0 },
-      radiusX: 10,
-      radiusY: 5,
-    };
-
-    expect(resolveEllipseSegmentCount(ellipse, 4)).toBeGreaterThan(
-      resolveEllipseSegmentCount(ellipse, 1),
-    );
-  });
-
-  it.each([
-    [
-      "non-finite center",
-      { center: { x: Number.NaN, y: 0 }, radiusX: 1, radiusY: 1 },
-    ],
-    ["zero radius", { center: { x: 0, y: 0 }, radiusX: 0, radiusY: 1 }],
-    [
-      "incomplete arc",
-      { center: { x: 0, y: 0 }, radiusX: 1, radiusY: 1, startAngle: 0 },
-    ],
-  ])("rejects invalid ellipse geometry: %s", (_name, ellipse) => {
-    expect(() => sampleEllipseArc(ellipse)).toThrow(RangeError);
-  });
-
-  it("rejects invalid marker sizes and viewport scales", () => {
-    const marker = {
-      center: { x: 0, y: 0 },
-      shape: MarkerShape.Circle,
-      size: 0,
-      sizeSpace: MarkerSizeSpace.Screen,
-    };
-
-    expect(() => resolveMarkerGeometry(marker)).toThrow(RangeError);
-    expect(() => resolveMarkerGeometry({ ...marker, size: 10 }, 0)).toThrow(
-      RangeError,
-    );
   });
 });

--- a/packages/core/src/utils/shape-geometry.ts
+++ b/packages/core/src/utils/shape-geometry.ts
@@ -1,28 +1,13 @@
 import type { Point } from "#types/detections";
-import { MarkerShape, MarkerSizeSpace } from "#types/shape-style";
+import {
+  MarkerShape,
+  MarkerSizeSpace,
+  type EllipseShapeInstruction,
+  type MarkerShapeInstruction,
+} from "#types/shape-style";
 
 const DEFAULT_ELLIPSE_SEGMENT_COUNT = 48;
 const FULL_TURN = Math.PI * 2;
-const GEOMETRY_EPSILON = 1e-9;
-const MIN_ELLIPSE_SEGMENT_COUNT = 4;
-const MAX_ELLIPSE_SEGMENT_COUNT = 512;
-
-export interface EllipseGeometry {
-  readonly center: Point;
-  readonly radiusX: number;
-  readonly radiusY: number;
-  readonly rotation?: number;
-  readonly startAngle?: number;
-  readonly endAngle?: number;
-}
-
-export interface MarkerGeometryInput {
-  readonly center: Point;
-  readonly shape: MarkerShape;
-  readonly size: number;
-  readonly sizeSpace: MarkerSizeSpace;
-  readonly rotation?: number;
-}
 
 export interface SampledShapePath {
   readonly closed: boolean;
@@ -38,17 +23,14 @@ export interface SampledShapePath {
  * endpoints.
  */
 export function sampleEllipseArc(
-  ellipse: EllipseGeometry,
+  ellipse: Omit<EllipseShapeInstruction, "kind" | "fill" | "stroke">,
   segmentCount = DEFAULT_ELLIPSE_SEGMENT_COUNT,
 ): SampledShapePath {
-  validateEllipseGeometry(ellipse);
-  assertIntegerAtLeast(segmentCount, MIN_ELLIPSE_SEGMENT_COUNT, "segmentCount");
-
   const rotation = ellipse.rotation ?? 0;
   const startAngle = ellipse.startAngle ?? 0;
   const endAngle = ellipse.endAngle ?? startAngle + FULL_TURN;
   const range = endAngle - startAngle;
-  const closed = ellipse.startAngle === undefined;
+  const closed = Math.abs(Math.abs(range) - FULL_TURN) < 1e-9;
   const pointCount = closed ? segmentCount : segmentCount + 1;
   const cosRotation = Math.cos(rotation);
   const sinRotation = Math.sin(rotation);
@@ -68,38 +50,6 @@ export function sampleEllipseArc(
   return { closed, points };
 }
 
-/**
- * Chooses a bounded segment count from the ellipse's on-screen radius. The
- * result targets sub-pixel chord error without making tiny markers expensive.
- */
-export function resolveEllipseSegmentCount(
-  ellipse: EllipseGeometry,
-  viewportScale = 1,
-  maxErrorPixels = 0.5,
-): number {
-  validateEllipseGeometry(ellipse);
-  assertPositiveFinite(viewportScale, "viewportScale");
-  assertPositiveFinite(maxErrorPixels, "maxErrorPixels");
-
-  const screenRadius =
-    Math.max(ellipse.radiusX, ellipse.radiusY) * viewportScale;
-  assertPositiveFinite(screenRadius, "screenRadius");
-  const clampedError = Math.min(maxErrorPixels, screenRadius);
-  const maxStep =
-    clampedError === screenRadius
-      ? Math.PI / 2
-      : 2 * Math.acos(1 - clampedError / screenRadius);
-  const startAngle = ellipse.startAngle ?? 0;
-  const endAngle = ellipse.endAngle ?? startAngle + FULL_TURN;
-  const arcLength = Math.abs(endAngle - startAngle);
-  const segmentCount = Math.ceil(arcLength / maxStep);
-
-  return Math.min(
-    MAX_ELLIPSE_SEGMENT_COUNT,
-    Math.max(MIN_ELLIPSE_SEGMENT_COUNT, segmentCount),
-  );
-}
-
 export type MarkerGeometry =
   | {
       readonly kind: "circle";
@@ -117,25 +67,18 @@ export type MarkerGeometry =
  * are divided by the viewport scale, matching stroke-width semantics.
  */
 export function resolveMarkerGeometry(
-  marker: MarkerGeometryInput,
+  marker: Omit<MarkerShapeInstruction, "kind" | "fill" | "stroke">,
   viewportScale = 1,
 ): MarkerGeometry {
-  assertFinitePoint(marker.center, "center");
-  assertPositiveFinite(marker.size, "size");
-  assertPositiveFinite(viewportScale, "viewportScale");
-  if (marker.rotation !== undefined) {
-    assertFinite(marker.rotation, "rotation");
-  }
-
   const size =
     marker.sizeSpace === MarkerSizeSpace.Screen
-      ? marker.size / viewportScale
+      ? marker.size / Math.max(viewportScale, Number.EPSILON)
       : marker.size;
   const radius = size / 2;
   const rotation = marker.rotation ?? 0;
 
   if (marker.shape === MarkerShape.Circle) {
-    return { center: marker.center, kind: "circle", radius };
+    return { center: marker.point, kind: "circle", radius };
   }
 
   if (marker.shape === MarkerShape.Cross) {
@@ -144,12 +87,12 @@ export function resolveMarkerGeometry(
       kind: "subpaths",
       subpaths: [
         [
-          rotatePoint(marker.center, -radius, -radius, rotation),
-          rotatePoint(marker.center, radius, radius, rotation),
+          rotatePoint(marker.point, -radius, -radius, rotation),
+          rotatePoint(marker.point, radius, radius, rotation),
         ],
         [
-          rotatePoint(marker.center, radius, -radius, rotation),
-          rotatePoint(marker.center, -radius, radius, rotation),
+          rotatePoint(marker.point, radius, -radius, rotation),
+          rotatePoint(marker.point, -radius, radius, rotation),
         ],
       ],
     };
@@ -161,10 +104,10 @@ export function resolveMarkerGeometry(
       kind: "subpaths",
       subpaths: [
         [
-          rotatePoint(marker.center, -radius, -radius, rotation),
-          rotatePoint(marker.center, radius, -radius, rotation),
-          rotatePoint(marker.center, radius, radius, rotation),
-          rotatePoint(marker.center, -radius, radius, rotation),
+          rotatePoint(marker.point, -radius, -radius, rotation),
+          rotatePoint(marker.point, radius, -radius, rotation),
+          rotatePoint(marker.point, radius, radius, rotation),
+          rotatePoint(marker.point, -radius, radius, rotation),
         ],
       ],
     };
@@ -180,65 +123,12 @@ export function resolveMarkerGeometry(
     kind: "subpaths",
     subpaths: [
       [
-        rotatePoint(marker.center, 0, radius, rotation),
-        rotatePoint(marker.center, baseOffsetX, baseOffsetY, rotation),
-        rotatePoint(marker.center, -baseOffsetX, baseOffsetY, rotation),
+        rotatePoint(marker.point, 0, radius, rotation),
+        rotatePoint(marker.point, baseOffsetX, baseOffsetY, rotation),
+        rotatePoint(marker.point, -baseOffsetX, baseOffsetY, rotation),
       ],
     ],
   };
-}
-
-function validateEllipseGeometry(ellipse: EllipseGeometry) {
-  assertFinitePoint(ellipse.center, "center");
-  assertPositiveFinite(ellipse.radiusX, "radiusX");
-  assertPositiveFinite(ellipse.radiusY, "radiusY");
-  if (ellipse.rotation !== undefined) {
-    assertFinite(ellipse.rotation, "rotation");
-  }
-
-  const hasStart = ellipse.startAngle !== undefined;
-  const hasEnd = ellipse.endAngle !== undefined;
-  if (hasStart !== hasEnd) {
-    throw new RangeError("startAngle and endAngle must be provided together");
-  }
-
-  if (hasStart && hasEnd) {
-    assertFinite(ellipse.startAngle!, "startAngle");
-    assertFinite(ellipse.endAngle!, "endAngle");
-    const range = Math.abs(ellipse.endAngle! - ellipse.startAngle!);
-    if (range <= GEOMETRY_EPSILON || range >= FULL_TURN - GEOMETRY_EPSILON) {
-      throw new RangeError(
-        "ellipse arc range must be greater than 0 and less than one full turn",
-      );
-    }
-  }
-}
-
-function assertFinitePoint(point: Point, name: string) {
-  assertFinite(point.x, `${name}.x`);
-  assertFinite(point.y, `${name}.y`);
-}
-
-function assertFinite(value: number, name: string): asserts value is number {
-  if (!Number.isFinite(value)) {
-    throw new RangeError(`${name} must be finite`);
-  }
-}
-
-function assertPositiveFinite(
-  value: number,
-  name: string,
-): asserts value is number {
-  assertFinite(value, name);
-  if (value <= 0) {
-    throw new RangeError(`${name} must be greater than 0`);
-  }
-}
-
-function assertIntegerAtLeast(value: number, minimum: number, name: string) {
-  if (!Number.isInteger(value) || value < minimum) {
-    throw new RangeError(`${name} must be an integer of at least ${minimum}`);
-  }
 }
 
 function rotatePoint(

--- a/packages/web/src/renderers/pixi-media-scene.ts
+++ b/packages/web/src/renderers/pixi-media-scene.ts
@@ -158,27 +158,36 @@ export async function createPixiMediaScene(
     polylineStyle: options.polylineStyle,
     keypointStyle: options.keypointStyle,
     shapeStyle: options.shapeStyle,
-    resolveContextState,
-  });
-  const regionLayer = createPixiRegionLayer({
-    Assets,
-    Container,
-    GifSprite,
-    Sprite,
-    detectionTimeline: options.detectionTimeline,
-    onInvalidate: () => {
-      if (!hasPresentedSample || mediaWidth <= 0 || mediaHeight <= 0) return;
-      const boxState = boxLayer.drawFrame(currentMediaTime, viewportScale);
-      const regionState = regionLayer.drawFrame(
-        currentMediaTime,
-        viewportScale,
-      );
-      options.onPresentationUpdate?.(
-        createPresentedSampleState(currentMediaTime, boxState, regionState),
-      );
+    // Icon textures resolve asynchronously; paused or static media gets an
+    // immediate redraw instead of waiting for the next media sample.
+    onAssetLoaded: () => {
+      vectorLayer.drawFrame(currentMediaTime, viewportScale);
     },
-    onAssetError: options.diagnostics?.onAssetError,
-    regionRenderers: options.regionRenderers,
+    loadIconTexture: async (href) => {
+      const image = new Image();
+
+      image.decoding = "async";
+      image.crossOrigin = "anonymous";
+      image.src = href;
+      await image.decode();
+
+      // Rasterize through a canvas so every image type uploads uniformly.
+      const size = 64;
+      const canvas = document.createElement("canvas");
+
+      canvas.width = size;
+      canvas.height = size;
+      canvas.getContext("2d")?.drawImage(image, 0, 0, size, size);
+
+      return new Texture({
+        source: new CanvasSource({
+          dynamic: false,
+          height: size,
+          resource: canvas,
+          width: size,
+        }),
+      });
+    },
     resolveContextState,
   });
   const annotationOverlayLayer = createPixiAnnotationOverlayLayer(

--- a/packages/web/src/renderers/pixi-vector-layer.test.ts
+++ b/packages/web/src/renderers/pixi-vector-layer.test.ts
@@ -6,7 +6,6 @@ import {
   MarkerShape,
   MarkerSizeSpace,
   ShapeInstructionKind,
-  StrokeAlignment,
 } from "supervision-js-core";
 import type {
   BufferedDetectionTimeline,
@@ -159,7 +158,7 @@ describe("pixi vector layer", () => {
         {
           fill: { alpha: 1, color: 0xff0000 },
           kind: ShapeInstructionKind.Marker,
-          center: { x: 30, y: 20 },
+          point: { x: 30, y: 20 },
           shape: MarkerShape.Triangle,
           size: 12,
           sizeSpace: MarkerSizeSpace.Screen,
@@ -167,16 +166,10 @@ describe("pixi vector layer", () => {
         {
           fill: { alpha: 1, color: 0x00ff00 },
           kind: ShapeInstructionKind.Marker,
-          center: { x: 30, y: 40 },
+          point: { x: 30, y: 40 },
           shape: MarkerShape.Circle,
           size: 10,
           sizeSpace: MarkerSizeSpace.Screen,
-          stroke: {
-            alignment: StrokeAlignment.Outside,
-            alpha: 1,
-            color: 0xffffff,
-            width: 2,
-          },
         },
       ],
     };
@@ -206,15 +199,9 @@ describe("pixi vector layer", () => {
     expect(trianglePoints[1]).toBeCloseTo(23);
     // Circle: native circle with the screen size divided by the scale.
     expect(display.circle).toHaveBeenCalledWith(30, 40, 2.5);
-    expect(display.stroke).toHaveBeenCalledWith({
-      alignment: 0,
-      alpha: 1,
-      color: 0xffffff,
-      width: 1,
-    });
   });
 
-  it("draws dashed circle marker strokes through the shared path lowering", () => {
+  it("draws icons once their texture resolves and skips them before", async () => {
     const boxOnlyFrame: DetectionFrame = {
       detections: [
         { id: "box-0", rect: { height: 40, width: 20, x: 30, y: 40 } },
@@ -222,20 +209,22 @@ describe("pixi vector layer", () => {
       frameIndex: 0,
       mediaTime: 0,
     };
+    const fakeTexture = { id: "texture" };
+    let resolveTexture: (texture: unknown) => void = () => {};
+    const loadIconTexture = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveTexture = resolve;
+        }),
+    );
     const shapeStyle: ShapeStyle = {
       resolve: () => [
         {
-          kind: ShapeInstructionKind.Marker,
-          center: { x: 30, y: 40 },
-          shape: MarkerShape.Circle,
-          size: 10,
-          sizeSpace: MarkerSizeSpace.Media,
-          stroke: {
-            alpha: 1,
-            color: 0xffffff,
-            dash: [4, 2],
-            width: 2,
-          },
+          href: "data:image/svg+xml,icon",
+          kind: ShapeInstructionKind.Icon,
+          point: { x: 30, y: 20 },
+          size: 24,
+          sizeSpace: MarkerSizeSpace.Screen,
         },
       ],
     };
@@ -244,6 +233,160 @@ describe("pixi vector layer", () => {
       detectionTimeline: createTimeline([boxOnlyFrame]),
       Graphics: FakeGraphics as never,
       keypointStyle: null,
+      loadIconTexture: loadIconTexture as never,
+      polygonStyle: null,
+      polylineStyle: null,
+      shapeStyle,
+    });
+    const container = layer.createContainer() as unknown as FakeContainer;
+
+    layer.drawFrame(0, 2);
+    const display = container.children[0]!;
+    expect(loadIconTexture).toHaveBeenCalledOnce();
+    expect(display.texture).not.toHaveBeenCalled();
+
+    resolveTexture(fakeTexture);
+    await Promise.resolve();
+    layer.drawFrame(0, 2);
+
+    expect(loadIconTexture).toHaveBeenCalledOnce();
+    expect(display.texture).toHaveBeenCalledWith(
+      fakeTexture,
+      0xffffff,
+      24,
+      14,
+      12,
+      12,
+    );
+  });
+
+  it("notifies the host when an icon texture resolves after its frame", async () => {
+    const boxOnlyFrame: DetectionFrame = {
+      detections: [
+        { id: "box-0", rect: { height: 40, width: 20, x: 30, y: 40 } },
+      ],
+      frameIndex: 0,
+      mediaTime: 0,
+    };
+    const onAssetLoaded = vi.fn();
+    let resolveTexture: (texture: unknown) => void = () => {};
+    const layer = createPixiVectorLayer({
+      Container: FakeContainer as never,
+      detectionTimeline: createTimeline([boxOnlyFrame]),
+      Graphics: FakeGraphics as never,
+      keypointStyle: null,
+      loadIconTexture: (() =>
+        new Promise((resolve) => {
+          resolveTexture = resolve;
+        })) as never,
+      onAssetLoaded,
+      polygonStyle: null,
+      polylineStyle: null,
+      shapeStyle: iconShapeStyle,
+    });
+
+    layer.createContainer();
+    layer.drawFrame(0);
+    expect(onAssetLoaded).not.toHaveBeenCalled();
+
+    resolveTexture({ destroy: vi.fn() });
+    await Promise.resolve();
+
+    expect(onAssetLoaded).toHaveBeenCalledOnce();
+  });
+
+  it("destroys loaded icon textures on teardown", async () => {
+    const boxOnlyFrame: DetectionFrame = {
+      detections: [
+        { id: "box-0", rect: { height: 40, width: 20, x: 30, y: 40 } },
+      ],
+      frameIndex: 0,
+      mediaTime: 0,
+    };
+    const texture = { destroy: vi.fn(), source: { style: {} } };
+    const layer = createPixiVectorLayer({
+      Container: FakeContainer as never,
+      detectionTimeline: createTimeline([boxOnlyFrame]),
+      Graphics: FakeGraphics as never,
+      keypointStyle: null,
+      loadIconTexture: (() => Promise.resolve(texture)) as never,
+      polygonStyle: null,
+      polylineStyle: null,
+      shapeStyle: iconShapeStyle,
+    });
+
+    layer.createContainer();
+    layer.drawFrame(0);
+    await Promise.resolve();
+
+    layer.destroy();
+
+    expect(texture.destroy).toHaveBeenCalledWith(true);
+  });
+
+  it("disposes icon textures that resolve after teardown", async () => {
+    const boxOnlyFrame: DetectionFrame = {
+      detections: [
+        { id: "box-0", rect: { height: 40, width: 20, x: 30, y: 40 } },
+      ],
+      frameIndex: 0,
+      mediaTime: 0,
+    };
+    const onAssetLoaded = vi.fn();
+    const texture = { destroy: vi.fn(), source: { style: {} } };
+    let resolveTexture: (value: unknown) => void = () => {};
+    const layer = createPixiVectorLayer({
+      Container: FakeContainer as never,
+      detectionTimeline: createTimeline([boxOnlyFrame]),
+      Graphics: FakeGraphics as never,
+      keypointStyle: null,
+      loadIconTexture: (() =>
+        new Promise((resolve) => {
+          resolveTexture = resolve;
+        })) as never,
+      onAssetLoaded,
+      polygonStyle: null,
+      polylineStyle: null,
+      shapeStyle: iconShapeStyle,
+    });
+
+    layer.createContainer();
+    layer.drawFrame(0);
+    layer.destroy();
+
+    resolveTexture(texture);
+    await Promise.resolve();
+
+    expect(texture.destroy).toHaveBeenCalledWith(true);
+    expect(onAssetLoaded).not.toHaveBeenCalled();
+  });
+
+  it("marks failed icon loads and does not retry them", async () => {
+    const boxOnlyFrame: DetectionFrame = {
+      detections: [
+        { id: "box-0", rect: { height: 40, width: 20, x: 30, y: 40 } },
+      ],
+      frameIndex: 0,
+      mediaTime: 0,
+    };
+    const loadIconTexture = vi.fn(() => Promise.reject(new Error("nope")));
+    const shapeStyle: ShapeStyle = {
+      resolve: () => [
+        {
+          href: "data:image/svg+xml,broken",
+          kind: ShapeInstructionKind.Icon,
+          point: { x: 30, y: 20 },
+          size: 24,
+          sizeSpace: MarkerSizeSpace.Screen,
+        },
+      ],
+    };
+    const layer = createPixiVectorLayer({
+      Container: FakeContainer as never,
+      detectionTimeline: createTimeline([boxOnlyFrame]),
+      Graphics: FakeGraphics as never,
+      keypointStyle: null,
+      loadIconTexture: loadIconTexture as never,
       polygonStyle: null,
       polylineStyle: null,
       shapeStyle,
@@ -251,16 +394,12 @@ describe("pixi vector layer", () => {
     const container = layer.createContainer() as unknown as FakeContainer;
 
     layer.drawFrame(0);
+    await Promise.resolve();
+    layer.invalidateDetection("box-0");
+    layer.drawFrame(0);
 
-    const display = container.children[0]!;
-    expect(display.circle).not.toHaveBeenCalled();
-    expect(display.moveTo).toHaveBeenCalled();
-    expect(display.lineTo).toHaveBeenCalled();
-    expect(display.stroke).toHaveBeenCalledWith({
-      alpha: 1,
-      color: 0xffffff,
-      width: 2,
-    });
+    expect(loadIconTexture).toHaveBeenCalledOnce();
+    expect(container.children[0]!.texture).not.toHaveBeenCalled();
   });
 
   it("draws every subpath of a path instruction", () => {
@@ -335,6 +474,18 @@ describe("pixi vector layer", () => {
   });
 });
 
+const iconShapeStyle: ShapeStyle = {
+  resolve: () => [
+    {
+      href: "data:image/svg+xml,icon",
+      kind: ShapeInstructionKind.Icon,
+      point: { x: 30, y: 20 },
+      size: 24,
+      sizeSpace: MarkerSizeSpace.Screen,
+    },
+  ],
+};
+
 class FakeContainer {
   readonly children: FakeGraphics[] = [];
   sortableChildren = false;
@@ -348,6 +499,7 @@ class FakeGraphics {
   readonly circle = vi.fn(() => this);
   readonly clear = vi.fn(() => this);
   readonly closePath = vi.fn(() => this);
+  readonly texture = vi.fn(() => this);
   readonly fill = vi.fn(() => this);
   readonly lineTo = vi.fn(() => this);
   readonly moveTo = vi.fn(() => this);

--- a/packages/web/src/renderers/pixi-vector-layer.ts
+++ b/packages/web/src/renderers/pixi-vector-layer.ts
@@ -3,10 +3,8 @@ import {
   BasePolygonStyle,
   BasePolylineStyle,
   KeypointMarkerShape,
-  MarkerShape,
   MarkerSizeSpace,
   ShapeInstructionKind,
-  resolveEllipseSegmentCount,
   resolveMarkerGeometry,
   sampleEllipseArc,
   type BufferedDetectionTimeline,
@@ -21,12 +19,14 @@ import {
   type PolygonStyle,
   type PolylineDrawInstruction,
   type PolylineStyle,
+  type IconShapeInstruction,
   type ShapeDrawInstruction,
   type ShapeStyle,
 } from "supervision-js-core";
 import type {
   Container as PixiContainer,
   Graphics as PixiGraphics,
+  Texture as PixiTexture,
 } from "pixi.js";
 import { drawPixiPath, resolvePixiStroke } from "./pixi-path";
 
@@ -66,6 +66,16 @@ export function createPixiVectorLayer(options: {
   readonly polylineStyle?: PolylineStyle | null;
   readonly keypointStyle?: KeypointStyle | null;
   readonly shapeStyle?: ShapeStyle | null;
+  /**
+   * Loads and decodes an icon image reference into a texture. Required for
+   * icon shape instructions; icons are skipped when absent.
+   */
+  readonly loadIconTexture?: (href: string) => Promise<PixiTexture>;
+  /**
+   * Notifies the host scene that an icon texture finished loading after its
+   * first frame, so paused or static media can redraw immediately.
+   */
+  readonly onAssetLoaded?: () => void;
   readonly resolveContextState?: (
     detection: Detection,
   ) => Partial<AnnotationStyleContext>;
@@ -86,6 +96,12 @@ export function createPixiVectorLayer(options: {
   // Shape decorations are opt-in; no default style exists so configuring
   // nothing keeps the semantic-geometry skip untouched.
   let shapeStyle = options.shapeStyle ?? null;
+  // Icon textures resolve asynchronously; a bumped version forces the next
+  // drawFrame to redraw so freshly loaded icons appear.
+  const iconTextures = new Map<string, PixiTexture | "loading" | "failed">();
+  let assetVersion = 0;
+  let drawnAssetVersion = -1;
+  let isDestroyed = false;
   let styleVersion = 0;
   let drawnStyleVersion = -1;
   // A versioned source can replace a frame without changing its timeline key.
@@ -112,6 +128,7 @@ export function createPixiVectorLayer(options: {
       if (
         frame === lastFrame &&
         drawnStyleVersion === styleVersion &&
+        drawnAssetVersion === assetVersion &&
         viewportScale === lastViewportScale &&
         invalidated.size === 0
       ) {
@@ -120,6 +137,7 @@ export function createPixiVectorLayer(options: {
 
       lastFrame = frame;
       drawnStyleVersion = styleVersion;
+      drawnAssetVersion = assetVersion;
       lastViewportScale = viewportScale;
 
       if (!frame) {
@@ -192,9 +210,18 @@ export function createPixiVectorLayer(options: {
     },
 
     destroy() {
+      isDestroyed = true;
+
+      for (const cached of iconTextures.values()) {
+        if (cached !== "loading" && cached !== "failed") {
+          cached.destroy(true);
+        }
+      }
+
       entries.clear();
       entryPool.length = 0;
       invalidated.clear();
+      iconTextures.clear();
       container = undefined;
     },
   };
@@ -273,7 +300,11 @@ export function createPixiVectorLayer(options: {
     const { keypoints, polygon, polyline, shapes } = detection;
 
     for (const shape of shapes ?? []) {
-      drawShapeInstruction(graphics, shape, viewportScale);
+      if (shape.kind === ShapeInstructionKind.Icon) {
+        drawIconInstruction(graphics, shape, viewportScale);
+      } else {
+        drawShapeInstruction(graphics, shape, viewportScale);
+      }
     }
 
     if (polygon) {
@@ -353,6 +384,153 @@ export function createPixiVectorLayer(options: {
         );
       }
     }
+  }
+  function drawIconInstruction(
+    graphics: PixiGraphics,
+    instruction: IconShapeInstruction,
+    viewportScale: number,
+  ) {
+    const texture = resolveIconTexture(instruction.href);
+
+    if (!texture) {
+      return;
+    }
+
+    const size =
+      instruction.sizeSpace === MarkerSizeSpace.Screen
+        ? instruction.size / Math.max(viewportScale, Number.EPSILON)
+        : instruction.size;
+
+    graphics.texture(
+      texture,
+      0xffffff,
+      instruction.point.x - size / 2,
+      instruction.point.y - size / 2,
+      size,
+      size,
+    );
+  }
+
+  function resolveIconTexture(href: string): PixiTexture | undefined {
+    const cached = iconTextures.get(href);
+
+    if (cached === "loading" || cached === "failed") {
+      return undefined;
+    }
+
+    if (cached) {
+      return cached;
+    }
+
+    const loadIconTexture = options.loadIconTexture;
+
+    if (!loadIconTexture) {
+      iconTextures.set(href, "failed");
+      return undefined;
+    }
+
+    iconTextures.set(href, "loading");
+    loadIconTexture(href).then(
+      (texture) => {
+        // A load can resolve after the layer is destroyed; own the texture
+        // long enough to dispose it instead of leaking it into a dead cache.
+        if (isDestroyed) {
+          texture.destroy(true);
+          return;
+        }
+
+        iconTextures.set(href, texture);
+        assetVersion += 1;
+        options.onAssetLoaded?.();
+      },
+      () => {
+        if (!isDestroyed) {
+          iconTextures.set(href, "failed");
+        }
+      },
+    );
+
+    return undefined;
+  }
+}
+
+function drawShapeInstruction(
+  graphics: PixiGraphics,
+  instruction: Exclude<ShapeDrawInstruction, IconShapeInstruction>,
+  viewportScale: number,
+) {
+  if (instruction.kind === ShapeInstructionKind.Ellipse) {
+    const { closed, points } = sampleEllipseArc(instruction);
+
+    if (closed && instruction.fill) {
+      graphics.poly(
+        points.flatMap(({ x, y }) => [x, y]),
+        true,
+      );
+      graphics.fill(instruction.fill);
+    }
+
+    if (instruction.stroke) {
+      drawPixiPath(graphics, points, closed, instruction.stroke, viewportScale);
+    }
+
+    return;
+  }
+
+  if (instruction.kind === ShapeInstructionKind.Marker) {
+    const geometry = resolveMarkerGeometry(instruction, viewportScale);
+
+    if (geometry.kind === "circle") {
+      graphics.circle(geometry.center.x, geometry.center.y, geometry.radius);
+      if (instruction.fill) graphics.fill(instruction.fill);
+      if (instruction.stroke)
+        graphics.stroke({
+          alpha: instruction.stroke.alpha,
+          color: instruction.stroke.color,
+          width: resolveScreenLength(instruction.stroke.width, viewportScale),
+        });
+      return;
+    }
+
+    for (const subpath of geometry.subpaths) {
+      if (geometry.closed && instruction.fill) {
+        graphics.poly(
+          subpath.flatMap(({ x, y }) => [x, y]),
+          true,
+        );
+        graphics.fill(instruction.fill);
+      }
+
+      if (instruction.stroke) {
+        drawPixiPath(
+          graphics,
+          subpath,
+          geometry.closed,
+          instruction.stroke,
+          viewportScale,
+        );
+      }
+    }
+
+    return;
+  }
+
+  for (const segment of instruction.segments) {
+    if (instruction.closed && instruction.fill) {
+      graphics.poly(
+        segment.flatMap(({ x, y }) => [x, y]),
+        true,
+      );
+      graphics.fill(instruction.fill);
+    }
+
+    drawPixiPath(
+      graphics,
+      segment,
+      instruction.closed,
+      instruction.stroke,
+      viewportScale,
+    );
   }
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
         replacement: `${coreSource("styles")}/$1.ts`,
       },
       {
-        find: /^#types\/(annotation-renderer|box-style|detection-timeline|detections|editing|focus-style|interaction|interaction-style|keypoint-style|label-style|mask-style|media|media-rendering|paint-style|polygon-style|polyline-style|session-lifecycle|shape-style|style|viewport)$/,
+        find: /^#types\/(annotation-renderer|box-style|detection-timeline|detections|editing|focus-style|interaction|interaction-style|keypoint-style|label-style|mask-style|media|media-rendering|polygon-style|polyline-style|session-lifecycle|shape-style|style|viewport)$/,
         replacement: `${coreSource("types")}/$1.ts`,
       },
       {


### PR DESCRIPTION
# Status\n\nSuperseded by the asset-backed region annotation renderer. Icons, PNGs, and animated GIF overlays use the semantic RegionRenderer path and do not need a separate Pixi texture primitive in the public API.\n\nThis PR should not be merged.