### PR TITLE
Prepare supervision 0.1.2 release

### DIFF
--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -57,15 +57,18 @@ publisher.
 
 Use SemVer against the published browser surface only:
 
-| Change                                                                      | Example version from `0.1.0` | Tag      |
-| --------------------------------------------------------------------------- | ---------------------------- | -------- |
-| Backward-compatible fix, docs, dependency maintenance, or internal refactor | `0.1.1`                      | `latest` |
-| Backward-compatible public browser API addition                             | `0.2.0`                      | `latest` |
-| Breaking browser API or behavior change before 1.0                          | `0.2.0`                      | `latest` |
+| Change                                                                                                   | Example version from `0.1.1` | Tag      |
+| -------------------------------------------------------------------------------------------------------- | ---------------------------- | -------- |
+| Backward-compatible fix, docs, dependency maintenance, internal refactor, or public browser API addition | `0.1.2`                      | `latest` |
+| Breaking browser API or behavior change before 1.0                                                       | `0.2.0`                      | `latest` |
 
-For pre-1.0 versions, a new minor version communicates a breaking public
-change. Changes limited to private React Native experiments do not by themselves
-change the published browser package version.
+While the browser package remains in the experimental `0.1.x` line,
+backward-compatible public API additions release as patches alongside fixes.
+A new minor version communicates an intentional compatibility break or reset
+before `1.0`. This is the repository's release policy for the prototype phase;
+SemVer itself treats `0.y.z` as initial development. Changes limited to private
+React Native experiments do not by themselves change the published browser
+package version.
 
 ## Release Procedure
 

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -2,7 +2,7 @@
 
 (function () {
   const packageName = "supervision";
-  const packageVersion = "0.1.1";
+  const packageVersion = "0.1.2";
   const packageReleaseStatus = "";
   const kindIconMap = {
     Accessor: "A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10351,7 +10351,7 @@
     },
     "packages/web": {
       "name": "supervision",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.52.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supervision",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Browser-native computer vision media rendering and annotation engine.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Prepares the next stable `supervision` release as `0.1.2`, including the package manifest, lockfile, and public-docs version mirror.

It also records the prototype release policy: while the browser package remains on `0.1.x`, backward-compatible public API additions ship as patch releases; intentional compatibility breaks advance the minor version. This allows the newly merged frame-capture API to ship as `0.1.2` without implying a stable pre-1.0 compatibility boundary.

## Type of change

- [x] Maintenance (non-breaking, non-user facing changing such as dependency update, adding test, modifying secrets, etc.)
- [x] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

- `npm run verify`
- `npm run package:tarball`
- `npm run package:tarball:smoke`
- `npm run package:publish:dry-run`
- `npm run demo:build`
- `npm run benchmark:initial:build`
- `npm run benchmark:media-upload:build`
- `npm run benchmark:masks:gpu:build`

## Will the change affect Universe? If so was this change tested in universe?

No

## Any specific deployment considerations

- After merge, dispatch **Publish npm package** from `main` with the `latest` tag and approve the `npm-publish` environment.
- Verify `supervision@0.1.2` on npm before updating Core PR #14109.

### Infrastructure impact

- [ ] This change affects infrastructure needs (GPUs, Cloud Function sizing, storage etc.)
