### PR TITLE
Fix mask focus fallback geometry

### DIFF
--- a/packages/web/src/renderers/pixi-focus-layer.test.ts
+++ b/packages/web/src/renderers/pixi-focus-layer.test.ts
@@ -324,6 +324,58 @@ describe("pixi focus layer", () => {
     expect(display.rect).toHaveBeenCalledWith(2, 2, 1, 1);
     expect(display.cut).toHaveBeenCalledOnce();
   });
+
+  it("does not fall back to bounds for a readable empty mask", () => {
+    const emptyMaskFrame: DetectionFrame = {
+      detections: [
+        {
+          className: "player",
+          id: "player-1",
+          mask: {
+            counts: encodeCompressedRleCounts([16]),
+            encoding: DetectionMaskEncoding.CompressedRle,
+            height: 4,
+            width: 4,
+          },
+          rect: { height: 30, width: 20, x: 20, y: 30 },
+        },
+      ],
+      frameIndex: 3,
+      mediaTime: 0.1,
+    };
+    const selectedPick = {
+      detection: emptyMaskFrame.detections[0]!,
+      detectionIndex: 0,
+      frame: emptyMaskFrame,
+      mediaTime: emptyMaskFrame.mediaTime,
+      point: { x: 15, y: 20 },
+      target: DetectionPickTarget.Mask,
+    };
+    const layer = createPixiFocusLayer({
+      Graphics: FakeGraphics as never,
+      focusStyle: new BaseFocusStyle({
+        cornerRadius: 6,
+        fill: { alpha: 0.5, color: 0x000000 },
+        shape: BoxShape.RoundedRect,
+      }),
+    });
+    const display = layer.createDisplay({
+      height: 80,
+      width: 120,
+    }) as FakeGraphics;
+
+    layer.drawFrame({
+      frame: emptyMaskFrame,
+      hoveredPick: null,
+      mediaTime: emptyMaskFrame.mediaTime,
+      selectedPick,
+    });
+
+    expect(display.roundRect).not.toHaveBeenCalled();
+    expect(display.rect).toHaveBeenCalledOnce();
+    expect(display.rect).toHaveBeenCalledWith(0, 0, 120, 80);
+    expect(display.cut).not.toHaveBeenCalled();
+  });
 });
 
 class FakeGraphics {

--- a/packages/web/src/renderers/pixi-focus-layer.test.ts
+++ b/packages/web/src/renderers/pixi-focus-layer.test.ts
@@ -319,9 +319,9 @@ describe("pixi focus layer", () => {
 
     expect(display.roundRect).not.toHaveBeenCalled();
     expect(display.rect).toHaveBeenNthCalledWith(1, 0, 0, 120, 80);
-    expect(display.rect).toHaveBeenCalledWith(1, 0, 1, 1);
-    expect(display.rect).toHaveBeenCalledWith(1, 1, 2, 1);
-    expect(display.rect).toHaveBeenCalledWith(2, 2, 1, 1);
+    expect(display.rect).toHaveBeenCalledWith(30, 0, 30, 20);
+    expect(display.rect).toHaveBeenCalledWith(30, 20, 60, 20);
+    expect(display.rect).toHaveBeenCalledWith(60, 40, 30, 20);
     expect(display.cut).toHaveBeenCalledOnce();
   });
 

--- a/packages/web/src/renderers/pixi-focus-layer.test.ts
+++ b/packages/web/src/renderers/pixi-focus-layer.test.ts
@@ -4,6 +4,7 @@ import { PreparedMaskFrameKind } from "#render-preparation/mask-frame-artifact";
 import { createPixiFocusLayer } from "#renderers/pixi-focus-layer";
 import { BaseFocusStyle } from "supervision-js-core";
 import { BoxShape } from "supervision-js-core";
+import { encodeCompressedRleCounts } from "supervision-js-core";
 import { FocusTargetMode } from "supervision-js-core";
 import {
   DetectionMaskEncoding,
@@ -224,12 +225,24 @@ describe("pixi focus layer", () => {
     expect(graphics.fill).not.toHaveBeenCalled();
   });
 
-  it("uses one bounds cutout while a mask artifact is unavailable", () => {
+  it("uses a bounds cutout for an unreadable mask when an ID-mask artifact is unavailable", () => {
+    const unreadableMaskFrame: DetectionFrame = {
+      ...maskFrame,
+      detections: [
+        {
+          ...maskFrame.detections[0]!,
+          mask: {
+            ...maskFrame.detections[0]!.mask!,
+            width: 0,
+          },
+        },
+      ],
+    };
     const selectedPick = {
-      detection: maskFrame.detections[0]!,
+      detection: unreadableMaskFrame.detections[0]!,
       detectionIndex: 0,
-      frame: maskFrame,
-      mediaTime: maskFrame.mediaTime,
+      frame: unreadableMaskFrame,
+      mediaTime: unreadableMaskFrame.mediaTime,
       point: { x: 15, y: 20 },
       target: DetectionPickTarget.Mask,
     };
@@ -247,14 +260,68 @@ describe("pixi focus layer", () => {
     }) as FakeGraphics;
 
     layer.drawFrame({
-      frame: maskFrame,
+      frame: unreadableMaskFrame,
       hoveredPick: null,
-      mediaTime: maskFrame.mediaTime,
+      mediaTime: unreadableMaskFrame.mediaTime,
       selectedPick,
     });
 
     expect(display.roundRect).toHaveBeenCalledOnce();
     expect(display.roundRect).toHaveBeenCalledWith(10, 15, 20, 30, 6);
+    expect(display.cut).toHaveBeenCalledOnce();
+  });
+
+  it("uses the semantic mask shape when an ID-mask artifact is unavailable", () => {
+    const semanticMaskFrame: DetectionFrame = {
+      detections: [
+        {
+          className: "player",
+          id: "player-1",
+          mask: {
+            counts: encodeCompressedRleCounts([4, 2, 3, 2, 5]),
+            encoding: DetectionMaskEncoding.CompressedRle,
+            height: 4,
+            width: 4,
+          },
+          rect: { height: 30, width: 20, x: 20, y: 30 },
+        },
+      ],
+      frameIndex: 3,
+      mediaTime: 0.1,
+    };
+    const selectedPick = {
+      detection: semanticMaskFrame.detections[0]!,
+      detectionIndex: 0,
+      frame: semanticMaskFrame,
+      mediaTime: semanticMaskFrame.mediaTime,
+      point: { x: 15, y: 20 },
+      target: DetectionPickTarget.Mask,
+    };
+    const layer = createPixiFocusLayer({
+      Graphics: FakeGraphics as never,
+      focusStyle: new BaseFocusStyle({
+        cornerRadius: 6,
+        fill: { alpha: 0.5, color: 0x000000 },
+        shape: BoxShape.RoundedRect,
+      }),
+    });
+    const display = layer.createDisplay({
+      height: 80,
+      width: 120,
+    }) as FakeGraphics;
+
+    layer.drawFrame({
+      frame: semanticMaskFrame,
+      hoveredPick: null,
+      mediaTime: semanticMaskFrame.mediaTime,
+      selectedPick,
+    });
+
+    expect(display.roundRect).not.toHaveBeenCalled();
+    expect(display.rect).toHaveBeenNthCalledWith(1, 0, 0, 120, 80);
+    expect(display.rect).toHaveBeenCalledWith(1, 0, 1, 1);
+    expect(display.rect).toHaveBeenCalledWith(1, 1, 2, 1);
+    expect(display.rect).toHaveBeenCalledWith(2, 2, 1, 1);
     expect(display.cut).toHaveBeenCalledOnce();
   });
 });

--- a/packages/web/src/renderers/pixi-focus-layer.ts
+++ b/packages/web/src/renderers/pixi-focus-layer.ts
@@ -367,7 +367,7 @@ export function createPixiFocusLayer(options: {
     const mask = target.detection.mask;
 
     if (!mask) {
-      return false;
+      return undefined;
     }
 
     let runs: MaskCutoutCacheEntry;

--- a/packages/web/src/renderers/pixi-focus-layer.ts
+++ b/packages/web/src/renderers/pixi-focus-layer.ts
@@ -24,7 +24,11 @@ const MAX_FOCUS_MASK_IDS = 16;
 
 type PixiFocusMesh = PixiMesh<PixiMeshGeometry, PixiShader>;
 type CutoutShapeResult = "drawn" | "empty";
-type MaskCutoutCacheEntry = readonly MaskRectRun[] | null;
+type MaskCutoutCacheEntry = {
+  readonly height: number;
+  readonly runs: readonly MaskRectRun[];
+  readonly width: number;
+} | null;
 
 type GraphicsConstructor = new () => PixiFocusGraphics;
 type ContainerConstructor = new () => PixiContainer;
@@ -375,9 +379,13 @@ export function createPixiFocusLayer(options: {
     if (!maskCutoutRuns.has(mask)) {
       try {
         const decoded = decodeCompressedRleMask(mask);
-        runs =
-          extractMaskRectRuns(decoded.data, decoded.width, decoded.height) ??
-          [];
+        runs = {
+          height: decoded.height,
+          runs:
+            extractMaskRectRuns(decoded.data, decoded.width, decoded.height) ??
+            [],
+          width: decoded.width,
+        };
       } catch {
         // Preserve the documented rectangle fallback for malformed masks. A
         // valid mask must never lose its shape merely because ID-mask rendering
@@ -394,11 +402,19 @@ export function createPixiFocusLayer(options: {
       return undefined;
     }
 
-    for (const run of runs) {
-      graphics.rect(run.x, run.y, run.width, run.height);
+    const horizontalScale = mediaWidth / runs.width;
+    const verticalScale = mediaHeight / runs.height;
+
+    for (const run of runs.runs) {
+      graphics.rect(
+        run.x * horizontalScale,
+        run.y * verticalScale,
+        run.width * horizontalScale,
+        run.height * verticalScale,
+      );
     }
 
-    return runs.length === 0 ? "empty" : "drawn";
+    return runs.runs.length === 0 ? "empty" : "drawn";
   }
 
   function hide() {

--- a/packages/web/src/renderers/pixi-focus-layer.ts
+++ b/packages/web/src/renderers/pixi-focus-layer.ts
@@ -23,6 +23,8 @@ import type {
 const MAX_FOCUS_MASK_IDS = 16;
 
 type PixiFocusMesh = PixiMesh<PixiMeshGeometry, PixiShader>;
+type CutoutShapeResult = "drawn" | "empty";
+type MaskCutoutCacheEntry = readonly MaskRectRun[] | null;
 
 type GraphicsConstructor = new () => PixiFocusGraphics;
 type ContainerConstructor = new () => PixiContainer;
@@ -133,7 +135,7 @@ export function createPixiFocusLayer(options: {
   // A frame can fall back to a composited RGBA texture when its colored ID-mask
   // palette is exhausted. Keep decoded row runs by the immutable mask payload so
   // that fallback focus still cuts out the actual mask, not its bounding rect.
-  const maskCutoutRuns = new WeakMap<object, readonly MaskRectRun[]>();
+  const maskCutoutRuns = new WeakMap<object, MaskCutoutCacheEntry>();
 
   return {
     createDisplay({ width, height }) {
@@ -300,15 +302,19 @@ export function createPixiFocusLayer(options: {
       focusMaskGraphics.clear();
 
       for (const target of targetsWithGeometry) {
-        drawCutoutShape(focusMaskGraphics, target, instruction);
-        focusMaskGraphics.fill({ alpha: 1, color: 0xffffff });
+        if (
+          drawCutoutShape(focusMaskGraphics, target, instruction) === "drawn"
+        ) {
+          focusMaskGraphics.fill({ alpha: 1, color: 0xffffff });
+        }
       }
       return;
     }
 
     for (const target of targetsWithGeometry) {
-      drawCutoutShape(focusGraphics, target, instruction);
-      focusGraphics.cut();
+      if (drawCutoutShape(focusGraphics, target, instruction) === "drawn") {
+        focusGraphics.cut();
+      }
     }
   }
 
@@ -316,9 +322,11 @@ export function createPixiFocusLayer(options: {
     graphics: PixiFocusGraphics,
     target: DetectionPickResult,
     instruction: FocusDrawInstruction,
-  ) {
-    if (drawMaskCutout(graphics, target)) {
-      return;
+  ): CutoutShapeResult {
+    const maskCutout = drawMaskCutout(graphics, target);
+
+    if (maskCutout) {
+      return maskCutout;
     }
 
     if (target.detection.polygon?.points.length && graphics.poly) {
@@ -326,11 +334,11 @@ export function createPixiFocusLayer(options: {
         target.detection.polygon.points.flatMap(({ x, y }) => [x, y]),
         true,
       );
-      return;
+      return "drawn";
     }
 
     if (!target.detection.rect) {
-      return;
+      return "empty";
     }
 
     const { rect } = target.detection;
@@ -348,21 +356,23 @@ export function createPixiFocusLayer(options: {
     } else {
       graphics.rect(left, top, rect.width, rect.height);
     }
+
+    return "drawn";
   }
 
   function drawMaskCutout(
     graphics: PixiFocusGraphics,
     target: DetectionPickResult,
-  ) {
+  ): CutoutShapeResult | undefined {
     const mask = target.detection.mask;
 
     if (!mask) {
       return false;
     }
 
-    let runs = maskCutoutRuns.get(mask);
+    let runs: MaskCutoutCacheEntry;
 
-    if (runs === undefined) {
+    if (!maskCutoutRuns.has(mask)) {
       try {
         const decoded = decodeCompressedRleMask(mask);
         runs =
@@ -372,21 +382,23 @@ export function createPixiFocusLayer(options: {
         // Preserve the documented rectangle fallback for malformed masks. A
         // valid mask must never lose its shape merely because ID-mask rendering
         // is unavailable, but an unreadable payload still has only bounds.
-        runs = [];
+        runs = null;
       }
 
       maskCutoutRuns.set(mask, runs);
+    } else {
+      runs = maskCutoutRuns.get(mask)!;
     }
 
-    if (runs.length === 0) {
-      return false;
+    if (runs === null) {
+      return undefined;
     }
 
     for (const run of runs) {
       graphics.rect(run.x, run.y, run.width, run.height);
     }
 
-    return true;
+    return runs.length === 0 ? "empty" : "drawn";
   }
 
   function hide() {

--- a/packages/web/src/renderers/pixi-focus-layer.ts
+++ b/packages/web/src/renderers/pixi-focus-layer.ts
@@ -5,6 +5,11 @@ import { BoxShape } from "supervision-js-core";
 import type { FocusDrawInstruction, FocusStyle } from "supervision-js-core";
 import type { DetectionPickResult } from "supervision-js-core";
 import { centerRectToTopLeftRect } from "supervision-js-core";
+import {
+  decodeCompressedRleMask,
+  extractMaskRectRuns,
+} from "supervision-js-core";
+import type { MaskRectRun } from "supervision-js-core";
 import type {
   Container as PixiContainer,
   ImageSource as PixiImageSource,
@@ -125,6 +130,10 @@ export function createPixiFocusLayer(options: {
   let targetAlpha = 0;
   let lastTick: number | null = null;
   let isDestroyed = false;
+  // A frame can fall back to a composited RGBA texture when its colored ID-mask
+  // palette is exhausted. Keep decoded row runs by the immutable mask payload so
+  // that fallback focus still cuts out the actual mask, not its bounding rect.
+  const maskCutoutRuns = new WeakMap<object, readonly MaskRectRun[]>();
 
   return {
     createDisplay({ width, height }) {
@@ -269,11 +278,14 @@ export function createPixiFocusLayer(options: {
       return;
     }
 
-    const targetsWithRects = instruction.targets.filter(
-      (target) => target.detection.rect || target.detection.polygon,
+    const targetsWithGeometry = instruction.targets.filter(
+      (target) =>
+        target.detection.mask ||
+        target.detection.rect ||
+        target.detection.polygon,
     );
 
-    if (targetsWithRects.length === 0) {
+    if (targetsWithGeometry.length === 0) {
       hideVectorFocus();
       return;
     }
@@ -287,14 +299,14 @@ export function createPixiFocusLayer(options: {
       focusMaskGraphics.visible = true;
       focusMaskGraphics.clear();
 
-      for (const target of targetsWithRects) {
+      for (const target of targetsWithGeometry) {
         drawCutoutShape(focusMaskGraphics, target, instruction);
         focusMaskGraphics.fill({ alpha: 1, color: 0xffffff });
       }
       return;
     }
 
-    for (const target of targetsWithRects) {
+    for (const target of targetsWithGeometry) {
       drawCutoutShape(focusGraphics, target, instruction);
       focusGraphics.cut();
     }
@@ -305,6 +317,10 @@ export function createPixiFocusLayer(options: {
     target: DetectionPickResult,
     instruction: FocusDrawInstruction,
   ) {
+    if (drawMaskCutout(graphics, target)) {
+      return;
+    }
+
     if (target.detection.polygon?.points.length && graphics.poly) {
       graphics.poly(
         target.detection.polygon.points.flatMap(({ x, y }) => [x, y]),
@@ -332,6 +348,45 @@ export function createPixiFocusLayer(options: {
     } else {
       graphics.rect(left, top, rect.width, rect.height);
     }
+  }
+
+  function drawMaskCutout(
+    graphics: PixiFocusGraphics,
+    target: DetectionPickResult,
+  ) {
+    const mask = target.detection.mask;
+
+    if (!mask) {
+      return false;
+    }
+
+    let runs = maskCutoutRuns.get(mask);
+
+    if (runs === undefined) {
+      try {
+        const decoded = decodeCompressedRleMask(mask);
+        runs =
+          extractMaskRectRuns(decoded.data, decoded.width, decoded.height) ??
+          [];
+      } catch {
+        // Preserve the documented rectangle fallback for malformed masks. A
+        // valid mask must never lose its shape merely because ID-mask rendering
+        // is unavailable, but an unreadable payload still has only bounds.
+        runs = [];
+      }
+
+      maskCutoutRuns.set(mask, runs);
+    }
+
+    if (runs.length === 0) {
+      return false;
+    }
+
+    for (const run of runs) {
+      graphics.rect(run.x, run.y, run.width, run.height);
+    }
+
+    return true;
   }
 
   function hide() {


### PR DESCRIPTION
# Description

Preserves semantic mask-shaped focus cutouts when a dense frame cannot use the PNG ID-mask artifact. The RGBA fallback previously rendered the mask layer correctly but focused `detection.rect`, causing rectangular bright cutouts.

The fallback now decodes the compressed semantic mask into merged raster runs and uses those runs for the vector/stencil cutout. It retains the bounds fallback only for unreadable masks and also accepts mask-only focus targets.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [ ] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

- `npm exec -- vitest run packages/web/src/renderers/pixi-focus-layer.test.ts packages/core/src/utils/id-mask-frame.test.ts`
- `npm exec -- eslint packages/web/src/renderers/pixi-focus-layer.ts packages/web/src/renderers/pixi-focus-layer.test.ts`
- `npm exec -- prettier --check packages/web/src/renderers/pixi-focus-layer.ts packages/web/src/renderers/pixi-focus-layer.test.ts`
- GitHub `verify` workflow

## Notes For Reviewers

- The fix is renderer-only. Core can consume it through a normal `supervision` version update after release.