### PR TITLE
Prepare supervision 0.1.3 release

### DIFF
--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -2,7 +2,7 @@
 
 (function () {
   const packageName = "supervision";
-  const packageVersion = "0.1.2";
+  const packageVersion = "0.1.3";
   const packageReleaseStatus = "";
   const kindIconMap = {
     Accessor: "A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10351,7 +10351,7 @@
     },
     "packages/web": {
       "name": "supervision",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.52.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supervision",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Browser-native computer vision media rendering and annotation engine.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Prepares `supervision@0.1.3`, a patch release containing the approved mask-focus fallback fix from #72. Updates the published package manifest, lockfile workspace metadata, and documentation toolbar version together.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [x] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

- `npm run verify`
- `npm run package:tarball:smoke`
- `npm run package:publish:dry-run`

## Notes For Reviewers

- `0.1.2` is already immutable on npm. After this PR merges, run the approved **Publish npm package** workflow from `main` with the `latest` tag to publish `0.1.3`.