### PR TITLE
Prepare supervision 0.1.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ session.setPresentation({
 npm install supervision
 ```
 
-The current browser release is `0.1.1`, published as npm's default `latest`
-release. Its package includes the private core dependency. Consumers import
+The next browser release is `0.1.4`, prepared for npm's default `latest` tag.
+Its package includes the private core dependency. Consumers import
 only the public browser entrypoints:
 
 ```ts
@@ -103,8 +103,10 @@ Start with [Application Integration](docs/public/guides/application-integration.
 ## Current API Status
 
 **Supported browser APIs** include `createMediaSession`, media preparation and
-playback controls, detections, boxes, masks, polygons, polylines, keypoints,
-labels, presentation styles, picking, and the advanced editing subpath.
+playback controls, detections, the renderer-first `annotationRenderers` API,
+boxes, box corners, ellipses, markers, masks, mask halos, polygons, polylines,
+keypoints, labels, asset regions, presentation styles, picking, and the
+advanced editing subpath.
 
 **Advanced browser APIs** expose lower-level renderer construction, detection
 sources, streaming ingestion, normalization, interaction, and diagnostics for

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -2,7 +2,7 @@
 
 (function () {
   const packageName = "supervision";
-  const packageVersion = "0.1.3";
+  const packageVersion = "0.1.4";
   const packageReleaseStatus = "";
   const kindIconMap = {
     Accessor: "A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10351,7 +10351,7 @@
     },
     "packages/web": {
       "name": "supervision",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.52.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supervision",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Browser-native computer vision media rendering and annotation engine.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Prepares `supervision@0.1.4` for the `latest` tag. This release makes the renderer-first annotation API available alongside the new asset-region, mask-halo, ellipse, box-corners, and marker renderers. It also updates the public README and docs toolbar to match the release version.

## Type of Change

- [x] New feature
- [x] Documentation or example update

## Validation

- [x] Tests added or updated where behavior changed
- [x] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

- `npm run verify`
- `npm run package:tarball`
- `npm run package:tarball:smoke`
- `npm run package:publish:dry-run`

## Notes For Reviewers

The repository release policy keeps compatible public API additions in the `0.1.x` patch line. After merge, dispatch **Publish npm package** from `main` with `dist_tag: latest`.