### PR TITLE
Improve marker playground controls

### DIFF
--- a/demo/src/components/DocsAnnotationRendererPlayground.tsx
+++ b/demo/src/components/DocsAnnotationRendererPlayground.tsx
@@ -7,6 +7,8 @@ import {
   filterDocsAnnotationRendererFrames,
   type DocsAnnotationRendererControl,
   type DocsAnnotationRendererId,
+  type DocsAnnotationRendererSelectControl,
+  type DocsAnnotationRendererSelectSetting,
   type NumericPresentationSetting,
 } from "../docs-annotation-renderer";
 import { useDemoRenderer } from "../hooks/useDemoRenderer";
@@ -77,6 +79,18 @@ function DocsStyleAnnotationRendererPlayground({
     },
     [demo.presentationSettings, demo.setPresentationSettings],
   );
+  const updateSelectPresentation = useCallback(
+    (
+      key: DocsAnnotationRendererSelectSetting,
+      value: DemoPresentationSettings[DocsAnnotationRendererSelectSetting],
+    ) => {
+      demo.setPresentationSettings({
+        ...demo.presentationSettings,
+        [key]: value,
+      });
+    },
+    [demo.presentationSettings, demo.setPresentationSettings],
+  );
 
   return (
     <main
@@ -113,6 +127,14 @@ function DocsStyleAnnotationRendererPlayground({
         </header>
 
         <div className="docs-layer-playground__controls">
+          {definition.selects?.map((control) => (
+            <RendererSelectControl
+              control={control}
+              key={control.key}
+              onChange={(value) => updateSelectPresentation(control.key, value)}
+              value={demo.presentationSettings[control.key]}
+            />
+          ))}
           {definition.controls.map((control) => (
             <RendererRangeControl
               control={control}
@@ -161,6 +183,39 @@ function DocsStyleAnnotationRendererPlayground({
         </div>
       </section>
     </main>
+  );
+}
+
+function RendererSelectControl({
+  control,
+  onChange,
+  value,
+}: {
+  readonly control: DocsAnnotationRendererSelectControl;
+  readonly onChange: (
+    value: DemoPresentationSettings[DocsAnnotationRendererSelectSetting],
+  ) => void;
+  readonly value: DemoPresentationSettings[DocsAnnotationRendererSelectSetting];
+}) {
+  return (
+    <label className="docs-layer-playground__select">
+      <strong>{control.label}</strong>
+      <select
+        onChange={(event) =>
+          onChange(
+            event.currentTarget
+              .value as DemoPresentationSettings[DocsAnnotationRendererSelectSetting],
+          )
+        }
+        value={value}
+      >
+        {control.options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
   );
 }
 

--- a/demo/src/docs-annotation-renderer.test.ts
+++ b/demo/src/docs-annotation-renderer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MarkerShape } from "supervision";
 import { defaultDemoPresentationSettings } from "./presentation/demo-presentation";
 import {
   createDocsAnnotationRendererPresentation,
@@ -67,10 +68,20 @@ describe("docs annotation renderers", () => {
     expect(
       createDocsAnnotationRendererSnippet("markers", {
         ...defaultDemoPresentationSettings,
+        markerPosition: "bottom-right",
+        markerShape: MarkerShape.Triangle,
         markerSize: 20,
         markerStrokeWidth: 3,
       }),
     ).toContain("size: 20");
+    const markerSnippet = createDocsAnnotationRendererSnippet("markers", {
+      ...defaultDemoPresentationSettings,
+      markerPosition: "bottom-right",
+      markerShape: MarkerShape.Triangle,
+    });
+    expect(markerSnippet).toContain("shape: MarkerShape.Triangle");
+    expect(markerSnippet).toContain("x: rect.x + rect.width / 2");
+    expect(markerSnippet).toContain("y: rect.y + rect.height / 2");
     expect(
       createDocsAnnotationRendererSnippet("box-corners", {
         ...defaultDemoPresentationSettings,
@@ -93,6 +104,20 @@ describe("docs annotation renderers", () => {
       "y: detection.rect.y + detection.rect.height / 2 - radiusY,",
     );
     expect(ellipseSnippet).toContain("alpha: 1,");
+  });
+
+  it("exposes marker shape and bounding-box position controls", () => {
+    expect(createDocsAnnotationRendererPresentation("markers")).toMatchObject({
+      markerPosition: "bottom-center",
+      markerShape: MarkerShape.Triangle,
+    });
+    expect(docsAnnotationRenderers.markers.selects).toMatchObject([
+      { key: "markerShape" },
+      { key: "markerPosition" },
+    ]);
+    expect(docsAnnotationRenderers.markers.selects?.[1]?.options).toHaveLength(
+      9,
+    );
   });
 
   it("keeps the polyline playground focused on one committed basketball trace", () => {

--- a/demo/src/docs-annotation-renderer.ts
+++ b/demo/src/docs-annotation-renderer.ts
@@ -1,5 +1,9 @@
-import type { DetectionFrame } from "supervision";
-import type { DemoPresentationSettings } from "./presentation/demo-presentation";
+import { MarkerShape, type DetectionFrame } from "supervision";
+import {
+  demoMarkerPositionOffsets,
+  type DemoMarkerPosition,
+  type DemoPresentationSettings,
+} from "./presentation/demo-presentation";
 
 const DOCS_ELLIPSE_COLOR = 0x8b5cf6;
 const DOCS_MASK_HALO_COLOR = 0x8b5cf6;
@@ -33,9 +37,22 @@ export interface DocsAnnotationRendererControl {
   readonly unit: "percent" | "pixels";
 }
 
+export type DocsAnnotationRendererSelectSetting =
+  "markerPosition" | "markerShape";
+
+export interface DocsAnnotationRendererSelectControl {
+  readonly key: DocsAnnotationRendererSelectSetting;
+  readonly label: string;
+  readonly options: readonly {
+    readonly label: string;
+    readonly value: DemoPresentationSettings[DocsAnnotationRendererSelectSetting];
+  }[];
+}
+
 export interface DocsAnnotationRendererDefinition {
   readonly controls: readonly DocsAnnotationRendererControl[];
   readonly description: string;
+  readonly selects?: readonly DocsAnnotationRendererSelectControl[];
   readonly title: string;
 }
 
@@ -193,7 +210,34 @@ export const docsAnnotationRenderers: Readonly<
         unit: "pixels",
       },
     ],
-    description: "Anchored marker at each detection center",
+    description: "Geometric markers anchored to detection bounds",
+    selects: [
+      {
+        key: "markerShape",
+        label: "Shape",
+        options: [
+          { label: "Circle", value: MarkerShape.Circle },
+          { label: "Square", value: MarkerShape.Square },
+          { label: "Triangle", value: MarkerShape.Triangle },
+          { label: "Cross", value: MarkerShape.Cross },
+        ],
+      },
+      {
+        key: "markerPosition",
+        label: "Position",
+        options: [
+          { label: "Top left", value: "top-left" },
+          { label: "Top center", value: "top-center" },
+          { label: "Top right", value: "top-right" },
+          { label: "Center left", value: "center-left" },
+          { label: "Center", value: "center" },
+          { label: "Center right", value: "center-right" },
+          { label: "Bottom left", value: "bottom-left" },
+          { label: "Bottom center", value: "bottom-center" },
+          { label: "Bottom right", value: "bottom-right" },
+        ],
+      },
+    ],
     title: "Markers",
   },
   labels: {
@@ -318,6 +362,12 @@ export function createDocsAnnotationRendererPresentation(
     maskHaloEnabled: renderer === "mask-halo",
     masksEnabled: renderer === "masks" || renderer === "polylines",
     markersEnabled: renderer === "markers",
+    ...(renderer === "markers"
+      ? {
+          markerPosition: "bottom-center" as const,
+          markerShape: MarkerShape.Triangle,
+        }
+      : {}),
     polygonsEnabled: renderer === "polygons",
     polylinesEnabled: renderer === "polylines",
     maskFillAlpha: 1,
@@ -437,6 +487,15 @@ export function createDocsAnnotationRendererSnippet(
   renderers: [
     annotationRenderers.marker({
       style: new BaseMarkerStyle({
+        center: (detection) => {
+          const rect = detection.rect;
+          if (!rect) return undefined;
+          return {
+            x: ${formatMarkerCoordinate("x", settings.markerPosition)},
+            y: ${formatMarkerCoordinate("y", settings.markerPosition)},
+          };
+        },
+        shape: MarkerShape.${markerShapeMemberNames[settings.markerShape]},
         size: ${formatNumber(settings.markerSize)},
         stroke: { width: ${formatNumber(settings.markerStrokeWidth)} },
       }),
@@ -512,4 +571,20 @@ function formatNumber(value: number) {
 
 function formatColor(color: number) {
   return `0x${color.toString(16).padStart(6, "0")}`;
+}
+
+const markerShapeMemberNames: Readonly<Record<MarkerShape, string>> = {
+  [MarkerShape.Circle]: "Circle",
+  [MarkerShape.Cross]: "Cross",
+  [MarkerShape.Square]: "Square",
+  [MarkerShape.Triangle]: "Triangle",
+};
+
+function formatMarkerCoordinate(axis: "x" | "y", position: DemoMarkerPosition) {
+  const offset = demoMarkerPositionOffsets[position][axis];
+  const dimension = axis === "x" ? "width" : "height";
+
+  if (offset === 0) return `rect.${axis}`;
+
+  return `rect.${axis} ${offset < 0 ? "-" : "+"} rect.${dimension} / 2`;
 }

--- a/demo/src/presentation/demo-presentation.test.ts
+++ b/demo/src/presentation/demo-presentation.test.ts
@@ -11,6 +11,7 @@ import {
   FocusTargetMode,
   KeypointVisibility,
   LabelPlacement,
+  MarkerShape,
   MaskRenderMode,
 } from "supervision";
 import {
@@ -454,6 +455,26 @@ describe("demo presentation", () => {
     expect(
       keypointsOnly.renderers?.map((renderer) => renderer.kind),
     ).not.toContain("polygon");
+  });
+
+  it("maps marker shape and bounding-box position onto the marker style", () => {
+    const presentation = createDemoPresentation({
+      ...defaultDemoPresentationSettings,
+      markerPosition: "top-left",
+      markerShape: MarkerShape.Triangle,
+      markersEnabled: true,
+    });
+
+    expect(
+      presentation.markerStyle?.resolve(rectangleDetection, {
+        detectionIndex: 0,
+        frame: { detections: [rectangleDetection], mediaTime: 0 },
+        mediaTime: 0,
+      }),
+    ).toMatchObject({
+      center: { x: 0, y: -8 },
+      shape: MarkerShape.Triangle,
+    });
   });
 
   it("maps polygon controls onto class-aware polygon draw instructions", () => {

--- a/demo/src/presentation/demo-presentation.ts
+++ b/demo/src/presentation/demo-presentation.ts
@@ -14,6 +14,7 @@ import {
   type DetectionClassColorStyle,
   FocusTargetMode,
   LabelPlacement,
+  MarkerShape,
   MaskRenderMode,
   annotationRenderers,
   type BoxDrawInstruction,
@@ -37,6 +38,20 @@ import {
 } from "supervision";
 
 export type DemoClassStyle = DetectionClassColorStyle;
+
+export const demoMarkerPositionOffsets = {
+  "top-left": { x: -0.5, y: -0.5 },
+  "top-center": { x: 0, y: -0.5 },
+  "top-right": { x: 0.5, y: -0.5 },
+  "center-left": { x: -0.5, y: 0 },
+  center: { x: 0, y: 0 },
+  "center-right": { x: 0.5, y: 0 },
+  "bottom-left": { x: -0.5, y: 0.5 },
+  "bottom-center": { x: 0, y: 0.5 },
+  "bottom-right": { x: 0.5, y: 0.5 },
+} as const;
+
+export type DemoMarkerPosition = keyof typeof demoMarkerPositionOffsets;
 
 export interface DemoPresentationSettings {
   readonly boxesEnabled: boolean;
@@ -75,6 +90,8 @@ export interface DemoPresentationSettings {
   readonly maskOpacity: number;
   readonly maskStrokeAlpha: number;
   readonly maskStrokeWidth: number;
+  readonly markerPosition: DemoMarkerPosition;
+  readonly markerShape: MarkerShape;
   readonly markerSize: number;
   readonly markerStrokeWidth: number;
   readonly polygonFillAlpha: number;
@@ -207,6 +224,8 @@ export const defaultDemoPresentationSettings: DemoPresentationSettings = {
   maskStrokeAlpha: 1,
   maskStrokeWidth: 2,
   masksEnabled: true,
+  markerPosition: "center",
+  markerShape: MarkerShape.Circle,
   markerSize: 14,
   markerStrokeWidth: 2,
   markersEnabled: false,
@@ -300,10 +319,20 @@ export function createDemoPresentation(
 function createDemoMarkerStyle(
   settings: DemoPresentationSettings,
 ): MarkerStyle {
+  const positionOffset = demoMarkerPositionOffsets[settings.markerPosition];
+
   return new BaseMarkerStyle({
+    center: (detection) =>
+      detection.rect
+        ? {
+            x: detection.rect.x + detection.rect.width * positionOffset.x,
+            y: detection.rect.y + detection.rect.height * positionOffset.y,
+          }
+        : undefined,
     fill: (detection) => ({
       color: resolveClassStyle(detection, settings).fill,
     }),
+    shape: settings.markerShape,
     shouldRender: (detection) => passesConfidenceThreshold(detection, settings),
     size: settings.markerSize,
     stroke: (detection) => ({

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -431,6 +431,13 @@ body {
   gap: 0.38rem;
 }
 
+.docs-layer-playground__select {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(4.5rem, 0.7fr) minmax(0, 1.3fr);
+}
+
 .docs-layer-playground__range > span,
 .docs-layer-playground__toggle {
   align-items: center;
@@ -439,10 +446,34 @@ body {
 }
 
 .docs-layer-playground__range strong,
+.docs-layer-playground__select strong,
 .docs-layer-playground__toggle strong {
   color: var(--muted-strong);
   font-size: 0.73rem;
   font-weight: 690;
+}
+
+.docs-layer-playground__select select {
+  appearance: none;
+  background:
+    linear-gradient(45deg, transparent 50%, var(--violet) 50%)
+      calc(100% - 0.9rem) calc(50% - 0.12rem) / 0.32rem 0.32rem no-repeat,
+    linear-gradient(135deg, var(--violet) 50%, transparent 50%)
+      calc(100% - 0.58rem) calc(50% - 0.12rem) / 0.32rem 0.32rem no-repeat,
+    #ffffff;
+  border: 1px solid #d4d4d8;
+  border-radius: 8px;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.73rem;
+  font-weight: 650;
+  min-width: 0;
+  padding: 0.45rem 1.7rem 0.45rem 0.6rem;
+}
+
+.docs-layer-playground__select select:focus-visible {
+  outline: 2px solid #8b5cf6;
+  outline-offset: 2px;
 }
 
 .docs-layer-playground__range output {

--- a/docs/public/annotation-renderers/markers.md
+++ b/docs/public/annotation-renderers/markers.md
@@ -20,8 +20,9 @@ the same renderer rather than separate rendering systems.
 </div>
 
 The playground uses the frozen basketball fixture's existing detection bounds.
-Markers are presentation only and do not replace the detection geometry used by
-picking or editing.
+Change the shape, choose any of the nine bounding-box anchors, and tune the
+size and stroke width while the code sample updates. Markers are presentation
+only and do not replace the detection geometry used by picking or editing.
 
 ## Add a marker renderer
 
@@ -30,6 +31,11 @@ session.setPresentation({
   renderers: [
     annotationRenderers.marker({
       style: new BaseMarkerStyle({
+        center: (detection) => {
+          const rect = detection.rect;
+          if (!rect) return undefined;
+          return { x: rect.x, y: rect.y + rect.height / 2 };
+        },
         shape: MarkerShape.Triangle,
         size: 14,
         stroke: { color: 0x8b5cf6, width: 2 },


### PR DESCRIPTION
## Description

Improves the focused marker annotation renderer playground so users can explore the existing renderer-neutral marker API beyond size and stroke width.

- Adds shape controls for circle, square, triangle, and cross markers.
- Adds nine bounding-box anchor positions resolved through `BaseMarkerStyle.center`.
- Keeps the live code sample synchronized with shape, position, size, and stroke changes.
- Updates the marker guide with the configurable anchor example.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [x] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

- `npm run verify`
- Headless Chrome smoke check of `/?embed=annotation-renderer&renderer=markers`

## Notes For Reviewers

This does not add or change the public marker renderer contract. The playground maps its controls onto the existing `MarkerShape` and media-space `center` resolver primitives. Marker presentation remains independent from picking and editing geometry.