### PR TITLE
Add static icons to the asset region playground

### DIFF
--- a/demo/src/assets/white-team-badge.svg
+++ b/demo/src/assets/white-team-badge.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <circle cx="48" cy="48" r="43" fill="#f5f3ff" stroke="#7c3aed" stroke-width="6" />
+  <path
+    d="M36 27 25 34l-8 16 12 6 5-9v25h28V47l5 9 12-6-8-16-11-7c-2 5-6 8-12 8s-10-3-12-8Z"
+    fill="#ffffff"
+    stroke="#24143d"
+    stroke-linejoin="round"
+    stroke-width="4"
+  />
+  <path d="M40 49h16M48 41v16" stroke="#7c3aed" stroke-linecap="round" stroke-width="4" />
+</svg>

--- a/demo/src/assets/yellow-team-badge.svg
+++ b/demo/src/assets/yellow-team-badge.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <circle cx="48" cy="48" r="43" fill="#fff7cc" stroke="#7c3aed" stroke-width="6" />
+  <path
+    d="M36 27 25 34l-8 16 12 6 5-9v25h28V47l5 9 12-6-8-16-11-7c-2 5-6 8-12 8s-10-3-12-8Z"
+    fill="#facc15"
+    stroke="#24143d"
+    stroke-linejoin="round"
+    stroke-width="4"
+  />
+  <path d="M40 49h16M48 41v16" stroke="#7c3aed" stroke-linecap="round" stroke-width="4" />
+</svg>

--- a/demo/src/components/DocsRegionAnnotationRendererPlayground.tsx
+++ b/demo/src/components/DocsRegionAnnotationRendererPlayground.tsx
@@ -1,32 +1,41 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
   MediaRendererPlaybackState,
-  annotationRenderers,
   type MediaRendererPresentation,
 } from "supervision";
 import playerFireUrl from "../assets/player-fire.gif?url";
+import whiteTeamBadgeUrl from "../assets/white-team-badge.svg?url";
+import yellowTeamBadgeUrl from "../assets/yellow-team-badge.svg?url";
+import {
+  createRegionPlaygroundRenderers,
+  createRegionPlaygroundSettings,
+  createRegionPlaygroundSnippet,
+  initialRegionPlaygroundSettings,
+  RegionPlaygroundMode,
+  type RegionPlaygroundMode as RegionPlaygroundModeValue,
+  type RegionPlaygroundSettings,
+} from "../docs-region-annotation-renderer";
 import { useDemoRenderer } from "../hooks/useDemoRenderer";
 import { RendererViewport } from "./RendererViewport";
 
-interface RegionPlaygroundSettings {
-  readonly offsetY: number;
-  readonly rotationDegrees: number;
-  readonly scale: number;
-}
-
-const initialSettings: RegionPlaygroundSettings = {
-  offsetY: -0.58,
-  rotationDegrees: 0,
-  scale: 1.35,
+const regionPlaygroundAssets = {
+  fireGif: playerFireUrl,
+  whiteTeamBadge: whiteTeamBadgeUrl,
+  yellowTeamBadge: yellowTeamBadgeUrl,
 };
 
 export function DocsRegionAnnotationRendererPlayground() {
-  const settingsRef = useRef(initialSettings);
-  const [settings, setSettings] = useState(initialSettings);
+  const settingsRef = useRef(initialRegionPlaygroundSettings);
+  const [settings, setSettings] = useState(initialRegionPlaygroundSettings);
   const presentationTransform = useCallback(
     (presentation: MediaRendererPresentation): MediaRendererPresentation => ({
       ...presentation,
-      renderers: [createFireRenderer(settingsRef.current)],
+      renderers: [
+        ...createRegionPlaygroundRenderers(
+          settingsRef.current,
+          regionPlaygroundAssets,
+        ),
+      ],
     }),
     [],
   );
@@ -54,7 +63,10 @@ export function DocsRegionAnnotationRendererPlayground() {
         : 0,
     [currentTime, demo.duration],
   );
-  const snippet = useMemo(() => createSnippet(settings), [settings]);
+  const snippet = useMemo(
+    () => createRegionPlaygroundSnippet(settings),
+    [settings],
+  );
   const updateSettings = useCallback(
     (next: RegionPlaygroundSettings) => {
       settingsRef.current = next;
@@ -63,6 +75,12 @@ export function DocsRegionAnnotationRendererPlayground() {
     },
     [demo],
   );
+  const updateMode = useCallback(
+    (mode: RegionPlaygroundModeValue) =>
+      updateSettings(createRegionPlaygroundSettings(mode)),
+    [updateSettings],
+  );
+  const showsIcons = settings.mode === RegionPlaygroundMode.StaticIcons;
 
   return (
     <main
@@ -82,8 +100,12 @@ export function DocsRegionAnnotationRendererPlayground() {
         <header className="docs-layer-playground__header">
           <div>
             <p>Annotation renderer</p>
-            <h1>Animated Asset Regions</h1>
-            <span>Looping fire GIFs anchored to player keypoints</span>
+            <h1>Asset Regions</h1>
+            <span>
+              {showsIcons
+                ? "Class-specific SVG badges anchored to player keypoints"
+                : "Looping fire GIFs anchored to player keypoints"}
+            </span>
           </div>
           <button
             aria-label={
@@ -99,8 +121,9 @@ export function DocsRegionAnnotationRendererPlayground() {
         </header>
 
         <div className="docs-layer-playground__controls">
+          <RegionModeControl onChange={updateMode} value={settings.mode} />
           <RegionRangeControl
-            label="Scale"
+            label={showsIcons ? "Icon scale" : "GIF scale"}
             max={2.2}
             min={0.5}
             onChange={(scale) =>
@@ -117,7 +140,7 @@ export function DocsRegionAnnotationRendererPlayground() {
             onChange={(offsetY) =>
               updateSettings({ ...settingsRef.current, offsetY })
             }
-            step={0.05}
+            step={0.01}
             value={settings.offsetY}
             valueLabel={settings.offsetY.toFixed(2)}
           />
@@ -155,6 +178,40 @@ export function DocsRegionAnnotationRendererPlayground() {
   );
 }
 
+function RegionModeControl({
+  onChange,
+  value,
+}: {
+  readonly onChange: (mode: RegionPlaygroundModeValue) => void;
+  readonly value: RegionPlaygroundModeValue;
+}) {
+  return (
+    <fieldset className="docs-layer-playground__asset-type">
+      <legend>Asset type</legend>
+      <div>
+        <label>
+          <input
+            checked={value === RegionPlaygroundMode.StaticIcons}
+            name="region-asset-type"
+            onChange={() => onChange(RegionPlaygroundMode.StaticIcons)}
+            type="radio"
+          />
+          <span>Static icons</span>
+        </label>
+        <label>
+          <input
+            checked={value === RegionPlaygroundMode.AnimatedGif}
+            name="region-asset-type"
+            onChange={() => onChange(RegionPlaygroundMode.AnimatedGif)}
+            type="radio"
+          />
+          <span>Animated GIF</span>
+        </label>
+      </div>
+    </fieldset>
+  );
+}
+
 function RegionRangeControl({
   label,
   max,
@@ -188,40 +245,4 @@ function RegionRangeControl({
       />
     </label>
   );
-}
-
-function createFireRenderer(settings: RegionPlaygroundSettings) {
-  return annotationRenderers.region({
-    compose: { mode: "over" },
-    id: "player-fire",
-    region: { anchor: "head", kind: "keypoint-anchor" },
-    source: { asset: { src: playerFireUrl }, kind: "asset" },
-    target: {
-      className: ["white team player", "yellow team player"],
-    },
-    transform: {
-      offset: { x: 0, y: settings.offsetY },
-      rotation: (settings.rotationDegrees * Math.PI) / 180,
-      scale: settings.scale,
-    },
-  });
-}
-
-function createSnippet(settings: RegionPlaygroundSettings) {
-  return `session.setPresentation({
-  renderers: [
-    annotationRenderers.region({
-      id: "player-fire",
-      target: { className: ["white team player", "yellow team player"] },
-      source: { kind: "asset", asset: { src: fireGifUrl } },
-      region: { kind: "keypoint-anchor", anchor: "head" },
-      transform: {
-        scale: ${settings.scale.toFixed(2)},
-        offset: { x: 0, y: ${settings.offsetY.toFixed(2)} },
-        rotation: ${((settings.rotationDegrees * Math.PI) / 180).toFixed(2)},
-      },
-      compose: { mode: "over" },
-    }),
-  ],
-});`;
 }

--- a/demo/src/docs-region-annotation-renderer.test.ts
+++ b/demo/src/docs-region-annotation-renderer.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRegionPlaygroundRenderers,
+  createRegionPlaygroundSettings,
+  createRegionPlaygroundSnippet,
+  RegionPlaygroundMode,
+} from "./docs-region-annotation-renderer";
+
+const assets = {
+  fireGif: "/fire.gif",
+  whiteTeamBadge: "/white-team.svg",
+  yellowTeamBadge: "/yellow-team.svg",
+};
+
+describe("docs region annotation renderer", () => {
+  it("renders class-specific icons through multiple region descriptors", () => {
+    const settings = {
+      ...createRegionPlaygroundSettings(RegionPlaygroundMode.StaticIcons),
+      offsetY: -0.8,
+      rotationDegrees: 15,
+      scale: 1.2,
+    };
+    const renderers = createRegionPlaygroundRenderers(settings, assets);
+
+    expect(renderers).toHaveLength(2);
+    expect(renderers).toMatchObject([
+      {
+        id: "white-team-badge",
+        kind: "region",
+        region: { anchor: "head", kind: "keypoint-anchor" },
+        source: { asset: { src: assets.whiteTeamBadge }, kind: "asset" },
+        target: { className: "white team player" },
+      },
+      {
+        id: "yellow-team-badge",
+        kind: "region",
+        source: { asset: { src: assets.yellowTeamBadge }, kind: "asset" },
+        target: { className: "yellow team player" },
+      },
+    ]);
+    expect(renderers[0]?.transform).toMatchObject({
+      offset: { x: 0, y: -0.8 },
+      rotation: Math.PI / 12,
+      scale: 1.2,
+    });
+  });
+
+  it("keeps the animated GIF example on the same region API", () => {
+    const settings = createRegionPlaygroundSettings(
+      RegionPlaygroundMode.AnimatedGif,
+    );
+
+    expect(createRegionPlaygroundRenderers(settings, assets)).toMatchObject([
+      {
+        id: "player-fire",
+        kind: "region",
+        source: { asset: { src: assets.fireGif }, kind: "asset" },
+        target: {
+          className: ["white team player", "yellow team player"],
+        },
+      },
+    ]);
+  });
+
+  it("keeps the selected asset type and live transforms in the snippet", () => {
+    const icons = createRegionPlaygroundSnippet({
+      ...createRegionPlaygroundSettings(RegionPlaygroundMode.StaticIcons),
+      offsetY: -0.75,
+      rotationDegrees: 30,
+      scale: 1.1,
+    });
+    const animated = createRegionPlaygroundSnippet(
+      createRegionPlaygroundSettings(RegionPlaygroundMode.AnimatedGif),
+    );
+
+    expect(icons).toContain("id, className, src");
+    expect(icons).toContain("offset: { x: 0, y: -0.75 }");
+    expect(icons).toContain("rotation: 0.52");
+    expect(icons).toContain("scale: 1.10");
+    expect(animated).toContain("asset: { src: fireGifUrl }");
+  });
+});

--- a/demo/src/docs-region-annotation-renderer.ts
+++ b/demo/src/docs-region-annotation-renderer.ts
@@ -1,0 +1,149 @@
+import {
+  annotationRenderers,
+  type RegionAnnotationRenderer,
+} from "supervision";
+
+export const RegionPlaygroundMode = {
+  AnimatedGif: "animated-gif",
+  StaticIcons: "static-icons",
+} as const;
+
+export type RegionPlaygroundMode =
+  (typeof RegionPlaygroundMode)[keyof typeof RegionPlaygroundMode];
+
+export interface RegionPlaygroundSettings {
+  readonly mode: RegionPlaygroundMode;
+  readonly offsetY: number;
+  readonly rotationDegrees: number;
+  readonly scale: number;
+}
+
+export interface RegionPlaygroundAssets {
+  readonly fireGif: string;
+  readonly whiteTeamBadge: string;
+  readonly yellowTeamBadge: string;
+}
+
+const modeDefaults: Readonly<
+  Record<RegionPlaygroundMode, RegionPlaygroundSettings>
+> = {
+  [RegionPlaygroundMode.AnimatedGif]: {
+    mode: RegionPlaygroundMode.AnimatedGif,
+    offsetY: -0.58,
+    rotationDegrees: 0,
+    scale: 1.35,
+  },
+  [RegionPlaygroundMode.StaticIcons]: {
+    mode: RegionPlaygroundMode.StaticIcons,
+    offsetY: -1.05,
+    rotationDegrees: 0,
+    scale: 0.95,
+  },
+};
+
+export const initialRegionPlaygroundSettings =
+  modeDefaults[RegionPlaygroundMode.StaticIcons];
+
+export function createRegionPlaygroundSettings(
+  mode: RegionPlaygroundMode,
+): RegionPlaygroundSettings {
+  return modeDefaults[mode];
+}
+
+export function createRegionPlaygroundRenderers(
+  settings: RegionPlaygroundSettings,
+  assets: RegionPlaygroundAssets,
+): readonly RegionAnnotationRenderer[] {
+  if (settings.mode === RegionPlaygroundMode.AnimatedGif) {
+    return [
+      createRegionRenderer({
+        assetUrl: assets.fireGif,
+        className: ["white team player", "yellow team player"],
+        id: "player-fire",
+        settings,
+      }),
+    ];
+  }
+
+  return [
+    createRegionRenderer({
+      assetUrl: assets.whiteTeamBadge,
+      className: "white team player",
+      id: "white-team-badge",
+      settings,
+    }),
+    createRegionRenderer({
+      assetUrl: assets.yellowTeamBadge,
+      className: "yellow team player",
+      id: "yellow-team-badge",
+      settings,
+    }),
+  ];
+}
+
+export function createRegionPlaygroundSnippet(
+  settings: RegionPlaygroundSettings,
+) {
+  const transform = `transform: {
+        scale: ${settings.scale.toFixed(2)},
+        offset: { x: 0, y: ${settings.offsetY.toFixed(2)} },
+        rotation: ${degreesToRadians(settings.rotationDegrees).toFixed(2)},
+      }`;
+
+  if (settings.mode === RegionPlaygroundMode.AnimatedGif) {
+    return `session.setPresentation({
+  renderers: [
+    annotationRenderers.region({
+      id: "player-fire",
+      target: { className: ["white team player", "yellow team player"] },
+      source: { kind: "asset", asset: { src: fireGifUrl } },
+      region: { kind: "keypoint-anchor", anchor: "head" },
+      ${transform},
+      compose: { mode: "over" },
+    }),
+  ],
+});`;
+  }
+
+  return `const teamBadges = [
+  ["white-team-badge", "white team player", whiteBadgeUrl],
+  ["yellow-team-badge", "yellow team player", yellowBadgeUrl],
+];
+
+session.setPresentation({
+  renderers: teamBadges.map(([id, className, src]) =>
+    annotationRenderers.region({
+      id,
+      target: { className },
+      source: { kind: "asset", asset: { src } },
+      region: { kind: "keypoint-anchor", anchor: "head" },
+      ${transform},
+      compose: { mode: "over" },
+    }),
+  ),
+});`;
+}
+
+function createRegionRenderer(options: {
+  readonly assetUrl: string;
+  readonly className: string | readonly string[];
+  readonly id: string;
+  readonly settings: RegionPlaygroundSettings;
+}) {
+  return annotationRenderers.region({
+    compose: { mode: "over" },
+    id: options.id,
+    region: { anchor: "head", kind: "keypoint-anchor" },
+    source: { asset: { src: options.assetUrl }, kind: "asset" },
+    target: { className: options.className },
+    transform: {
+      offset: { x: 0, y: options.settings.offsetY },
+      rotation: degreesToRadians(options.settings.rotationDegrees),
+      scale: options.settings.scale,
+    },
+  });
+}
+
+function degreesToRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
+}

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -438,6 +438,58 @@ body {
   grid-template-columns: minmax(4.5rem, 0.7fr) minmax(0, 1.3fr);
 }
 
+.docs-layer-playground__asset-type {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.docs-layer-playground__asset-type legend {
+  color: var(--muted-strong);
+  font-size: 0.73rem;
+  font-weight: 690;
+}
+
+.docs-layer-playground__asset-type > div {
+  background: #ede9fe;
+  border-radius: 9px;
+  display: grid;
+  gap: 0.25rem;
+  grid-template-columns: 1fr 1fr;
+  padding: 0.25rem;
+}
+
+.docs-layer-playground__asset-type label {
+  cursor: pointer;
+  position: relative;
+}
+
+.docs-layer-playground__asset-type input {
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.docs-layer-playground__asset-type span {
+  border-radius: 7px;
+  color: var(--muted-strong);
+  display: block;
+  font-size: 0.68rem;
+  font-weight: 720;
+  padding: 0.42rem 0.5rem;
+  text-align: center;
+}
+
+.docs-layer-playground__asset-type input:checked + span {
+  background: #ffffff;
+  box-shadow: 0 1px 4px rgba(76, 29, 149, 0.16);
+  color: var(--violet);
+}
+
+.docs-layer-playground__asset-type input:focus-visible + span {
+  outline: 2px solid #8b5cf6;
+  outline-offset: 1px;
+}
+
 .docs-layer-playground__range > span,
 .docs-layer-playground__toggle {
   align-items: center;

--- a/docs/public/annotation-renderers/asset-regions.md
+++ b/docs/public/annotation-renderers/asset-regions.md
@@ -6,9 +6,10 @@ summary: Place image assets over detection bounds or keypoint anchors.
 # Asset Regions
 
 The region annotation renderer places a browser-loadable image over a region
-owned by a semantic detection. It is useful for animated GIFs, badges, logos,
-and other assets that should follow objects across playback without exposing a
-Pixi texture, animation source, or display object to application code.
+owned by a semantic detection. It is useful for static icons, badges, logos,
+animated GIFs, and other assets that should follow objects across playback
+without exposing a Pixi texture, animation source, or display object to
+application code.
 
 <div class="supervision-layer-playground">
   <iframe
@@ -19,11 +20,41 @@ Pixi texture, animation source, or display object to application code.
 </div>
 
 The playground uses the frozen basketball fixture's real COCO pose keypoints.
-Its looping fire GIF is an original repository asset, loaded and animated by
-the browser renderer, then anchored to the visible face keypoints of each
-player.
+Switch between class-specific SVG team badges and a looping fire GIF, then tune
+the shared scale, offset, and rotation controls. Both examples are loaded by
+the browser renderer and anchored to visible face keypoints.
 
-## Add an asset region renderer
+## Add static icon regions
+
+Give each independently targeted asset a stable renderer id. This example
+maps two SVG badge URLs to the matching player classes while sharing the same
+semantic head anchor and transform:
+
+```ts
+const teamBadges = [
+  ["white-team-badge", "white team player", whiteBadgeUrl],
+  ["yellow-team-badge", "yellow team player", yellowBadgeUrl],
+] as const;
+
+session.setPresentation({
+  renderers: teamBadges.map(([id, className, src]) =>
+    annotationRenderers.region({
+      id,
+      target: { className },
+      source: { kind: "asset", asset: { src } },
+      region: { kind: "keypoint-anchor", anchor: "head" },
+      transform: {
+        scale: 0.95,
+        offset: { x: 0, y: -1.05 },
+        rotation: 0,
+      },
+      compose: { mode: "over" },
+    }),
+  ),
+});
+```
+
+## Add an animated asset region
 
 ```ts
 const fireGifUrl = new URL("./fire.gif", import.meta.url).href;


### PR DESCRIPTION
## Description

Extends the Asset Regions docs playground with class-specific static SVG badges alongside the existing animated GIF example.

The playground now lets readers switch asset type and tune scale, vertical offset, and rotation while keeping the live code sample synchronized. Static icons deliberately use the existing semantic `annotationRenderers.region` API with stable renderer IDs and class targets; this does not add a new public shape primitive or expose Pixi implementation types.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [x] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

- `npm run verify`
- Browser QA for the static icon/GIF toggle, per-mode defaults, range controls, and live snippets
- Direct browser rendering of both SVG badge assets

## Notes For Reviewers

This follows the asset-backed region direction that superseded the earlier icon primitive work in #65 and #66. The static badges remain regular browser-loadable assets and Pixi asset loading/sprites stay private to the renderer implementation.
