### PR TITLE
Prepare supervision 0.1.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ session.setPresentation({
 npm install supervision
 ```
 
-The next browser release is `0.1.4`, prepared for npm's default `latest` tag.
+The next browser release is `0.1.5`, prepared for npm's default `latest` tag.
 Its package includes the private core dependency. Consumers import
 only the public browser entrypoints:
 

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -2,7 +2,7 @@
 
 (function () {
   const packageName = "supervision";
-  const packageVersion = "0.1.4";
+  const packageVersion = "0.1.5";
   const packageReleaseStatus = "";
   const kindIconMap = {
     Accessor: "A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10364,7 +10364,7 @@
     },
     "packages/web": {
       "name": "supervision",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.52.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supervision",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Browser-native computer vision media rendering and annotation engine.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Prepare supervision@0.1.5 for the stable npm latest channel after browser tracking was merged in #82. The release metadata, lockfile, documentation toolbar, and README now agree on the published version.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [x] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] npm run verify
- [x] npm run package:tarball
- [x] npm run package:tarball:smoke
- [x] npm publish ./artifacts/supervision-0.1.5.tgz --access public --tag latest --dry-run
- [x] Tests added or updated where behavior changed
- [x] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

## Notes For Reviewers

This is release preparation only. After merge, dispatch Publish npm package from main with the latest tag and approve the npm-publish environment.