### PR TITLE
Resolve the docs demo link from the page base once

### DIFF
--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -247,7 +247,7 @@
       `${base}assets/brand/roboflow-logomark.svg`,
       window.location.href,
     ).href;
-    const demoUrl = resolveDemoUrl(`${base}demo/`);
+    const demoUrl = resolveDemoUrl("demo/");
     const version = packageReleaseStatus
       ? `v${packageVersion} (${packageReleaseStatus})`
       : `v${packageVersion}`;

--- a/tools/docs-contract.test.mjs
+++ b/tools/docs-contract.test.mjs
@@ -415,6 +415,10 @@ test("deployed site presents docs at the root and the workbench at /demo/", asyn
     /data-supervision-playground-src="demo\/\?embed=docs-playground"/,
   );
   assert.match(toolbar, /function resolveDemoUrl\(deployedPath\)/);
+  // resolveDemoUrl() prefixes data-base itself, so a call site that also
+  // interpolates the base applies it twice. That resolves above the project
+  // prefix on nested pages and sends the deployed link to /demo/.
+  assert.doesNotMatch(toolbar, /resolveDemoUrl\(`\$\{base\}/);
 });
 
 test("copyable integration examples typecheck", async () => {


### PR DESCRIPTION
## Description

The documentation toolbar built its demo URL as `resolveDemoUrl(`${base}demo/`)`, but
`resolveDemoUrl()` already prefixes `data-base` internally. The base was therefore applied
twice.

TypeDoc emits `data-base="./"` on the three root pages and `data-base="../"` on the other
417. The doubling was a no-op on the home page (`./` + `./demo/`), so the link worked there,
but every nested page resolved `../` + `../demo/` to `../../demo/` — one level above the
project prefix. On GitHub Pages that lands on `https://roboflow.github.io/demo/`, which 404s,
instead of `https://roboflow.github.io/supervision-js/demo/`.

Every other `resolveDemoUrl()` call site already passes a base-less path — the home hero
button passes `demo/`, and each playground iframe passes `demo/?embed=…`. This makes the
toolbar consistent with them.

The deployed-site contract test asserted that `resolveDemoUrl()` exists but never asserted
how it is called, so the double-application passed. It now rejects any call site that
interpolates the base.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [ ] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

- `npm run docs:check` passes. Reintroducing the old call site fails the
  `deployed site presents docs at the root and the workbench at /demo/` test, confirming the
  new assertion actually catches the regression.
- `npm run format:check` and `npm run lint` pass.
- `npm run pages:build` completes, including its own artifact verification.
- Served the assembled `dist/pages` behind a `/supervision-js/` path prefix and read the
  resolved links from the live DOM:
  - `documents/Annotation_Renderers.Mask_Halo.html` (`data-base="../"`) — toolbar Demo now
    resolves to `/supervision-js/demo/` and returns 200; previously `/demo/`.
  - `index.html` (`data-base="./"`) — toolbar Demo, the home hero button, and the embedded
    playground all still resolve to `/supervision-js/demo/`.
  - Playground iframes, the Docs home link, and the sidebar root link are unchanged.

## Notes For Reviewers

This only reproduces under a path prefix. The standalone docs server mounts the site at its
origin root, where both the correct and doubled paths resolve to something plausible, which
is why it survived local review. To reproduce, serve `dist/pages` beneath a `supervision-js/`
directory rather than at the root.

No public API or documentation content changes; the fix is one line in the toolbar script
plus the assertion that guards it.
