### PR TITLE
Prepare supervision 0.1.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ session.setPresentation({
 npm install supervision
 ```
 
-The next browser release is `0.1.5`, prepared for npm's default `latest` tag.
+The next browser release is `0.1.6`, prepared for npm's default `latest` tag.
 Its package includes the private core dependency. Consumers import
 only the public browser entrypoints:
 

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -2,7 +2,7 @@
 
 (function () {
   const packageName = "supervision";
-  const packageVersion = "0.1.5";
+  const packageVersion = "0.1.6";
   const packageReleaseStatus = "";
   const kindIconMap = {
     Accessor: "A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10750,7 +10750,7 @@
     },
     "packages/web": {
       "name": "supervision",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.52.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supervision",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Browser-native computer vision media rendering and annotation engine.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Prepares the `0.1.6` browser release. Version-only change: `packages/web/package.json`, the docs toolbar mirror in `docs/public/typedoc-icons.js`, the README install note, and `package-lock.json`.

Ships three merged changes that are on `main` but unreleased:

- #87 — harden live media and progressive detection integration
- #85 — experimental Android saved-video frame source (NDK MediaCodec)
- #86 — resolve the docs demo link from the page base once

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [x] Refactor or maintenance
- [ ] Performance improvement

## Validation

- `npm run verify` — 102 test files, 803 tests, all green
- `npm run docs:check` — toolbar version mirror matches the package manifest

- [ ] Tests added or updated where behavior changed
- [x] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

## Notes For Reviewers

Patch bump, consistent with the `0.1.1`–`0.1.5` cadence: #87 keeps the existing public structural contracts assignable and adds capability behind narrower interfaces.

One behavior change in #87 is worth calling out in the release notes even though it is compatible in practice: `getChangesSince()` now clips the ranges it returns to the ranges the caller asked about, so a caller receives the intersection rather than the full journaled range. Every in-repo consumer already intersected the result, and the clip also guarantees a finite, loadable range when a caller asks about an unbounded interval.
