### PR TITLE
chore: prepare supervision 0.1.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ session.setPresentation({
 npm install supervision
 ```
 
-The next browser release is `0.1.6`, prepared for npm's default `latest` tag.
+The next browser release is `0.1.7`, prepared for npm's default `latest` tag.
 Its package includes the private core dependency. Consumers import
 only the public browser entrypoints:
 

--- a/docs/public/typedoc-icons.js
+++ b/docs/public/typedoc-icons.js
@@ -2,7 +2,7 @@
 
 (function () {
   const packageName = "supervision";
-  const packageVersion = "0.1.6";
+  const packageVersion = "0.1.7";
   const packageReleaseStatus = "";
   const kindIconMap = {
     Accessor: "A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10750,7 +10750,7 @@
     },
     "packages/web": {
       "name": "supervision",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "mediabunny": "^1.52.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supervision",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Browser-native computer vision media rendering and annotation engine.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Version bump only — same four files as every release commit in this repo:
`packages/web/package.json`, `package-lock.json`, `README.md`, and
`docs/public/typedoc-icons.js` (the docs toolbar mirror that `npm run docs:check`
enforces against the manifest).

`0.1.6` was published on 2026-08-19 20:11Z, about 17 hours before #83 merged, so
it does not contain the keypoint editing work. npm never allows republishing a
version — even an unpublish inside the 72h window burns the number permanently —
so this goes out as `0.1.7` rather than as a correction to `0.1.6`.

## What ships that `0.1.6` did not

- #83 — keypoint editing parity: viewport-scaled picking, nearest keypoint and
  handle picking, `KeypointGeometry.boxRelative`, click-vs-drag threshold on
  handles, and in-place editing driven by the live preview.

Note for consumers who tuned pick tolerances: `DetectionPickOptions` paddings are
now screen-space, divided by the media-to-screen scale, and the renderers always
supply that scale. A `padding` value that was tuned as a media-space number will
resolve to a different effective tolerance at any scale other than 1. The new
semantics are the intended ones — a fixed media-space tolerance shrinks below the
drawn marker when zoomed out — but the change is silent from a caller's side.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [x] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes
- `npm run verify` green (102 test files / 822 tests)

## Release plan

1. Merge this.
2. Run `publish-npm.yml` from `main` for `0.1.7` on the default `latest` tag.
3. roboflow/roboflow#14491 pins `0.1.7` and merges after the publish lands.