### PR TITLE
fix(web): include exact range-end chunks in chunked detection source

### DIFF
--- a/packages/web/src/detections/chunked-detection-frame-source.test.ts
+++ b/packages/web/src/detections/chunked-detection-frame-source.test.ts
@@ -63,6 +63,50 @@ describe("createChunkedDetectionFrameSource", () => {
     ]);
   });
 
+  it("returns frames that start exactly at the requested range end", async () => {
+    const manifest = createManifest();
+    const chunks = new Map<number, DetectionFrameChunk>([
+      [
+        1,
+        {
+          frames: [
+            { detections: [], endTime: 1.8, frameIndex: 2, mediaTime: 1.6 },
+          ],
+        },
+      ],
+      [
+        2,
+        {
+          frames: [
+            { detections: [], frameIndex: 3, mediaTime: 2 },
+            { detections: [], endTime: 2.5, frameIndex: 4, mediaTime: 2 },
+            { detections: [], frameIndex: 5, mediaTime: 2.05 },
+          ],
+        },
+      ],
+    ]);
+    const fetchChunk = vi.fn(async (chunk: { chunkIndex: number }) => {
+      const fixtureChunk = chunks.get(chunk.chunkIndex);
+
+      if (!fixtureChunk) {
+        throw new Error(`Missing test chunk ${chunk.chunkIndex}.`);
+      }
+
+      return fixtureChunk;
+    });
+    const source = createChunkedDetectionFrameSource({
+      fetchChunk,
+      manifest,
+    });
+
+    const frames = await source.loadFrames(1.5, 2);
+
+    expect(frames.map((frame) => frame.frameIndex).sort()).toEqual([2, 3, 4]);
+    expect(
+      fetchChunk.mock.calls.map(([chunk]) => chunk.chunkIndex).sort(),
+    ).toEqual([1, 2]);
+  });
+
   it("loads JSON chunks from descriptor URLs by default", async () => {
     const manifest = createManifest();
     const fetchMock = vi.fn(async () => {

--- a/packages/web/src/detections/chunked-detection-frame-source.ts
+++ b/packages/web/src/detections/chunked-detection-frame-source.ts
@@ -81,7 +81,7 @@ function getOverlappingChunks(
   endTime: number,
 ) {
   return chunks.filter(
-    (chunk) => chunk.startTime < endTime && chunk.endTime > startTime,
+    (chunk) => chunk.startTime <= endTime && chunk.endTime > startTime,
   );
 }
 


### PR DESCRIPTION
## Description

Fixes #94

`createChunkedDetectionFrameSource().loadFrames(startTime, endTime)` previously used a strict `chunk.startTime < endTime` predicate in `getOverlappingChunks`.

Because chunk descriptors use half-open intervals `[startTime, endTime)`, a point frame located exactly at `endTime` resides in the chunk starting at `endTime`. While `detectionFrameOverlapsRange` correctly treats point frames at `endTime` as overlapping (`frame.mediaTime <= endTime`), the chunk holding those frames was never fetched, causing boundary detections to be silently dropped.

This change updates the predicate to:
```ts
chunk.startTime <= endTime && chunk.endTime > startTime
```
This ensures chunks starting at `endTime` are fetched and matches the range iteration behavior used in `browser-cold-detection-frame-store.ts`. Extra frames beyond the query range continue to be filtered out by `detectionFrameOverlapsRange`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [ ] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

Added unit tests in `chunked-detection-frame-source.test.ts` verifying that point frames and interval frames starting exactly at the requested range end are fetched and returned, while frames strictly past the end are excluded.

Ran:
- `npx vitest run packages/web/src/detections/chunked-detection-frame-source.test.ts`
- `npm run verify`

## Notes For Reviewers

None.