### PR TITLE
fix(web): guard seek and step presentation against superseded navigation

### DIFF
--- a/packages/web/src/renderers/media-renderer-core.test.ts
+++ b/packages/web/src/renderers/media-renderer-core.test.ts
@@ -591,6 +591,85 @@ describe("media renderer core", () => {
     renderer.destroy();
   });
 
+  it("keeps the latest seek when an older prepare resolves afterward", async () => {
+    resetMocks();
+
+    const prepareGate = createDeferred<void>();
+    let releaseOlderPrepare: (() => void) | undefined;
+    const olderPrepareEntered = new Promise<void>((resolve) => {
+      releaseOlderPrepare = resolve;
+    });
+    const olderSample = createMockSample(
+      0.5,
+      0.5,
+    ) as unknown as DecodedVideoSample;
+    const latestSample = createMockSample(
+      1.5,
+      0.5,
+    ) as unknown as DecodedVideoSample;
+    const samples = [
+      createMockSample(0, 2),
+      olderSample,
+      latestSample,
+    ] as unknown as DecodedVideoSample[];
+    const detectionSource = {
+      loadFrames: vi.fn(async (startTime: number) => {
+        if (startTime === 0.5) {
+          releaseOlderPrepare?.();
+          await prepareGate.promise;
+        }
+
+        return [];
+      }),
+    };
+    const scene = createScene();
+    const renderer = await createMediaRendererCore(
+      {
+        autoPlay: false,
+        container: {} as HTMLElement,
+        detectionBuffer: {
+          bufferAheadSeconds: 0,
+          bufferBehindSeconds: 0,
+          frameRate: 30,
+          selectionMode: DetectionFrameSelectionMode.NearestFrameIndex,
+        },
+        detectionSource,
+        loop: false,
+        source: createSource(samples, {
+          duration: 2,
+        }),
+      } satisfies MediaRendererOptions,
+      {
+        createScene: vi.fn(async () => scene),
+        openMediaSource: vi.fn(),
+      },
+    );
+
+    vi.mocked(scene.presentSample).mockClear();
+
+    const olderRequest = renderer.seek(0.5);
+    await olderPrepareEntered;
+
+    const latestRequest = renderer.seek(1.5);
+    await latestRequest;
+
+    expect(renderer.getState().currentTime).toBe(1.5);
+
+    prepareGate.resolve();
+    await olderRequest;
+
+    expect(renderer.getState().currentTime).toBe(1.5);
+    expect(scene.presentSample).not.toHaveBeenCalledWith(
+      expect.objectContaining({ timestamp: 0.5 }),
+    );
+    expect(scene.presentSample).toHaveBeenLastCalledWith(
+      expect.objectContaining({ timestamp: 1.5 }),
+    );
+    expect(olderSample.close).toHaveBeenCalledTimes(1);
+
+    renderer.destroy();
+  });
+
   it("steps through decoded samples without a host-owned decoder", async () => {
     resetMocks();
 

--- a/packages/web/src/renderers/media-renderer-core.ts
+++ b/packages/web/src/renderers/media-renderer-core.ts
@@ -142,7 +142,10 @@ export async function createMediaRendererCore(
     mediaInput = undefined;
   };
 
-  const prepareAndPresentSample = async (sample: DecodedVideoSample) => {
+  const prepareAndPresentSample = async (
+    sample: DecodedVideoSample,
+    isCurrent: () => boolean = () => true,
+  ) => {
     let shouldCloseSample = true;
 
     try {
@@ -150,6 +153,10 @@ export async function createMediaRendererCore(
         duration: runtimeState.duration(),
         firstTimestamp,
       });
+
+      if (!isCurrent()) {
+        return;
+      }
 
       presentSample(sample);
       shouldCloseSample = false;
@@ -239,7 +246,19 @@ export async function createMediaRendererCore(
           return;
         }
 
-        await prepareAndPresentSample(sample);
+        await prepareAndPresentSample(
+          sample,
+          () =>
+            requestVersion === navigationVersion && !runtimeState.isDestroyed(),
+        );
+
+        if (
+          requestVersion !== navigationVersion ||
+          runtimeState.isDestroyed()
+        ) {
+          return;
+        }
+
         playbackController.seek(runtimeState.currentTime());
 
         if (wasPlaying) {
@@ -675,7 +694,16 @@ export async function createMediaRendererCore(
 
       const sampleToPresent = sample;
       sample = null;
-      await prepareAndPresentSample(sampleToPresent);
+      await prepareAndPresentSample(
+        sampleToPresent,
+        () =>
+          requestVersion === navigationVersion && !runtimeState.isDestroyed(),
+      );
+
+      if (requestVersion !== navigationVersion || runtimeState.isDestroyed()) {
+        return;
+      }
+
       playbackController.seek(runtimeState.currentTime());
     } catch (error) {
       sample?.close();


### PR DESCRIPTION
## Description

Fixes #95

`MediaRendererCore.seek()` previously checked `requestVersion` only after decoding the video sample, but not after awaiting `prepareAndPresentSample(sample)`.

`prepareAndPresentSample` awaits `detectionTimeline.prepare(...)`, which can perform asynchronous detection loads. If a newer seek was issued and completed while an earlier seek was waiting in `prepare`, the older seek would proceed to present its stale sample once its prepare finished. This caused `currentTime` to regress and re-anchored the playback controller at the older position.

This change:
1. Adds an `isCurrent` callback guard parameter to `prepareAndPresentSample` so presentation is skipped when navigation has been superseded. When skipped, the `finally` block ensures the unpresented sample is closed.
2. Passes the version check `() => requestVersion === navigationVersion && !runtimeState.isDestroyed()` from `seek()` and `stepToAdjacentSample()`.
3. Retains the version check before `playbackController.seek(runtimeState.currentTime())`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [ ] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

Added an interleaved seek test in `media-renderer-core.test.ts` using deferred detection timeline preparation to verify:
- The latest seek wins for state and presented timestamp.
- The older seek sample is not presented.
- The older seek sample is properly closed without leaking.

Ran:
- `npx vitest run packages/web/src/renderers/media-renderer-core.test.ts`
- `npm run verify`

## Notes For Reviewers

None.