### PR TITLE
fix(web): prune and evict queued mask frames with loop-aware distances

### DIFF
--- a/packages/web/src/render-preparation/prepared-render-window.test.ts
+++ b/packages/web/src/render-preparation/prepared-render-window.test.ts
@@ -827,6 +827,83 @@ describe("prepared render window", () => {
     }
   });
 
+  it("keeps wrapped-ahead mask jobs queued across a loop boundary under load", async () => {
+    vi.useFakeTimers();
+    resetMocks();
+
+    try {
+      const fakeWorker = createFakeMaskPreparationWorker({
+        autoComplete: false,
+      });
+      const onMaskFramePrepared = vi.fn();
+      const renderWindow = createPreparedRenderWindow({
+        detectionTimeline: createTimeline(manyFrames),
+        maskStyle: new BaseMaskStyle(),
+        onMaskFramePrepared,
+        renderPreparation: {
+          maskFrame: {
+            maxPendingFrameCount: 10,
+            prefetchFrameCount: 7,
+            scheduleBatchSize: 10,
+            scanIntervalSeconds: 0,
+            workerCount: 1,
+          },
+          mode: RenderPreparationMode.Worker,
+          workerFactory: {
+            createWorker: () => fakeWorker.worker,
+          },
+        },
+      });
+
+      (
+        renderWindow as unknown as {
+          setTimelineContext(context: {
+            readonly duration: number;
+            readonly loop: boolean;
+          }): void;
+        }
+      ).setTimelineContext({ duration: 0.4, loop: true });
+
+      renderWindow.getFrame(0);
+      await flushMaskPreparationTimers(2);
+
+      expect(
+        fakeWorker.messages.map(
+          (message) => (message as { job: { key: string } }).job.key,
+        ),
+      ).toEqual(["0:0"]);
+
+      renderWindow.getFrame(0.36);
+      await flushMaskPreparationTimers(2);
+
+      expect(
+        fakeWorker.messages.map(
+          (message) =>
+            (message as { readonly job: { readonly key: string } }).job.key,
+        ),
+      ).toEqual(["0:0"]);
+
+      for (let index = 0; index < 7; index += 1) {
+        fakeWorker.completeNext();
+        await flushMaskPreparationTimers(2);
+      }
+
+      const preparedKeys = onMaskFramePrepared.mock.calls.map(
+        (call) => (call[0] as { readonly key: string }).key,
+      );
+
+      expect(preparedKeys).toContain("1:0.04");
+      expect(preparedKeys).toContain("2:0.08");
+      expect(preparedKeys).toContain("3:0.12");
+      expect(preparedKeys).toContain("4:0.16");
+      expect(preparedKeys).toContain("5:0.2");
+
+      renderWindow.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps prepared lookahead across a looping media boundary", async () => {
     vi.useFakeTimers();
     resetMocks();

--- a/packages/web/src/render-preparation/prepared-render-window.ts
+++ b/packages/web/src/render-preparation/prepared-render-window.ts
@@ -374,11 +374,19 @@ export function createPreparedRenderWindow(options: {
   }
 
   function pruneStaleQueuedMaskFrames(mediaTime: number, exemptKey?: string) {
+    const upcomingKeys = new Set(
+      timeline.getWindowFrameKeys(mediaTime, prefetchFrameCount),
+    );
+
     for (let index = queuedMaskFrameKeys.length - 1; index >= 0; index -= 1) {
       const key = queuedMaskFrameKeys[index];
       const job = key ? pendingMaskFrames.get(key) : undefined;
 
-      if (key !== exemptKey && (!job || job.mediaTime < mediaTime)) {
+      if (key === exemptKey) {
+        continue;
+      }
+
+      if (!job || !upcomingKeys.has(key)) {
         queuedMaskFrameKeys.splice(index, 1);
 
         if (key) {
@@ -400,7 +408,7 @@ export function createPreparedRenderWindow(options: {
         break;
       }
 
-      const distance = Math.abs(job.mediaTime - mediaTime);
+      const distance = timeline.getFrameDistance(job.mediaTime, mediaTime);
 
       if (distance > farthestDistance) {
         farthestDistance = distance;

--- a/packages/web/src/render-preparation/prepared-window-timeline.test.ts
+++ b/packages/web/src/render-preparation/prepared-window-timeline.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { DetectionFrame } from "supervision-js-core";
+
+import { createPreparedWindowTimeline } from "./prepared-window-timeline";
+
+function createFrame(frameIndex: number, mediaTime: number): DetectionFrame {
+  return {
+    detections: [],
+    frameIndex,
+    mediaTime,
+  };
+}
+
+describe("createPreparedWindowTimeline", () => {
+  it("returns loop-aware window keys across a looping media boundary", () => {
+    const timeline = createPreparedWindowTimeline({
+      getFrameKey: (frame) => `${frame.frameIndex}`,
+    });
+    const frames = [0, 1, 2, 3, 4].map((frameIndex) =>
+      createFrame(frameIndex, frameIndex * 0.25),
+    );
+
+    timeline.setContext({ duration: 1, loop: true });
+    timeline.rememberFrames(frames, new Set(["0", "1", "2", "3", "4"]));
+
+    expect(timeline.getWindowFrameKeys(0.75, 3)).toEqual(["3", "0", "4"]);
+    expect(timeline.getWindowFrameKeys(0, 2)).toEqual(["0", "4"]);
+  });
+
+  it("returns forward-only window keys for non-looping timelines", () => {
+    const timeline = createPreparedWindowTimeline({
+      getFrameKey: (frame) => `${frame.frameIndex}`,
+    });
+    const frames = [0, 1, 2, 3].map((frameIndex) =>
+      createFrame(frameIndex, frameIndex * 0.25),
+    );
+
+    timeline.setContext({ duration: 1, loop: false });
+    timeline.rememberFrames(frames, new Set(["0", "1", "2", "3"]));
+
+    expect(timeline.getWindowFrameKeys(0.5, 2)).toEqual(["2", "3"]);
+    expect(timeline.getWindowFrameKeys(0.5, 10)).toEqual(["2", "3"]);
+    expect(timeline.getWindowFrameKeys(0.5, 0)).toEqual([]);
+  });
+
+  it("measures wrapped-ahead frames as near and just-passed frames as far", () => {
+    const timeline = createPreparedWindowTimeline({
+      getFrameKey: (frame) => `${frame.frameIndex}`,
+    });
+
+    timeline.setContext({ duration: 10, loop: true });
+
+    expect(timeline.getFrameDistance(0, 9.75)).toBeCloseTo(0.25);
+    expect(timeline.getFrameDistance(0.75, 9.75)).toBeCloseTo(1);
+    expect(timeline.getFrameDistance(9.5, 9.75)).toBeCloseTo(9.75);
+
+    timeline.setContext({ duration: null, loop: false });
+
+    expect(timeline.getFrameDistance(9.9, 9.75)).toBeCloseTo(0.15);
+    expect(timeline.getFrameDistance(9.5, 9.75)).toBe(0);
+  });
+});

--- a/packages/web/src/render-preparation/prepared-window-timeline.ts
+++ b/packages/web/src/render-preparation/prepared-window-timeline.ts
@@ -8,6 +8,7 @@ export interface PreparedRenderTimelineContext {
 export interface PreparedWindowTimeline {
   clear(): void;
   getFrameDistance(frameTime: number, mediaTime: number): number;
+  getWindowFrameKeys(mediaTime: number, count: number): readonly string[];
   getWindowFrames(
     bufferedFrames: readonly DetectionFrame[],
     mediaTime: number,
@@ -41,16 +42,16 @@ export function createPreparedWindowTimeline(options: {
       return Math.max(0, frameTime - mediaTime);
     },
 
-    getWindowFrames(bufferedFrames, mediaTime) {
-      if (!isLoopingTimeline()) {
-        return bufferedFrames.filter((frame) => frame.mediaTime >= mediaTime);
-      }
+    getWindowFrameKeys(mediaTime, count) {
+      const windowCount = Math.max(0, count);
 
-      return Array.from(knownFrames.values()).sort(
-        (leftFrame, rightFrame) =>
-          getLoopDistance(leftFrame.mediaTime, mediaTime) -
-          getLoopDistance(rightFrame.mediaTime, mediaTime),
-      );
+      return orderWindowFrames(Array.from(knownFrames.values()), mediaTime)
+        .slice(0, windowCount)
+        .map(options.getFrameKey);
+    },
+
+    getWindowFrames(bufferedFrames, mediaTime) {
+      return orderWindowFrames(bufferedFrames, mediaTime);
     },
 
     rememberFrames(frames, retainedKeys) {
@@ -69,6 +70,25 @@ export function createPreparedWindowTimeline(options: {
       timelineContext = context;
     },
   };
+
+  function orderWindowFrames(
+    frames: readonly DetectionFrame[],
+    mediaTime: number,
+  ) {
+    if (!isLoopingTimeline()) {
+      return frames
+        .filter((frame) => frame.mediaTime >= mediaTime)
+        .sort(
+          (leftFrame, rightFrame) => leftFrame.mediaTime - rightFrame.mediaTime,
+        );
+    }
+
+    return Array.from(frames).sort(
+      (leftFrame, rightFrame) =>
+        getLoopDistance(leftFrame.mediaTime, mediaTime) -
+        getLoopDistance(rightFrame.mediaTime, mediaTime),
+    );
+  }
 
   function isLoopingTimeline() {
     return (


### PR DESCRIPTION
## Description

Fixes #96

In `prepared-render-window.ts`, `pruneStaleQueuedMaskFrames` (`job.mediaTime < mediaTime`) and `evictFarthestQueuedMaskFrame` (`Math.abs(job.mediaTime - mediaTime)`) used raw linear time comparisons.

During looping playback near the end of the media duration (for example, playing at `t = 9.75` in a 10s loop), queued prefetch jobs for wrapped-ahead frames (such as `t = 0.00` to `0.75`) were treated as stale (`mediaTime < 9.75`) and deleted on active-frame scheduling ticks, or evicted as farthest under worker load. Consequently, immediately after wrapping back to the beginning of the timeline, upcoming mask frames were missing and reported pending status.

This change:
1. Exposes `getWindowFrameKeys` on `PreparedWindowTimeline` to compute the target prefetch window using loop-aware ordering.
2. Updates `pruneStaleQueuedMaskFrames` to retain jobs that fall within the upcoming prefetch window, pruning only out-of-window or cancelled jobs.
3. Routes `evictFarthestQueuedMaskFrame` through `timeline.getFrameDistance` so wrapped-ahead frames are recognized as near and preserved under load.
4. Preserves forward-only ordering behavior for non-looping timelines.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation or example update
- [ ] Refactor or maintenance
- [ ] Performance improvement

## Validation

- [x] Tests added or updated where behavior changed
- [ ] Documentation updated where the public API or workflow changed
- [ ] Screenshots or recording attached for visual changes

Added unit tests in `prepared-window-timeline.test.ts` and `prepared-render-window.test.ts` covering:
- Loop-aware window key generation across boundary wraps.
- Wrapped-ahead prefetch frame retention and completion across loop boundaries under simulated worker concurrency.
- Forward-only behavior for non-looping timelines.

Ran:
- `npx vitest run packages/web/src/render-preparation/prepared-window-timeline.test.ts packages/web/src/render-preparation/prepared-render-window.test.ts`
- `npm run verify`

## Notes For Reviewers

None.