### PR TITLE
Allow npm prereleases from release branches

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -27,7 +27,9 @@ concurrency:
 
 jobs:
   publish:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      (startsWith(github.ref, 'refs/heads/release/') && inputs.dist_tag == 'next')
     name: Verify and publish supervision
     runs-on: ubuntu-latest
     environment:

--- a/docs/internal/npm-release.md
+++ b/docs/internal/npm-release.md
@@ -19,8 +19,9 @@ artifacts/supervision-<version>.tgz
 
 The manual GitHub Actions workflow at
 `.github/workflows/publish-npm.yml` recreates and independently validates that
-artifact before publishing it. It runs only from `main` and is gated by the
-`npm-publish` GitHub environment.
+artifact before publishing it. Stable `latest` releases run only from `main`;
+an explicit prerelease may run from a `release/*` branch with the `next` tag.
+Every publish is gated by the `npm-publish` GitHub environment.
 
 `latest` is the default tag for a reviewed, general-availability release. A
 stable publish updates the default version that `npm install supervision`
@@ -108,6 +109,16 @@ package version.
    commit the workflow published. Then verify that public installation guidance,
    the toolbar version, and the documentation deployment match the stable
    release.
+
+### Prerelease Procedure
+
+Use a dedicated `release/*` branch when an integration needs to consume an
+unmerged commit. Set `packages/web/package.json` to a unique SemVer prerelease
+such as `0.2.0-next.0`, update the lockfile and docs toolbar mirror, then run
+**Publish npm package** from that release branch with `next`. npm versions are
+immutable: each later prerelease needs a new version such as
+`0.2.0-next.1`; the `next` dist-tag moves to that newest version. A release
+branch can never publish `latest` or create a stable GitHub Release.
 
 ## Recovery
 


### PR DESCRIPTION
## Description

Allow the manual npm publish workflow to run from a dedicated `release/*` branch when the selected dist-tag is `next`. Stable `latest` publication remains restricted to `main`.

The release operations guide now documents the prerelease branch and versioning flow for unmerged integration builds.

## Type of Change

- [x] Refactor or maintenance
- [x] Documentation or example update

## Validation

- [x] Documentation updated where the public API or workflow changed

- `git diff --check`
- `prettier --check .github/workflows/publish-npm.yml docs/internal/npm-release.md`

## Notes For Reviewers

This does not grant publish access to `poc/*` branches. A prerelease must first be promoted to an explicit `release/*` branch, use a unique prerelease version, and pass the existing `npm-publish` environment gate.
