### PR TITLE
Recover video seeks when random access misses reordered frames

### DIFF
--- a/packages/web/src/media/mediabunny-media-source.ts
+++ b/packages/web/src/media/mediabunny-media-source.ts
@@ -1,6 +1,7 @@
 import { MediaSourceError, toMediaSourceError } from "#media/media-errors";
 import { normalizeMediaSourcePresentationTimeline } from "#media/presentation-timeline-media-source";
 import type { DecodedMediaSource } from "./media-source";
+import { createMediabunnySampleSink } from "./mediabunny-sample-sink";
 import type { MediaRendererSource } from "#types/media-renderer";
 import { MediaErrorKind } from "supervision-js-core";
 import type { InputFormat, Source } from "mediabunny";
@@ -104,7 +105,9 @@ export async function openMediabunnyMediaSource(
         trackCount: tracks.length,
         videoTrackCount: videoTracks.length,
       },
-      sampleSink: new VideoSampleSink(primaryVideoTrack),
+      sampleSink: createMediabunnySampleSink(
+        new VideoSampleSink(primaryVideoTrack),
+      ),
     });
   } catch (error) {
     input.dispose();

--- a/packages/web/src/media/mediabunny-sample-sink.test.ts
+++ b/packages/web/src/media/mediabunny-sample-sink.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DecodedVideoSampleSink } from "./media-source";
+import { createMediabunnySampleSink } from "./mediabunny-sample-sink";
+
+function sample(timestamp: number, duration = 1 / 30) {
+  return { timestamp, duration, close: vi.fn(), draw: vi.fn() };
+}
+
+describe("Mediabunny random-access recovery", () => {
+  it("keeps successful random access on its fast path", async () => {
+    const frame = sample(4.566666666666666);
+    const sink = {
+      getSample: vi.fn(async () => frame),
+      samples: vi.fn(async function* () {}),
+    } satisfies DecodedVideoSampleSink;
+    const options = { skipLiveWait: true };
+    expect(
+      await createMediabunnySampleSink(sink).getSample(4.57, options),
+    ).toBe(frame);
+    expect(sink.getSample).toHaveBeenCalledWith(4.57, options);
+    expect(sink.samples).not.toHaveBeenCalled();
+  });
+
+  it.each([2.466666666666667, 2.471666666666667])(
+    "recovers the containing reordered frame at %s and closes its iterator",
+    async (timestamp) => {
+      const frame = sample(2.466666666666667);
+      const release = vi.fn();
+      const sink = {
+        getSample: vi.fn(async () => null),
+        samples: vi.fn(async function* () {
+          try {
+            yield frame;
+            throw new Error(
+              "Must stop reading once the requested frame is found.",
+            );
+          } finally {
+            release();
+          }
+        }),
+      } satisfies DecodedVideoSampleSink;
+      const options = { skipLiveWait: true };
+      expect(
+        await createMediabunnySampleSink(sink).getSample(timestamp, options),
+      ).toBe(frame);
+      expect(sink.samples).toHaveBeenCalledWith(timestamp, undefined, options);
+      expect(release).toHaveBeenCalledOnce();
+      expect(frame.close).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not replace a missing frame with a later frame and releases rejected samples", async () => {
+    const earlier = sample(1, 0.1);
+    const later = sample(2, 0.1);
+    const release = vi.fn();
+    const sink = {
+      getSample: vi.fn(async () => null),
+      samples: vi.fn(async function* () {
+        try {
+          yield earlier;
+          yield later;
+        } finally {
+          release();
+        }
+      }),
+    } satisfies DecodedVideoSampleSink;
+    expect(await createMediabunnySampleSink(sink).getSample(1.5)).toBeNull();
+    expect(earlier.close).toHaveBeenCalledOnce();
+    expect(later.close).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("preserves decode failures instead of retrying indefinitely", async () => {
+    const error = new Error("Input disposed");
+    const sink = {
+      getSample: vi.fn(async () => {
+        throw error;
+      }),
+      samples: vi.fn(async function* () {}),
+    } satisfies DecodedVideoSampleSink;
+    await expect(createMediabunnySampleSink(sink).getSample(1)).rejects.toBe(
+      error,
+    );
+    expect(sink.samples).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/media/mediabunny-sample-sink.ts
+++ b/packages/web/src/media/mediabunny-sample-sink.ts
@@ -1,0 +1,34 @@
+import type { DecodedVideoSampleSink } from "./media-source";
+
+/** Keep decoder-specific random-access recovery inside the media adapter. */
+export function createMediabunnySampleSink(
+  sink: DecodedVideoSampleSink,
+): DecodedVideoSampleSink {
+  return {
+    async getSample(timestamp, options) {
+      const sample = await sink.getSample(timestamp, options);
+      if (sample) return sample;
+
+      // Some reordered H.264 frames need packets beyond the random-access
+      // decoder's stopping point. The iterator supplies that decode lookahead.
+      for await (const candidate of sink.samples(
+        timestamp,
+        undefined,
+        options,
+      )) {
+        if (
+          candidate.timestamp <= timestamp &&
+          candidate.timestamp + candidate.duration > timestamp
+        ) {
+          return candidate;
+        }
+        candidate.close();
+        if (candidate.timestamp > timestamp) return null;
+      }
+      return null;
+    },
+    samples(startTimestamp, endTimestamp, options) {
+      return sink.samples(startTimestamp, endTimestamp, options);
+    },
+  };
+}


### PR DESCRIPTION
## Description

Seeking some H.264 B-frames currently stops playback because random access returns no sample; recover the containing frame through the decoder's existing iterator while preserving the normal seek path.

## Type of Change

- [x] Bug fix

## Validation

- [x] Tests added or updated where behavior changed
- 30 focused adapter, presentation-timeline and renderer tests pass.
- ESLint, TypeScript/Rollup build and 8 portable-package smoke checks pass.
- Reproduced against a real clip with Mediabunny 1.52.3 and 1.55.5; packaged fix verified in the real platform: inference, class-track click/drag seeking, active action and sample switching.

## Notes For Reviewers

The fallback remains inside the media adapter and closes rejected samples and its iterator. Public API is unchanged. Consumers need a subsequent official package release; this PR does not publish one.
